### PR TITLE
libvmi core: call get_memory_layout() during partial init 

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -514,6 +514,7 @@ vmi_init_private(
 
     if (VMI_INIT_PARTIAL == init_mode) {
         init_page_offset(*vmi);
+        get_memory_layout(*vmi);
         driver_get_memsize(*vmi, &(*vmi)->size);
         return VMI_SUCCESS;
     }


### PR DESCRIPTION
In existing code, paging mode and cr3 are not probed until full initialization. However, get_memory_layout() really only probes register values, so it should be safe to run during partial initialization (the function already exits as a NOP when the target is a file, rather than a live VM).  This small change opens up a variety of functions for use prior to full initialization which would otherwise be unavailable.
