### PR TITLE
Pyvmiaddressspace.py fixes

### DIFF
--- a/tools/pyvmi/pyvmiaddressspace.py
+++ b/tools/pyvmi/pyvmiaddressspace.py
@@ -57,7 +57,7 @@ class PyVmiAddressSpace(addrspace.BaseAddressSpace):
             return ''
 
         # This should not happen but in case it does
-	# pad the end of the read
+        # pad the end of the read
         end = addr + length
         if end > self.vmi.get_memsize():
 	    pad = True


### PR DESCRIPTION
Currently pyvmiaddressspace in get_available_addresses returns a memory range that is actually outside the available range for the VM. This in effect triggered Volatility to try to read outside of available memory, which was simply handled by returning '' as the memory previously, instead of reading what was available and padding the remainder with 0's. These were causing all sorts of weird inconsistent performance issues with Volatility scans.
