### PR TITLE
Record number of VCPUs used by a guest and provide an accessor function.

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -148,6 +148,13 @@ vmi_get_memsize(
     return vmi->size;
 }
 
+unsigned int
+vmi_get_num_vcpus(
+    vmi_instance_t vmi)
+{
+    return vmi->num_vcpus;
+}
+
 status_t
 vmi_get_vcpureg(
     vmi_instance_t vmi,

--- a/libvmi/driver/kvm.c
+++ b/libvmi/driver/kvm.c
@@ -369,6 +369,7 @@ kvm_init(
 {
     virConnectPtr conn = NULL;
     virDomainPtr dom = NULL;
+    virDomainInfo info;
 
     conn =
         virConnectOpenAuth("qemu:///system", virConnectAuthPtrDefault,
@@ -397,6 +398,13 @@ kvm_init(
     kvm_get_instance(vmi)->dom = dom;
     kvm_get_instance(vmi)->socket_fd = 0;
     vmi->hvm = 1;
+
+    //get the VCPU count from virDomainInfo structure
+    if (-1 == virDomainGetInfo(kvm_get_instance(vmi)->dom, &info)) {
+        dbprint("--failed to get vm info\n");
+        return VMI_FAILURE;
+    }
+    vmi->num_vcpus = info.nrVirtCpu;
 
     char *status = exec_memory_access(kvm_get_instance(vmi));
 

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -322,6 +322,9 @@ xen_init(
         goto _bail;
     }
 
+    /* record the count of VCPUs used by this instance */
+    vmi->num_vcpus = xen_get_instance(vmi)->info.max_vcpu_id + 1;
+
     /* determine if target is hvm or pv */
     vmi->hvm = xen_get_instance(vmi)->hvm =
         xen_get_instance(vmi)->info.hvm;

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1065,6 +1065,16 @@ unsigned long vmi_get_memsize(
     vmi_instance_t vmi);
 
 /**
+ * Gets the memory size of the guest that LibVMI is accessing.
+ * This information is required for any interaction with of VCPU registers.
+ *
+ * @param[in] vmi LibVMI instance
+ * @return Number of VCPUs
+ */
+unsigned int vmi_get_num_vcpus (
+    vmi_instance_t vmi);
+
+/**
  * Gets the current value of a VCPU register.  This currently only
  * supports control registers.  When LibVMI is accessing a raw
  * memory file, this function will fail.

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -142,6 +142,8 @@ struct vmi_instance {
     uint32_t memory_cache_size;/**< current size of memory cache */
 
     uint32_t memory_cache_size_max;/**< max size of memory cache */
+
+    unsigned int num_vcpus; /**< number of VCPUs used by this instance */
 };
 
 /** Windows' UNICODE_STRING structure (x86) */


### PR DESCRIPTION
This pull request makes the number of VCPUs used by a particular instance available via the API. This feature supports other existing functions which take the index of a VCPU an input parameter, e.g. vmi_get_vcpureg. The vmi_instance_t structure gained a member, a new accessor function was added, and support for both KVM and Xen was provided.
