### PR TITLE
Switch peparse_get_export_table to work on PA instead of VA

### DIFF
--- a/libvmi/os/windows/peparse.h
+++ b/libvmi/os/windows/peparse.h
@@ -192,8 +192,7 @@ peparse_validate_pe_image(
 status_t
 peparse_get_export_table(
     vmi_instance_t vmi,
-    addr_t base_vaddr,
-    uint32_t pid,
+    addr_t base_paddr,
     struct export_table *et);
 
 #pragma GCC visibility pop


### PR DESCRIPTION
Currently peparse_get_export_table requires LibVMI to be in full init mode. By switching the function to take the PE header's base address as a PA the function can be used when LibVMI is in partial init mode.
