### PR TITLE
Limit reliance on Xenstore in VMI_XEN mode

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -198,9 +198,12 @@ unsigned long
 vmi_get_vmid(
     vmi_instance_t vmi)
 {
-    char *name = vmi_get_name(vmi);
-    unsigned long tmp_id = driver_get_id_from_name(vmi, name);
+    unsigned long domid = VMI_INVALID_DOMID;
+    if(VMI_INVALID_DOMID == (domid = driver_get_id(vmi))) {
+        char *name = vmi_get_name(vmi);
+        domid = driver_get_id_from_name(vmi, name);
+        free(name);
+    }
 
-    free(name);
-    return tmp_id;
+    return domid;
 }

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -42,11 +42,20 @@ struct driver_instance {
     *get_id_from_name_ptr) (
     vmi_instance_t,
     char *);
+    status_t (
+    *get_name_from_id_ptr) (
+    vmi_instance_t,
+    unsigned long,
+    char **);
     unsigned long (
     *get_id_ptr) (
     vmi_instance_t);
     void (
     *set_id_ptr) (
+    vmi_instance_t,
+    unsigned long);
+    status_t (
+    *check_id_ptr) (
     vmi_instance_t,
     unsigned long);
     status_t (
@@ -116,8 +125,10 @@ driver_xen_setup(
     instance->init_ptr = &xen_init;
     instance->destroy_ptr = &xen_destroy;
     instance->get_id_from_name_ptr = &xen_get_domainid_from_name;
+    instance->get_name_from_id_ptr = &xen_get_name_from_domainid;
     instance->get_id_ptr = &xen_get_domainid;
     instance->set_id_ptr = &xen_set_domainid;
+    instance->check_id_ptr = &xen_check_domainid;
     instance->get_name_ptr = &xen_get_domainname;
     instance->set_name_ptr = &xen_set_domainname;
     instance->get_memsize_ptr = &xen_get_memsize;
@@ -142,8 +153,10 @@ driver_kvm_setup(
     instance->init_ptr = &kvm_init;
     instance->destroy_ptr = &kvm_destroy;
     instance->get_id_from_name_ptr = &kvm_get_id_from_name;
+    instance->get_name_from_id_ptr = &kvm_get_name_from_id;
     instance->get_id_ptr = &kvm_get_id;
     instance->set_id_ptr = &kvm_set_id;
+    instance->check_id_ptr = &kvm_check_id;
     instance->get_name_ptr = &kvm_get_name;
     instance->set_name_ptr = &kvm_set_name;
     instance->get_memsize_ptr = &kvm_get_memsize;
@@ -168,8 +181,10 @@ driver_file_setup(
     instance->init_ptr = &file_init;
     instance->destroy_ptr = &file_destroy;
     instance->get_id_from_name_ptr = NULL;  //TODO add get_id_from_name_ptr
+    instance->get_name_from_id_ptr = NULL;  //TODO add get_name_from_id_ptr
     instance->get_id_ptr = NULL;    //TODO add get_id_ptr
     instance->set_id_ptr = NULL;    //TODO add set_id_ptr
+    instance->check_id_ptr = NULL;     //TODO add check_id_ptr
     instance->get_name_ptr = &file_get_name;
     instance->set_name_ptr = &file_set_name;
     instance->get_memsize_ptr = &file_get_memsize;
@@ -193,8 +208,10 @@ driver_null_setup(
     instance->init_ptr = NULL;
     instance->destroy_ptr = NULL;
     instance->get_id_from_name_ptr = NULL;
+    instance->get_name_from_id_ptr = NULL;
     instance->get_id_ptr = NULL;
     instance->set_id_ptr = NULL;
+    instance->check_id_ptr = NULL;
     instance->get_name_ptr = NULL;
     instance->set_name_ptr = NULL;
     instance->get_memsize_ptr = NULL;
@@ -329,6 +346,24 @@ driver_get_id_from_name(
     }
 }
 
+status_t
+driver_get_name_from_id(
+    vmi_instance_t vmi,
+    unsigned long domid,
+    char **name)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+
+    if (NULL != ptrs && NULL != ptrs->get_name_from_id_ptr) {
+        return ptrs->get_name_from_id_ptr(vmi, domid, name);
+    }
+    else {
+        dbprint
+            ("WARNING: driver_get_name_from_id function not implemented.\n");
+        return 0;
+    }
+}
+
 unsigned long
 driver_get_id(
     vmi_instance_t vmi)
@@ -356,6 +391,22 @@ driver_set_id(
     }
     else {
         dbprint("WARNING: driver_set_id function not implemented.\n");
+        return;
+    }
+}
+
+void
+driver_check_id(
+    vmi_instance_t vmi,
+    unsigned long id)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+
+    if (NULL != ptrs && NULL != ptrs->check_id_ptr) {
+        return ptrs->check_id_ptr(vmi, id);
+    }
+    else {
+        dbprint("WARNING: driver_check_id function not implemented.\n");
         return;
     }
 }

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -38,9 +38,16 @@ void driver_destroy(
 unsigned long driver_get_id_from_name(
     vmi_instance_t vmi,
     char *name);
+status_t driver_get_name_from_id(
+    vmi_instance_t vmi,
+    unsigned long domid,
+    char **name);
 unsigned long driver_get_id(
     vmi_instance_t vmi);
 void driver_set_id(
+    vmi_instance_t vmi,
+    unsigned long id);
+status_t driver_check_id(
     vmi_instance_t vmi,
     unsigned long id);
 status_t driver_get_name(

--- a/libvmi/driver/kvm.c
+++ b/libvmi/driver/kvm.c
@@ -474,6 +474,39 @@ kvm_get_id_from_name(
     return id;
 }
 
+status_t
+kvm_get_name_from_id(
+    vmi_instance_t vmi,
+    unsigned long domid,
+    char **name)
+{
+    virConnectPtr conn = NULL;
+    virDomainPtr dom = NULL;
+
+    conn =
+        virConnectOpenAuth("qemu:///system", virConnectAuthPtrDefault,
+                           0);
+    if (NULL == conn) {
+        dbprint("--no connection to kvm hypervisor\n");
+        return VMI_FAILURE;
+    }
+
+    dom = virDomainLookupByID(conn, domid);
+    if (NULL == dom) {
+        dbprint("--failed to find kvm domain\n");
+        return VMI_FAILURE;
+    }
+
+    *name = virDomainGetName(dom);
+
+    if (dom)
+        virDomainFree(dom);
+    if (conn)
+        virConnectClose(conn);
+
+    return VMI_SUCCESS;
+}
+
 unsigned long
 kvm_get_id(
     vmi_instance_t vmi)
@@ -487,6 +520,36 @@ kvm_set_id(
     unsigned long id)
 {
     kvm_get_instance(vmi)->id = id;
+}
+
+status_t
+kvm_check_id(
+    vmi_instance_t vmi,
+    unsigned long id)
+{
+    virConnectPtr conn = NULL;
+    virDomainPtr dom = NULL;
+
+    conn =
+        virConnectOpenAuth("qemu:///system", virConnectAuthPtrDefault,
+                           0);
+    if (NULL == conn) {
+        dbprint("--no connection to kvm hypervisor\n");
+        return VMI_FAILURE;
+    }
+
+    dom = virDomainLookupByID(conn, id);
+    if (NULL == dom) {
+        dbprint("--failed to find kvm domain\n");
+        return VMI_FAILURE;
+    }
+
+    if (dom)
+        virDomainFree(dom);
+    if (conn)
+        virConnectClose(conn);
+
+    return VMI_SUCCESS;
 }
 
 status_t
@@ -756,14 +819,6 @@ kvm_test(
         return VMI_FAILURE;
     }
 
-    dom = virDomainLookupByName(conn, name);
-    if (NULL == dom) {
-        dbprint("--failed to find kvm domain\n");
-        return VMI_FAILURE;
-    }
-
-    if (dom)
-        virDomainFree(dom);
     if (conn)
         virConnectClose(conn);
     return VMI_SUCCESS;
@@ -814,6 +869,15 @@ kvm_get_id_from_name(
     return 0;
 }
 
+status_t
+kvm_get_name_from_id(
+    vmi_instance_t vmi,
+    unsigned long domid,
+    char **name)
+{
+    return VMI_FAILURE;
+}
+
 unsigned long
 kvm_get_id(
     vmi_instance_t vmi)
@@ -827,6 +891,14 @@ kvm_set_id(
     unsigned long id)
 {
     return;
+}
+
+status_t
+kvm_check_id(
+    vmi_instance_t vmi,
+    unsigned long id)
+{
+    return VMI_FAILURE;
 }
 
 status_t

--- a/libvmi/driver/kvm.h
+++ b/libvmi/driver/kvm.h
@@ -51,9 +51,16 @@ void kvm_destroy(
 unsigned long kvm_get_id_from_name(
     vmi_instance_t vmi,
     char *name);
+status_t kvm_get_name_from_id(
+    vmi_instance_t vmi,
+    unsigned long domid,
+    char **name);
 unsigned long kvm_get_id(
     vmi_instance_t vmi);
 void kvm_set_id(
+    vmi_instance_t vmi,
+    unsigned long id);
+status_t kvm_check_id(
     vmi_instance_t vmi,
     unsigned long id);
 status_t kvm_get_name(

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -93,9 +93,16 @@ void xen_destroy(
 unsigned long xen_get_domainid_from_name(
     vmi_instance_t vmi,
     char *name);
+status_t xen_get_name_from_domainid(
+    vmi_instance_t vmi,
+    unsigned long domid,
+    char **name);
 unsigned long xen_get_domainid(
     vmi_instance_t vmi);
 void xen_set_domainid(
+    vmi_instance_t vmi,
+    unsigned long domainid);
+status_t xen_check_domainid(
     vmi_instance_t vmi,
     unsigned long domainid);
 status_t xen_get_domainname(


### PR DESCRIPTION
This branch builds on top of the custom-init and invalid-domid branches.

When performing Dom0 disaggregation, Xenstore requires additional privileges to be set for each domain to be accessed by a secondary domain running LibVMI. The use of Xenstore in LibVMI is currently tied to two pieces of information: determining a domains ID from its name, and getting the size of the memory of the domain. While the domain's name is a piece of information that can only be accessed through Xenstore, the available memory can be obtained from other sources (such as the getdomaininfo hypercall already noted in the comments of the function xen_get_memsize). When running LibVMI in a domain other then Dom0 limiting reliance on Xenstore is required so that LibVMI can initialize provided only with a domain ID.
