### PR TITLE
Add win_pname offset during config creation

### DIFF
--- a/tools/windows-offset-finder/createConfig.py
+++ b/tools/windows-offset-finder/createConfig.py
@@ -42,7 +42,9 @@ def configfromdump(filename):
                     base = "    win_pdbase  = "+ lineSplit[2]+ ';\n'
                 elif lineSplit[0] == "_EPROCESS"  and lineSplit[1] == "UniqueProcessId":
                     pid = "    win_pid     = "+ lineSplit[2]+';\n'
-    config += tasks + base + pid
+                elif lineSplit[0] == "_EPROCESS"  and lineSplit[1] == "ImageFileName":
+                    pname = "    win_pname   = "+ lineSplit[2]+';\n'
+    config += tasks + base + pid + pname
     config += "}"
     print config
 


### PR DESCRIPTION
When using the windows-offset-finder tool, the generated configuration could easily contain the offset win_pname as well.
