### PR TITLE
libvmi.h: expose vmi_pagetable_lookup() publicly

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -337,6 +337,20 @@ addr_t vmi_pid_to_dtb(
     vmi_instance_t vmi,
     int pid);
 
+/**
+ * Translates a virtual address to a physical address.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] dtb address of the relevant page directory base
+ * @param[in] vaddr virtual address to translate via dtb 
+ * @return Physical address, or zero on error
+ */
+
+addr_t vmi_pagetable_lookup (
+    vmi_instance_t vmi,
+    addr_t dtb,
+    addr_t vaddr);
+
 /*---------------------------------------------------------
  * Memory access functions from util.c
  */


### PR DESCRIPTION
This PR exposes vmi_pagetable_lookup() in the public header. It can be useful in some situations (e.g. task_struct->mm->pgd for comparison to CR3).
