### PR TITLE
Peparse v2 patch, expose peparsing to third-parties

### DIFF
--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = config
 
-h_sources = libvmi.h
+h_sources = libvmi.h os/windows/peparse.h
 c_sources = \
     accessors.c \
     cache.c \

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -42,7 +42,7 @@ get_ntoskrnl_base(
         if (MAX_HEADER_BYTES != nbytes) {
             continue;
         }
-        if (VMI_SUCCESS == validate_pe_image(image, MAX_HEADER_BYTES)) {
+        if (VMI_SUCCESS == peparse_validate_pe_image(image, MAX_HEADER_BYTES)) {
             dbprint("--FOUND KERNEL at paddr=0x%llx\n", paddr);
             goto normal_exit;
         }

--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -25,165 +25,10 @@
  */
 
 #include "libvmi.h"
+#include "peparse.h"
 #include "private.h"
 #define _GNU_SOURCE
 #include <string.h>
-
-#define IMAGE_DOS_HEADER 0x5A4D // ZM
-#define IMAGE_NT_SIGNATURE 0x00004550   // 00EP
-
-#define IMAGE_PE32_MAGIC      0x10b
-#define IMAGE_PE32_PLUS_MAGIC 0x20b
-
-#define IMAGE_DIRECTORY_ENTRY_EXPORT 0
-#define IMAGE_DIRECTORY_ENTRY_IMPORT 1
-#define IMAGE_DIRECTORY_ENTRY_RESOURCE 2
-#define IMAGE_DIRECTORY_ENTRY_EXCEPTION 3
-#define IMAGE_DIRECTORY_ENTRY_CERTIFICATE 4
-#define IMAGE_DIRECTORY_ENTRY_BASERELOC 5
-#define IMAGE_DIRECTORY_ENTRY_DEBUG 6
-#define IMAGE_DIRECTORY_ENTRY_ARCHITECTURE 7
-#define IMAGE_DIRECTORY_ENTRY_GLOBALPTR 8
-#define IMAGE_DIRECTORY_ENTRY_TLS 9
-#define IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG 10
-#define IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT 11
-#define IMAGE_DIRECTORY_ENTRY_IAT 12
-#define IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT 13
-#define IMAGE_DIRECTORY_ENTRY_CLR_RUNTIME 14
-#define IMAGE_DIRECTORY_ENTRY_RESERVED 15
-
-struct image_data_directory {
-    uint32_t virtual_address;
-    uint32_t size;
-} __attribute__ ((packed));
-
-struct pe_header {
-    int32_t signature;
-    uint16_t machine;
-    uint16_t number_of_sections;
-    uint32_t time_date_stamp;
-    uint32_t pointer_to_symbol_table;
-    uint32_t number_of_symbols;
-    uint16_t size_of_optional_header;
-    uint16_t characteristics;
-    // characteristics flags defined in pe.txt
-} __attribute__ ((packed));
-
-struct dos_header {
-    uint16_t signature;
-    uint16_t bytes_in_last_block;
-    uint16_t blocks_in_file;
-    uint16_t reloc_ct;
-    uint16_t header_size;
-    uint16_t min_mem;
-    uint16_t max_mem;
-    uint16_t ss;
-    uint16_t sp;
-    uint16_t chksum;
-    uint16_t ip;
-    uint16_t cs;
-    uint16_t reloc_tbl_ofs;
-    uint16_t overlay;
-    uint8_t reserved[32];
-    uint32_t offset_to_pe;
-} __attribute__ ((packed));
-
-struct optional_header_pe32 {
-    uint16_t magic; // 0x10b
-    uint8_t major_linker_version;
-    uint8_t minor_linker_version;
-    uint32_t size_of_code;
-    uint32_t size_of_initialized_data;
-    uint32_t size_of_uninitialized_data;
-    uint32_t address_of_entry_point;
-    uint32_t base_of_code;
-    uint32_t base_of_data;
-    uint32_t image_base;
-    uint32_t section_alignment;
-    uint32_t file_alignment;
-    uint16_t major_os_version;
-    uint16_t minor_os_version;
-    uint16_t major_image_version;
-    uint16_t minor_image_version;
-    uint16_t major_subsystem_version;
-    uint16_t minor_subsystem_version;
-    uint32_t win32_version_value;
-    uint32_t size_of_image;
-    uint32_t size_of_headers;
-    uint32_t checksum;
-    uint16_t subsystem;
-    uint16_t dll_characteristics;
-    uint32_t size_of_stack_reserve;
-    uint32_t size_of_stack_commit;
-    uint32_t size_of_heap_reserve;
-    uint32_t size_of_heap_commit;
-    uint32_t loader_flags;
-    uint32_t number_of_rva_and_sizes;
-    struct image_data_directory idd[16];
-} __attribute__ ((packed));
-
-struct optional_header_pe32plus {
-    uint16_t magic; // 0x20b
-    uint8_t major_linker_version;
-    uint8_t minor_linker_version;
-    uint32_t size_of_code;
-    uint32_t size_of_initialized_data;
-    uint32_t size_of_uninitialized_data;
-    uint32_t address_of_entry_point;
-    uint32_t base_of_code;
-    uint64_t image_base;
-    uint32_t section_alignment;
-    uint32_t file_alignment;
-    uint16_t major_os_version;
-    uint16_t minor_os_version;
-    uint16_t major_image_version;
-    uint16_t minor_image_version;
-    uint16_t major_subsystem_version;
-    uint16_t minor_subsystem_version;
-    uint32_t win32_version_value;
-    uint32_t size_of_image;
-    uint32_t size_of_headers;
-    uint32_t checksum;
-    uint16_t subsystem;
-    uint16_t dll_characteristics;
-    uint64_t size_of_stack_reserve;
-    uint64_t size_of_stack_commit;
-    uint64_t size_of_heap_reserve;
-    uint64_t size_of_heap_commit;
-    uint32_t loader_flags;
-    uint32_t number_of_rva_and_sizes;
-    struct image_data_directory idd[16];
-} __attribute__ ((packed));
-
-struct section_header {
-    char short_name[8];
-    union {
-        uint32_t physical_address;
-        uint32_t virtual_size;
-    } a;
-    uint32_t virtual_address;
-    uint32_t size_of_raw_data;
-    uint32_t pointer_to_raw_data;
-    uint32_t pointer_to_relocations;
-    uint32_t pointer_to_line_numbers;
-    uint16_t number_of_relocations;
-    uint16_t number_of_line_numbers;
-    uint32_t characteristics;
-} __attribute__ ((packed));
-
-struct export_table {
-    uint32_t export_flags;  // reserved, must be 0
-    uint32_t time_date_stamp;
-    uint16_t major_version;
-    uint16_t minor_version;
-    uint32_t name;
-    uint32_t base;
-    uint32_t number_of_functions;   // total number of exported items
-    uint32_t number_of_names;
-    uint32_t address_of_functions;
-    uint32_t address_of_names;
-    uint32_t address_of_name_ordinals;
-} __attribute__ ((packed));
 
 // takes an rva and looks up a null terminated string at that location
 char *
@@ -381,7 +226,7 @@ get_aon_index(
 }
 
 status_t
-validate_pe_image(
+peparse_validate_pe_image(
     const uint8_t * const image,
     size_t len)
 {
@@ -426,8 +271,10 @@ validate_pe_image(
 }
 
 status_t
-get_export_table(
+peparse_get_export_table(
     vmi_instance_t vmi,
+    addr_t base_vaddr,
+    uint32_t pid,
     struct export_table *et)
 {
     // Note: this function assumes a "normal" PE where all the headers are in
@@ -437,18 +284,17 @@ get_export_table(
     addr_t export_header_rva = 0;
     addr_t export_header_va = 0;
     size_t nbytes = 0;
-    addr_t base_vaddr = vmi->os.windows_instance.ntoskrnl_va;
 
 #define MAX_HEADER_BYTES 1024   // keep under 1 page
     uint8_t image[MAX_HEADER_BYTES];
 
     /* scoop up the headers in a single read */
-    nbytes = vmi_read_va(vmi, base_vaddr, 0, image, MAX_HEADER_BYTES);
+    nbytes = vmi_read_va(vmi, base_vaddr, pid, image, MAX_HEADER_BYTES);
     if (MAX_HEADER_BYTES != nbytes) {
         dbprint("--PEPARSE: failed to read PE header\n");
         return VMI_FAILURE;
     }
-    if (VMI_FAILURE == validate_pe_image(image, MAX_HEADER_BYTES)) {
+    if (VMI_FAILURE == peparse_validate_pe_image(image, MAX_HEADER_BYTES)) {
         dbprint("--PEPARSE: failed to validate PE header(s)\n");
         return VMI_FAILURE;
     }
@@ -488,7 +334,7 @@ get_export_table(
          export_header_va, vmi->os.windows_instance.ntoskrnl_va,
          export_header_rva);
 
-    nbytes = vmi_read_va(vmi, export_header_va, 0, et, sizeof(*et));
+    nbytes = vmi_read_va(vmi, export_header_va, pid, et, sizeof(*et));
     if (nbytes != sizeof(struct export_table)) {
         dbprint("--PEParse: failed to map export header\n");
         return VMI_FAILURE;
@@ -513,9 +359,10 @@ windows_export_to_rva(
     struct export_table et;
     int aon_index = -1;
     int aof_index = -1;
+    addr_t base_vaddr = vmi->os.windows_instance.ntoskrnl_va;
 
     // get export table structure
-    if (get_export_table(vmi, &et) != VMI_SUCCESS) {
+    if (peparse_get_export_table(vmi, base_vaddr, 0, &et) != VMI_SUCCESS) {
         dbprint("--PEParse: failed to get export table\n");
         return VMI_FAILURE;
     }

--- a/libvmi/os/windows/peparse.h
+++ b/libvmi/os/windows/peparse.h
@@ -1,0 +1,201 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Bryan D. Payne (bdpayne@acm.org)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PEPARSE_H
+#define PEPARSE_H
+#pragma GCC visibility push(default)
+
+#define IMAGE_DOS_HEADER 0x5A4D // ZM
+#define IMAGE_NT_SIGNATURE 0x00004550   // 00EP
+
+#define IMAGE_PE32_MAGIC      0x10b
+#define IMAGE_PE32_PLUS_MAGIC 0x20b
+
+#define IMAGE_DIRECTORY_ENTRY_EXPORT 0
+#define IMAGE_DIRECTORY_ENTRY_IMPORT 1
+#define IMAGE_DIRECTORY_ENTRY_RESOURCE 2
+#define IMAGE_DIRECTORY_ENTRY_EXCEPTION 3
+#define IMAGE_DIRECTORY_ENTRY_CERTIFICATE 4
+#define IMAGE_DIRECTORY_ENTRY_BASERELOC 5
+#define IMAGE_DIRECTORY_ENTRY_DEBUG 6
+#define IMAGE_DIRECTORY_ENTRY_ARCHITECTURE 7
+#define IMAGE_DIRECTORY_ENTRY_GLOBALPTR 8
+#define IMAGE_DIRECTORY_ENTRY_TLS 9
+#define IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG 10
+#define IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT 11
+#define IMAGE_DIRECTORY_ENTRY_IAT 12
+#define IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT 13
+#define IMAGE_DIRECTORY_ENTRY_CLR_RUNTIME 14
+#define IMAGE_DIRECTORY_ENTRY_RESERVED 15
+
+struct image_data_directory {
+    uint32_t virtual_address;
+    uint32_t size;
+} __attribute__ ((packed));
+
+struct pe_header {
+    int32_t signature;
+    uint16_t machine;
+    uint16_t number_of_sections;
+    uint32_t time_date_stamp;
+    uint32_t pointer_to_symbol_table;
+    uint32_t number_of_symbols;
+    uint16_t size_of_optional_header;
+    uint16_t characteristics;
+    // characteristics flags defined in pe.txt
+} __attribute__ ((packed));
+
+struct dos_header {
+    uint16_t signature;
+    uint16_t bytes_in_last_block;
+    uint16_t blocks_in_file;
+    uint16_t reloc_ct;
+    uint16_t header_size;
+    uint16_t min_mem;
+    uint16_t max_mem;
+    uint16_t ss;
+    uint16_t sp;
+    uint16_t chksum;
+    uint16_t ip;
+    uint16_t cs;
+    uint16_t reloc_tbl_ofs;
+    uint16_t overlay;
+    uint8_t reserved[32];
+    uint32_t offset_to_pe;
+} __attribute__ ((packed));
+
+struct optional_header_pe32 {
+    uint16_t magic; // 0x10b
+    uint8_t major_linker_version;
+    uint8_t minor_linker_version;
+    uint32_t size_of_code;
+    uint32_t size_of_initialized_data;
+    uint32_t size_of_uninitialized_data;
+    uint32_t address_of_entry_point;
+    uint32_t base_of_code;
+    uint32_t base_of_data;
+    uint32_t image_base;
+    uint32_t section_alignment;
+    uint32_t file_alignment;
+    uint16_t major_os_version;
+    uint16_t minor_os_version;
+    uint16_t major_image_version;
+    uint16_t minor_image_version;
+    uint16_t major_subsystem_version;
+    uint16_t minor_subsystem_version;
+    uint32_t win32_version_value;
+    uint32_t size_of_image;
+    uint32_t size_of_headers;
+    uint32_t checksum;
+    uint16_t subsystem;
+    uint16_t dll_characteristics;
+    uint32_t size_of_stack_reserve;
+    uint32_t size_of_stack_commit;
+    uint32_t size_of_heap_reserve;
+    uint32_t size_of_heap_commit;
+    uint32_t loader_flags;
+    uint32_t number_of_rva_and_sizes;
+    struct image_data_directory idd[16];
+} __attribute__ ((packed));
+
+struct optional_header_pe32plus {
+    uint16_t magic; // 0x20b
+    uint8_t major_linker_version;
+    uint8_t minor_linker_version;
+    uint32_t size_of_code;
+    uint32_t size_of_initialized_data;
+    uint32_t size_of_uninitialized_data;
+    uint32_t address_of_entry_point;
+    uint32_t base_of_code;
+    uint64_t image_base;
+    uint32_t section_alignment;
+    uint32_t file_alignment;
+    uint16_t major_os_version;
+    uint16_t minor_os_version;
+    uint16_t major_image_version;
+    uint16_t minor_image_version;
+    uint16_t major_subsystem_version;
+    uint16_t minor_subsystem_version;
+    uint32_t win32_version_value;
+    uint32_t size_of_image;
+    uint32_t size_of_headers;
+    uint32_t checksum;
+    uint16_t subsystem;
+    uint16_t dll_characteristics;
+    uint64_t size_of_stack_reserve;
+    uint64_t size_of_stack_commit;
+    uint64_t size_of_heap_reserve;
+    uint64_t size_of_heap_commit;
+    uint32_t loader_flags;
+    uint32_t number_of_rva_and_sizes;
+    struct image_data_directory idd[16];
+} __attribute__ ((packed));
+
+struct section_header {
+    char short_name[8];
+    union {
+        uint32_t physical_address;
+        uint32_t virtual_size;
+    } a;
+    uint32_t virtual_address;
+    uint32_t size_of_raw_data;
+    uint32_t pointer_to_raw_data;
+    uint32_t pointer_to_relocations;
+    uint32_t pointer_to_line_numbers;
+    uint16_t number_of_relocations;
+    uint16_t number_of_line_numbers;
+    uint32_t characteristics;
+} __attribute__ ((packed));
+
+struct export_table {
+    uint32_t export_flags;  // reserved, must be 0
+    uint32_t time_date_stamp;
+    uint16_t major_version;
+    uint16_t minor_version;
+    uint32_t name;
+    uint32_t base;
+    uint32_t number_of_functions;   // total number of exported items
+    uint32_t number_of_names;
+    uint32_t address_of_functions;
+    uint32_t address_of_names;
+    uint32_t address_of_name_ordinals;
+} __attribute__ ((packed));
+
+status_t
+peparse_validate_pe_image(
+    const uint8_t * const image,
+    size_t len);
+
+status_t
+peparse_get_export_table(
+    vmi_instance_t vmi,
+    addr_t base_vaddr,
+    uint32_t pid,
+    struct export_table *et);
+
+#pragma GCC visibility pop
+#endif /* PEPARSE_H */
+


### PR DESCRIPTION
LibVMI currently has PE header definition and parsing and validation code, but the code is only accessible internally. Exposing the structure definitions and some of the functions is desirable when dealing with Windows. As the list of definitions is quite long, creating and installing a separate header I think is a cleaner approach than jamming everything into libvmi.h. 

Please see attached patch as a first attempt, comments are welcome! The patch splits parts of peparse.c into a header, and exposes two functions that are renamed to start with peparse_ accordingly.
peparse_get_export_table is slightly modified as to not have the kernel's base address hard-coded, as to be able to take any base_vaddr and PID to get the export table.

http://code.google.com/p/vmitools/issues/detail?id=36
