### PR TITLE
libvmi.h: add 'extern C' to ensure c++ to ensure C linkage

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -32,6 +32,11 @@
  */
 #ifndef LIBVMI_H
 #define LIBVMI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #pragma GCC visibility push(default)
 
 #ifdef HAVE_CONFIG_H
@@ -1159,4 +1164,9 @@ void vmi_pidcache_add(
     addr_t dtb);
 
 #pragma GCC visibility pop
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* LIBVMI_H */


### PR DESCRIPTION
This small change makes it possible to use LibVMI from within C++ code by instructing the compiler to avoid mangling and allow C-style linkage (if and only if it's a C++ compiler; normal C code is entirely unchanged due to the #ifdef ).
