### PR TITLE
Custom init patches to take configuration as a GHashTable

### DIFF
--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -56,7 +56,9 @@ struct vmi_instance {
 
     uint32_t init_mode;     /**< VMI_INIT_PARTIAL or VMI_INIT_COMPLETE */
 
-    char *configstr;        /**< string holding config info */
+    vmi_config_t config;    /**< configuration */
+
+    uint32_t config_mode;     /**< VMI_CONFIG_NONE/FILE/STRING/GHASHTABLE */
 
     char *sysmap;           /**< system map file for domain's running kernel */
 


### PR DESCRIPTION
Currently the only way to pass custom configuration not specified in libvmi.conf is to the initialization libvmi by doing a partial init and than passing a string to the full init. Creating and parsing a string this way is highly inefficient, moreover, doesn't allow specifying if libvmi should be initialized on a domain name or a domain ID.

Custom init functions can take the regular file/string input or a GHashTable structure. The custom input structs can contain only the name|domid for partial init or the list of config parameters for full init. The way the custom input structure is defined internally in libvmi enables easy extension for alternative input sources to be added in the future.
