### PR TITLE
Resurrect the events branch with updates for Xen 4.2.0 and miscellaneous fixes. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,9 @@ xen_space=' '
         [else]
             AC_DEFINE([ENABLE_XEN], [1], [Define to 1 to enable Xen support.])
             have_xen='yes'
+
+            AC_CHECK_LIB(xenctrl, [xc_mem_event_enable], [AC_DEFINE(XENEVENT41, 1, "Xen memory event 4.1 style")])
+            AC_CHECK_LIB(xenctrl, [xc_mem_access_enable], [AC_DEFINE(XENEVENT42, 1, "Xen memory event 4.2 style")])
         [fi]
     [fi]
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -6,11 +6,12 @@ AM_CPPFLAGS = -I$(top_srcdir)
 AM_LDFLAGS = -L$(top_srcdir)/libvmi/.libs/
 LDADD = -lvmi -lm $(LIBS)
 
-bin_PROGRAMS = module-list process-list map-symbol map-addr dump-memory win-guid
+bin_PROGRAMS = module-list process-list map-symbol map-addr dump-memory win-guid event-example
 module_list_SOURCES = module-list.c
 process_list_SOURCES = process-list.c
 map_symbol_SOURCES = map-symbol.c
 map_addr_SOURCES = map-addr.c
 dump_memory_SOURCES = dump-memory.c
+event_example_SOURCES = event-example.c
 win_guid_SOURCES = win-guid.c
 

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -1,0 +1,299 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Nasser Salim (njsalim@sandia.gov)
+ * Author: Steven Maresca (steve@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libvmi/libvmi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#define PAGE_SIZE 1 << 12
+
+reg_t cr3;
+vmi_event_t cr3_event;
+vmi_event_t msr_syscall_lm_event;
+vmi_event_t msr_syscall_compat_event;
+vmi_event_t msr_syscall_sysenter_event;
+
+vmi_event_t kernel_vdso_event;
+vmi_event_t kernel_vsyscall_event;
+vmi_event_t kernel_sysenter_target_event;
+
+void print_event(vmi_event_t event){
+    printf("PAGE %lx ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %lu)\n",
+        event.mem_event.page,
+        (event.mem_event.out_access == VMI_MEM_R) ? 'r' : '-',
+        (event.mem_event.out_access == VMI_MEM_W) ? 'w' : '-',
+        (event.mem_event.out_access == VMI_MEM_X) ? 'x' : '-',
+        event.mem_event.gfn,
+        event.mem_event.offset,
+        event.mem_event.gla,
+	event.vcpu_id
+    );
+}
+    
+
+/* MSR registers used to hold system calls in x86_64. Note that compat mode is
+ *	used in concert with long mode for certain system calls.
+ *	e.g. in 3.2.0 ioctl, getrlimit, etc. (see /usr/include/asm-generic/unistd.h)
+ * MSR_STAR     -    legacy mode SYSCALL target (not addressed here)
+ * MSR_LSTAR    -    long mode SYSCALL target 
+ * MSR_CSTAR    -    compat mode SYSCALL target 
+ * 
+ * Note that modern code tends to employ the sysenter and/or vDSO mechanisms for 
+ *    performance reasons.
+ */
+
+void msr_syscall_sysenter_cb(vmi_instance_t vmi, vmi_event_t event){
+    reg_t rdi, rax;
+    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+
+    printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
+
+    print_event(event);   
+ 
+    vmi_clear_event(vmi, msr_syscall_sysenter_event);
+}
+
+void syscall_compat_cb(vmi_instance_t vmi, vmi_event_t event){
+    reg_t rdi, rax;
+    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+
+    printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
+    
+    print_event(event);   
+    
+    vmi_clear_event(vmi, msr_syscall_compat_event);
+}
+
+void vsyscall_cb(vmi_instance_t vmi, vmi_event_t event){
+    reg_t rdi, rax;
+    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+
+    printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
+    
+    print_event(event);   
+   
+    vmi_clear_event(vmi, kernel_vsyscall_event);
+}
+
+void ia32_sysenter_target_cb(vmi_instance_t vmi, vmi_event_t event){
+    reg_t rdi, rax;
+    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+
+    printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
+    
+    print_event(event);   
+   
+    vmi_clear_event(vmi, kernel_sysenter_target_event);
+}
+
+void syscall_lm_cb(vmi_instance_t vmi, vmi_event_t event){
+    reg_t rdi, rax;
+    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+
+    printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
+    
+    print_event(event);   
+   
+    vmi_clear_event(vmi, msr_syscall_lm_event);
+}
+
+void cr3_one_task_callback(vmi_instance_t vmi, vmi_event_t event){
+printf("one_task callback\n");
+    if(event.reg_event.value == cr3){
+        printf("My process is executing on vcpu %lu\n", event.vcpu_id);
+        
+        msr_syscall_sysenter_event.mem_event.in_access = VMI_MEM_X;
+        kernel_sysenter_target_event.mem_event.in_access = VMI_MEM_X;
+        kernel_vsyscall_event.mem_event.in_access = VMI_MEM_X;
+
+        if(vmi_handle_event(vmi, msr_syscall_sysenter_event, msr_syscall_sysenter_cb) == VMI_FAILURE)
+            fprintf(stderr, "Could not install sysenter syscall handler.\n");
+        if(vmi_handle_event(vmi, kernel_sysenter_target_event, ia32_sysenter_target_cb) == VMI_FAILURE)
+            fprintf(stderr, "Could not install sysenter syscall handler.\n");
+        if(vmi_handle_event(vmi, kernel_vsyscall_event, vsyscall_cb) == VMI_FAILURE)
+            fprintf(stderr, "Could not install sysenter syscall handler.\n");
+    }
+    else{
+        printf("My process is not executing.\n");
+        vmi_clear_event(vmi, msr_syscall_sysenter_event);
+    }
+}
+
+void cr3_all_tasks_callback(vmi_instance_t vmi, vmi_event_t event){
+	printf("My process with CR3=%lx executing on vcpu %lu.\n", event.reg_event.value, event.vcpu_id);
+
+	msr_syscall_sysenter_event.mem_event.in_access = VMI_MEM_X;
+
+	if(vmi_handle_event(vmi, msr_syscall_sysenter_event, msr_syscall_sysenter_cb) == VMI_FAILURE)
+	    fprintf(stderr, "Could not install sysenter syscall handler.\n");
+	vmi_clear_event(vmi, msr_syscall_sysenter_event);
+}
+
+
+
+
+int main (int argc, char **argv)
+{
+    vmi_instance_t vmi;
+
+    reg_t lstar;
+    addr_t phys_lstar;
+    reg_t cstar;
+    addr_t phys_cstar;
+    reg_t sysenter_ip;
+    addr_t phys_sysenter_ip;
+    
+    addr_t ia32_sysenter_target;
+    addr_t phys_ia32_sysenter_target;
+    addr_t vsyscall;
+    addr_t phys_vsyscall;
+
+    char *name = NULL;
+    int i=50;
+    int pid=-1;
+
+    if(argc < 2){
+        fprintf(stderr, "Usage: events_example <name of VM> <PID of process to track {optional}>\n");
+        exit(1);
+    }
+   
+    // Arg 1 is the VM name.
+    name = argv[1];
+    
+    // Arg 2 is the pid of the process to track.
+    if(argc == 3)
+        pid = (int) strtoul(argv[2], NULL, 0);
+
+    // Initialize the libvmi library.
+    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_COMPLETE | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+        printf("Failed to init LibVMI library.\n");
+        return 1;
+    }
+    else{
+        printf("LibVMI init succeeded!\n");
+    }
+
+    // Get the cr3 for this process.
+    cr3 = vmi_pid_to_dtb(vmi, pid);
+    printf("CR3 for process (%d) == %llx\n", pid, (unsigned long long)cr3);
+
+    // Get the value of lstar and cstar for the system.
+    // NOTE: all vCPUs have the same value for these registers
+    vmi_get_vcpureg(vmi, &lstar, MSR_LSTAR, 0);
+    vmi_get_vcpureg(vmi, &cstar, MSR_CSTAR, 0);
+    vmi_get_vcpureg(vmi, &sysenter_ip, SYSENTER_EIP, 0);
+    printf("vcpu 0 MSR_LSTAR == %llx\n", (unsigned long long)lstar);
+    printf("vcpu 0 MSR_CSTAR == %llx\n", (unsigned long long)cstar);
+    printf("vcpu 0 MSR_SYSENTER_IP == %llx\n", (unsigned long long)sysenter_ip);
+
+    ia32_sysenter_target = vmi_translate_ksym2v(vmi, "ia32_sysenter_target");
+    printf("ksym ia32_sysenter_target == %llx\n", (unsigned long long)ia32_sysenter_target);
+
+    vsyscall = 0xffffffffff600000;
+
+    // Translate to a physical address.
+    phys_lstar= vmi_translate_kv2p(vmi, lstar);
+    printf("Physical LSTAR == %llx\n", (unsigned long long)phys_lstar);
+    
+    phys_cstar= vmi_translate_kv2p(vmi, cstar);
+    printf("Physical CSTAR == %llx\n", (unsigned long long)phys_cstar);
+    
+    phys_sysenter_ip= vmi_translate_kv2p(vmi, sysenter_ip);
+    printf("Physical SYSENTER_IP == %llx\n", (unsigned long long)phys_sysenter_ip);
+
+    phys_ia32_sysenter_target = vmi_translate_kv2p(vmi,ia32_sysenter_target);
+    printf("Physical ia32_sysenter_target == %llx\n", (unsigned long long)ia32_sysenter_target);
+    phys_vsyscall = vmi_translate_kv2p(vmi,vsyscall);
+    printf("Physical phys_vsyscall == %llx\n", (unsigned long long)phys_vsyscall);
+
+    
+    // Get only the page that the handler starts.
+    phys_lstar >>= 12;
+    printf("LSTAR Physical PFN == %llx\n", (unsigned long long)phys_lstar);
+    phys_cstar >>= 12;
+    printf("CSTAR Physical PFN == %llx\n", (unsigned long long)phys_cstar);
+    phys_sysenter_ip >>= 12;
+    printf("SYSENTER_IP Physical PFN == %llx\n", (unsigned long long)phys_sysenter_ip);
+    phys_vsyscall >>= 12;
+    printf("phys_vsyscall Physical PFN == %llx\n", (unsigned long long)phys_vsyscall);
+    phys_ia32_sysenter_target >>= 12;
+    printf("phys_ia32_sysenter_target Physical PFN == %llx\n", (unsigned long long)phys_ia32_sysenter_target);
+
+    // Setup cr3 event to track when the process is running.
+    memset(&cr3_event, 0, sizeof(vmi_event_t));
+    cr3_event.type = VMI_REGISTER_EVENT;
+    cr3_event.reg_event.reg = CR3;
+ //   cr3_event.reg_event.onchange =1;
+    //cr3_event.reg_event.async =1;
+    cr3_event.reg_event.equal = cr3;
+    cr3_event.reg_event.in_access = VMI_REG_W;
+
+    if(pid == -1){
+        vmi_handle_event(vmi, cr3_event, cr3_all_tasks_callback);
+    } else {
+        vmi_handle_event(vmi, cr3_event, cr3_one_task_callback);
+    }
+
+    // Setup a default event for tracking memory at the syscall handler.
+    // But don't install it; that will be done by the cr3 handler.
+    memset(&msr_syscall_sysenter_event, 0, sizeof(vmi_event_t));
+    msr_syscall_sysenter_event.type = VMI_MEMORY_EVENT;
+    msr_syscall_sysenter_event.mem_event.page = phys_sysenter_ip;
+    msr_syscall_sysenter_event.mem_event.npages = 1;
+
+    memset(&kernel_sysenter_target_event, 0, sizeof(vmi_event_t));
+    kernel_sysenter_target_event.type = VMI_MEMORY_EVENT;
+    kernel_sysenter_target_event.mem_event.page = phys_ia32_sysenter_target;
+    kernel_sysenter_target_event.mem_event.npages = 1;
+
+    memset(&kernel_vsyscall_event, 0, sizeof(vmi_event_t));
+    kernel_vsyscall_event.type = VMI_MEMORY_EVENT;
+    kernel_vsyscall_event.mem_event.page = phys_vsyscall;
+    kernel_vsyscall_event.mem_event.npages = 1;
+
+   
+    while(i--){
+        printf("Waiting for events...\n");
+        vmi_events_listen(vmi,500);
+    }
+    printf("Finished with test.\n");
+
+leave:
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -6,6 +6,7 @@ c_sources = \
     cache.c \
     convenience.c \
     core.c \
+    events.c \
     memory.c \
     performance.c \
     pretty_print.c \
@@ -17,6 +18,7 @@ c_sources = \
     driver/kvm.c \
     driver/memory_cache.c \
     driver/xen.c \
+    driver/xen_events.c \
     os/linux/core.c \
     os/linux/memory.c \
     os/linux/symbols.c \

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -630,12 +630,12 @@ vmi_init_private(
     }
     dbprint("--completed driver init.\n");
 
-    if (VMI_INIT_PARTIAL == init_mode) {
+    if (init_mode & VMI_INIT_PARTIAL) {
         init_page_offset(*vmi);
         driver_get_memsize(*vmi, &(*vmi)->size);
         return VMI_SUCCESS;
     }
-    else if (VMI_INIT_COMPLETE == init_mode) {
+    else if (init_mode & VMI_INIT_COMPLETE) {
 
         /* init_complete requires configuration */
         if(VMI_CONFIG_NONE & (*vmi)->config_mode) {
@@ -685,6 +685,12 @@ vmi_init_private(
             (*vmi)->cr3 = find_cr3((*vmi));
             dbprint("**set cr3 = 0x%.16llx\n", (*vmi)->cr3);
         }   // if
+
+
+        /* Enable event handlers */
+        if(init_mode & VMI_INIT_EVENTS){
+            events_init(*vmi);
+        }
 
         /* setup OS specific stuff */
         if (VMI_OS_LINUX == (*vmi)->os_type) {
@@ -837,6 +843,9 @@ status_t
 vmi_destroy(
     vmi_instance_t vmi)
 {
+    if(vmi->init_mode & VMI_INIT_EVENTS){
+        events_destroy(vmi);
+    }
     driver_destroy(vmi);
     pid_cache_destroy(vmi);
     sym_cache_destroy(vmi);

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -90,6 +90,18 @@ struct driver_instance {
     status_t (
     *resume_vm_ptr) (
     vmi_instance_t);
+    status_t (
+    *events_listen_ptr)(
+    vmi_instance_t,
+    uint32_t);
+    status_t (
+    *set_reg_access_ptr)(
+    vmi_instance_t,
+    reg_event_t);
+    status_t (
+    *set_mem_access_ptr)(
+    vmi_instance_t,
+    mem_event_t);
 };
 typedef struct driver_instance *driver_instance_t;
 
@@ -116,6 +128,9 @@ driver_xen_setup(
     instance->is_pv_ptr = &xen_is_pv;
     instance->pause_vm_ptr = &xen_pause_vm;
     instance->resume_vm_ptr = &xen_resume_vm;
+    instance->events_listen_ptr = &xen_events_listen;
+    instance->set_reg_access_ptr = &xen_set_reg_access;
+    instance->set_mem_access_ptr = &xen_set_mem_access;
 }
 
 static void
@@ -139,6 +154,9 @@ driver_kvm_setup(
     instance->is_pv_ptr = &kvm_is_pv;
     instance->pause_vm_ptr = &kvm_pause_vm;
     instance->resume_vm_ptr = &kvm_resume_vm;
+    instance->events_listen_ptr = NULL;
+    instance->set_reg_access_ptr = NULL;
+    instance->set_mem_access_ptr = NULL;
 }
 
 static void
@@ -162,6 +180,9 @@ driver_file_setup(
     instance->is_pv_ptr = &file_is_pv;
     instance->pause_vm_ptr = &file_pause_vm;
     instance->resume_vm_ptr = &file_resume_vm;
+    instance->events_listen_ptr = NULL;
+    instance->set_reg_access_ptr = NULL;
+    instance->set_mem_access_ptr = NULL;
 }
 
 static void
@@ -183,6 +204,9 @@ driver_null_setup(
     instance->is_pv_ptr = NULL;
     instance->pause_vm_ptr = NULL;
     instance->resume_vm_ptr = NULL;
+    instance->events_listen_ptr = NULL;
+    instance->set_reg_access_ptr = NULL;
+    instance->set_mem_access_ptr = NULL;
 }
 
 static driver_instance_t
@@ -498,6 +522,48 @@ driver_resume_vm(
     else {
         dbprint
             ("WARNING: driver_resume_vm function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_events_listen(
+    vmi_instance_t vmi,
+    uint32_t timeout)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->events_listen_ptr){
+        return ptrs->events_listen_ptr(vmi, timeout);
+    }
+    else{
+        dbprint("WARNING: driver_events_listen function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_set_reg_access(
+    vmi_instance_t vmi,
+    reg_event_t event)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->set_reg_access_ptr){
+        return ptrs->set_reg_access_ptr(vmi, event);
+    }
+    else{
+        dbprint("WARNING: driver_set_reg_w_access function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_set_mem_access(
+    vmi_instance_t vmi,
+    mem_event_t event)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->set_mem_access_ptr){
+        return ptrs->set_mem_access_ptr(vmi, event);
+    }
+    else{
+        dbprint("WARNING: driver_set_mem_access function not implemented.\n");
         return VMI_FAILURE;
     }
 }

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -74,3 +74,15 @@ status_t driver_pause_vm(
     vmi_instance_t vmi);
 status_t driver_resume_vm(
     vmi_instance_t vmi);
+status_t driver_events_listen(
+    vmi_instance_t vmi,
+    uint32_t timeout);
+status_t driver_set_reg_w_access(
+    vmi_instance_t vmi,
+    registers_t reg,
+    int enable);
+status_t driver_set_mem_access(
+    vmi_instance_t vmi,
+    vmi_mem_access_t access,
+    addr_t start,
+    uint64_t count);

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -24,6 +24,8 @@
  * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "driver/xen_events.h"
+
 #if ENABLE_XEN == 1
 #include <xenctrl.h>
 
@@ -73,6 +75,8 @@ typedef struct xen_instance {
 
     struct xs_handle *xshandle;  /**< handle to xenstore daemon */
     char *name;
+
+    xen_events_t *events; /**< handle to events data */
 } xen_instance_t;
 
 #else

--- a/libvmi/driver/xen_events.c
+++ b/libvmi/driver/xen_events.c
@@ -1,0 +1,670 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * This file is part of LibVMI.
+ *
+ * Author: Nasser Salim (njsalim@sandia.gov)
+ * Author: Steven Maresca (steve@zentific.com)
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Portions of this header and dependent code is based upon that in xen-access, 
+ *    from the official Xen source distribution.  That code carries the 
+ *    following copyright notices and license.
+ *
+ * Copyright (c) 2011 Virtuata, Inc.
+ * Copyright (c) 2009 by Citrix Systems, Inc. (Patrick Colp), based on
+ *   xenpaging.c
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "libvmi.h"
+#include "private.h"
+#include "driver/xen.h"
+#include "driver/xen_private.h"
+#include "driver/xen_events.h"
+
+//----------------------------------------------------------------------------
+// Helper functions
+
+#if ENABLE_XEN==1
+static xen_events_t *xen_get_events(vmi_instance_t vmi) 
+{
+    return xen_get_instance(vmi)->events;
+}
+
+#define ADDR (*(volatile long *) addr)
+static inline int test_and_set_bit(int nr, volatile void *addr)
+{
+    int oldbit;
+    asm volatile (
+        "btsl %2,%1\n\tsbbl %0,%0"
+        : "=r" (oldbit), "=m" (ADDR)
+        : "Ir" (nr), "m" (ADDR) : "memory");
+    return oldbit;
+}
+
+/* Spinlock and mem event definitions */
+#define SPIN_LOCK_UNLOCKED 0
+
+static inline void spin_lock(spinlock_t *lock)
+{
+    while ( test_and_set_bit(1, lock) );
+}
+
+static inline void spin_lock_init(spinlock_t *lock)
+{
+    *lock = SPIN_LOCK_UNLOCKED;
+}
+
+static inline void spin_unlock(spinlock_t *lock)
+{
+    *lock = SPIN_LOCK_UNLOCKED;
+}
+
+#define xen_event_ring_lock_init(_m)  spin_lock_init(&(_m)->ring_lock)
+#define xen_event_ring_lock(_m)       spin_lock(&(_m)->ring_lock)
+#define xen_event_ring_unlock(_m)     spin_unlock(&(_m)->ring_lock)
+
+int wait_for_event_or_timeout(xc_interface *xch, xc_evtchn *xce, unsigned long ms)
+{
+    struct pollfd fd = { .fd = xc_evtchn_fd(xce), .events = POLLIN | POLLERR };
+    int port;
+    int rc;
+
+    rc = poll(&fd, 1, ms);
+    if ( rc == -1 )
+    {
+        if (errno == EINTR)
+            return 0;
+
+        errprint("Poll exited with an error\n");
+        goto err;
+    }
+
+    if ( rc == 1 )
+    {
+        port = xc_evtchn_pending(xce);
+        if ( port == -1 )
+        {
+            errprint("Failed to read port from event channel\n");
+            goto err;
+        }
+
+        rc = xc_evtchn_unmask(xce, port);
+        if ( rc != 0 )
+        {
+            errprint("Failed to unmask event channel port\n");
+            goto err;
+        }
+    }
+    else
+        port = -1;
+
+    return port;
+
+ err:
+    return -errno;
+}
+
+int get_mem_event(xen_mem_event_t *mem_event, mem_event_request_t *req)
+{
+    mem_event_back_ring_t *back_ring;
+    RING_IDX req_cons;
+
+    xen_event_ring_lock(mem_event);
+
+    back_ring = &mem_event->back_ring;
+    req_cons = back_ring->req_cons;
+
+    // Copy request
+    memcpy(req, RING_GET_REQUEST(back_ring, req_cons), sizeof(*req));
+    req_cons++;
+
+    // Update ring
+    back_ring->req_cons = req_cons;
+    back_ring->sring->req_event = req_cons + 1;
+
+    xen_event_ring_unlock(mem_event);
+
+    return 0;
+}
+
+static int put_mem_response(xen_mem_event_t *mem_event, mem_event_response_t *rsp)
+{
+    mem_event_back_ring_t *back_ring;
+    RING_IDX rsp_prod;
+
+    xen_event_ring_lock(mem_event);
+
+    back_ring = &mem_event->back_ring;
+    rsp_prod = back_ring->rsp_prod_pvt;
+
+    // Copy response
+    memcpy(RING_GET_RESPONSE(back_ring, rsp_prod), rsp, sizeof(*rsp));
+    rsp_prod++;
+
+    // Update ring
+    back_ring->rsp_prod_pvt = rsp_prod;
+    RING_PUSH_RESPONSES(back_ring);
+
+    xen_event_ring_unlock(mem_event);
+
+    return 0;
+}
+
+static int resume_domain(vmi_instance_t vmi, mem_event_response_t *rsp)
+{
+    xc_interface * xch;
+    xen_events_t * xe;
+    unsigned long dom;
+    int ret;
+
+    // Get xen handle and domain.
+    xch = xen_get_xchandle(vmi);
+    dom = xen_get_domainid(vmi);
+    xe = xen_get_events(vmi);
+
+    // Put the page info on the ring
+    ret = put_mem_response(&xe->mem_event, rsp);
+    if ( ret != 0 )
+        return ret;
+
+    // Tell Xen page is ready
+    ret = xc_mem_access_resume(xch, dom, rsp->gfn);
+    ret = xc_evtchn_notify(xe->mem_event.xce_handle, xe->mem_event.port);
+    return ret;
+}
+
+status_t process_register(vmi_instance_t vmi,
+                          registers_t reg,
+                          mem_event_request_t req)
+{
+    event_iter_t i;
+    vmi_event_t event, *eptr;
+    event_callback_t callback;
+
+    for_each_event(vmi, i, eptr, callback){
+        if(eptr->type==VMI_REGISTER_EVENT && eptr->reg_event.reg == reg){
+            /* reg_event.equal allows you to set a reg event for 
+             *  a specific VALUE of the register (passed in req.gfn) 
+             */
+            if(eptr->reg_event.equal && eptr->reg_event.equal != req.gfn)
+                return VMI_SUCCESS;
+            event = *eptr;
+            event.reg_event.value = req.gfn;
+            event.vcpu_id = req.vcpu_id;
+            
+            /* TODO MARESCA: note that vmi_event_t lacks a flags member
+             *   so we have no req.flags equivalent. might need to add
+             *   e.g !!(req.flags & MEM_EVENT_FLAG_VCPU_PAUSED)  would be nice
+             */
+            callback(vmi, event);
+            return VMI_SUCCESS;
+        }
+    }
+    return VMI_FAILURE;
+}
+
+status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
+{
+    event_iter_t i;
+    vmi_event_t event, *eptr;
+    event_callback_t callback;
+    addr_t page;
+    uint64_t npages;
+
+    struct hvm_hw_cpu ctx;
+    xc_interface * xch;
+    unsigned long dom;
+    xch = xen_get_xchandle(vmi);
+    dom = xen_get_domainid(vmi);
+
+    /* TODO, cleanup: ctx is unused here */
+    xc_domain_hvm_getcontext_partial(xch, dom,
+         HVM_SAVE_CODE(CPU), req.vcpu_id, &ctx, sizeof(ctx));
+
+    for_each_event(vmi, i, eptr, callback){
+        if(eptr->type==VMI_MEMORY_EVENT){
+            page = eptr->mem_event.page;
+            npages = eptr->mem_event.npages;
+            if(req.gfn >= page && req.gfn <= (page+(getpagesize()*npages))){
+                event = *eptr;
+                event.mem_event.gla = req.gla;
+                event.mem_event.gfn = req.gfn;
+                event.mem_event.offset = req.offset;
+                event.vcpu_id = req.vcpu_id;
+
+                if(req.access_r) event.mem_event.out_access = VMI_MEM_R;
+                else if(req.access_w) event.mem_event.out_access = VMI_MEM_W;
+                else if(req.access_x) event.mem_event.out_access = VMI_MEM_X;
+
+                /* TODO MARESCA: decide whether it's worthwhile to emulate xen-access here and call the following
+                 *    note: the 'access' variable is basically discarded in that spot. perhaps it's really only called
+                 *    to validate that the event is accessible (maybe that it's not consumed elsewhere??)
+                 * hvmmem_access_t access;
+                 * rc = xc_hvm_get_mem_access(xch, domain_id, event.mem_event.gfn, &access);
+                 */
+                callback(vmi, event);
+
+                return VMI_SUCCESS;
+            }
+        }
+    }
+    return VMI_FAILURE;
+}
+
+//----------------------------------------------------------------------------
+// Driver functions
+
+void xen_events_destroy(vmi_instance_t vmi)
+{
+    int rc;
+    xc_interface * xch;
+    xen_events_t * xe;
+    unsigned long dom;
+
+    // Get xen handle and domain.
+    xch = xen_get_xchandle(vmi);
+    dom = xen_get_domainid(vmi);
+    xe = xen_get_events(vmi);
+
+    if ( xe == NULL )
+        return;
+
+    // Turn off mem events
+    munmap(xe->mem_event.ring_page, getpagesize());
+    rc = xc_mem_access_disable(xch, dom);
+
+    if ( rc != 0 )
+    {
+        errprint("Error disabling mem events.\n");
+    }
+
+    /* TODO MARESCA - might want the evtchn_bind flag like in xen-access here
+     * for when this function is called before it was bound
+     */
+    // Unbind VIRQ
+    rc = xc_evtchn_unbind(xe->mem_event.xce_handle, xe->mem_event.port);
+    if ( rc != 0 )
+    {
+        errprint("Error unbinding event port\n");
+    }
+    xe->mem_event.port = -1;
+
+    // Close event channel
+    rc = xc_evtchn_close(xe->mem_event.xce_handle);
+    if ( rc != 0 )
+    {
+        errprint("Error closing event channel\n");
+    }
+    xe->mem_event.xce_handle = NULL;
+
+    free(xe);
+}
+
+status_t xen_events_init(vmi_instance_t vmi)
+{
+    xen_events_t * xe;
+    xc_interface * xch;
+    xc_domaininfo_t * dom_info;
+    unsigned long dom;
+    unsigned long ring_pfn, mmap_pfn;
+    int rc;
+
+    // Allocate memory
+    xe = malloc(sizeof(xen_events_t));
+    memset(xe, 0, sizeof(xen_events_t));
+
+    // Get xen handle and domain.
+    xch = xen_get_xchandle(vmi);
+    dom = xen_get_domainid(vmi);
+
+    dbprint("Init xen events with xch == %llx\n", (unsigned long long)xch);
+
+    // Initialise lock
+    xen_event_ring_lock_init(&xe->mem_event);
+
+    // Initialise shared page
+    xc_get_hvm_param(xch, dom, HVM_PARAM_ACCESS_RING_PFN, &ring_pfn);
+    mmap_pfn = ring_pfn;
+    xe->mem_event.ring_page =
+        xc_map_foreign_batch(xch, dom, PROT_READ | PROT_WRITE, &mmap_pfn, 1);
+    if ( mmap_pfn & XEN_DOMCTL_PFINFO_XTAB )
+    {
+        /* Map failed, populate ring page */
+        rc = xc_domain_populate_physmap_exact(xch,
+                                              dom,
+                                              1, 0, 0, &ring_pfn);
+        if ( rc != 0 )
+        {
+            errprint("Failed to populate ring gfn\n");
+            goto err;
+        }
+
+        mmap_pfn = ring_pfn;
+        xe->mem_event.ring_page =
+            xc_map_foreign_batch(xch, dom,
+                                    PROT_READ | PROT_WRITE, &mmap_pfn, 1);
+        if ( mmap_pfn & XEN_DOMCTL_PFINFO_XTAB )
+        {
+            errprint("Could not map the ring page\n");
+            goto err;
+        }
+    }
+
+    /* TODO MARESCA: xen 4.2/4.1 incompatibility expected here.
+     *  ifdef hackery needed
+     */
+    // Initialise Xen
+    rc = xc_mem_access_enable(xch, dom, &(xe->mem_event.evtchn_port));
+
+    if ( rc != 0 )
+    {
+        switch ( errno ) {
+            case EBUSY:
+                errprint("events are (or were) active on this domain\n");
+                break;
+            case ENODEV:
+                errprint("EPT not supported for this guest\n");
+                break;
+            default:
+                errprint("Error initialising shared page: %s\n", strerror(errno));
+                break;
+        }
+        goto err;
+    }
+
+    // Open event channel
+    xe->mem_event.xce_handle = xc_evtchn_open(NULL, 0);
+    if ( xe->mem_event.xce_handle == NULL )
+    {
+        errprint("Failed to open event channel\n");
+        goto err;
+    }
+
+    // Bind event notification
+    rc = xc_evtchn_bind_interdomain(
+          xe->mem_event.xce_handle, dom, xe->mem_event.evtchn_port);
+
+    if ( rc < 0 )
+    {
+        errprint("Failed to bind event channel\n");
+        goto err;
+    }
+
+    xe->mem_event.port = rc;
+    dbprint("Bound to event channel on port == %d\n", xe->mem_event.port);
+
+    // Initialise ring
+    SHARED_RING_INIT((mem_event_sring_t *)xe->mem_event.ring_page);
+    BACK_RING_INIT(&xe->mem_event.back_ring,
+                   (mem_event_sring_t *)xe->mem_event.ring_page,
+                   getpagesize());
+
+    /* Now that the ring is set, remove it from the guest's physmap */
+    if ( xc_domain_decrease_reservation_exact(xch,
+                    dom, 1, 0, &ring_pfn) )
+        errprint("Failed to remove ring from guest physmap");
+
+    // Get domaininfo
+    /* TODO MARESCA non allocated would work fine here via &dominfo below */
+    dom_info = malloc(sizeof(xc_domaininfo_t));
+    if ( dom_info == NULL )
+    {
+        errprint("Error allocating memory for domain info\n");
+        goto err;
+    }
+
+    rc = xc_domain_getinfolist(xch, dom, 1, dom_info);
+    if ( rc != 1 )
+    {
+        errprint("Error getting domain info\n");
+        goto err;
+    }
+
+    // This is mostly nice for setting global access.
+    // There may be a better way to manage this.
+    xe->mem_event.max_pages = dom_info->max_pages;
+    free(dom_info);
+
+    xen_get_instance(vmi)->events = xe;
+    return VMI_SUCCESS;
+
+ err:
+    xen_events_destroy(vmi);
+    return VMI_FAILURE;
+}
+
+status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event)
+{
+    xc_interface * xch = xen_get_xchandle(vmi);
+    unsigned long dom = xen_get_domainid(vmi);
+    int value = HVMPME_mode_disabled;
+    int hvm_param;
+
+    switch(event.in_access){
+        case VMI_REG_N: break;
+        case VMI_REG_W:
+            value = HVMPME_mode_sync;
+            if(event.async)
+                value = HVMPME_mode_async;
+            if(event.onchange)
+                /* MARESCA note bugfix was applied here
+                 *  Previously, was value = HVMPME_onchangeonly;
+                 */
+                value |= HVMPME_onchangeonly;
+            break;
+        case VMI_REG_R:
+        case VMI_REG_RW:
+            errprint("Register read events are unavailable in Xen.\n");
+            return VMI_FAILURE;
+            break;
+        default:
+            errprint("Unknown register access mode: %d\n", event.in_access);
+            return VMI_FAILURE;
+    }
+
+    switch(event.reg){
+        case CR0:
+            hvm_param = HVM_PARAM_MEMORY_EVENT_CR0;
+            break;
+        case CR3:
+            hvm_param = HVM_PARAM_MEMORY_EVENT_CR3;
+            break;
+        case CR4:
+            hvm_param = HVM_PARAM_MEMORY_EVENT_CR4;
+            break;
+        default:
+            errprint("Tried to register for unsupported register event.\n");
+            return VMI_FAILURE;
+    }
+    if(xc_set_hvm_param(xch, dom, hvm_param, value))
+        return VMI_FAILURE;
+    return VMI_SUCCESS;
+}
+
+status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event)
+{
+    int rc;
+    hvmmem_access_t access;
+    xc_interface * xch = xen_get_xchandle(vmi);
+    xen_events_t * xe = xen_get_events(vmi);
+    unsigned long dom = xen_get_domainid(vmi);
+    uint64_t npages = event.npages > xe->mem_event.max_pages
+        ? xe->mem_event.max_pages : event.npages;
+
+    // Convert betwen vmi_mem_access_t and hvmmem_access_t
+    // Xen does them backwards....
+    switch(event.in_access){
+        case VMI_MEM_N: access = HVMMEM_access_rwx; break;
+        case VMI_MEM_R: access = HVMMEM_access_wx; break;
+        case VMI_MEM_W: access = HVMMEM_access_rx; break;
+        case VMI_MEM_X: access = HVMMEM_access_rw; break;
+        case VMI_MEM_RW: access = HVMMEM_access_x; break;
+        case VMI_MEM_RX: access = HVMMEM_access_w; break;
+        case VMI_MEM_WX: access = HVMMEM_access_r; break;
+        case VMI_MEM_RWX: access = HVMMEM_access_n; break;
+        case VMI_MEM_X_ON_WRITE: access = HVMMEM_access_rx2rw; break;
+    }
+
+    dbprint("--Setting memaccess for domain %d on page: %llx npages: %llu\n",
+        dom, event.page, npages);
+    if(rc = xc_hvm_set_mem_access(xch, dom, access, event.page, npages)){
+        errprint("xc_hvm_set_mem_access failed with code: %d\n", rc);
+        return VMI_FAILURE;
+    }
+    dbprint("--Done Setting memaccess on page: %llu\n", event.page);
+    return VMI_SUCCESS;
+}
+
+status_t xen_set_int3_access(vmi_instance_t vmi, int enabled)
+{
+    int param = HVMPME_mode_disabled;
+    if(enabled)
+        param = HVMPME_mode_sync;
+
+    return xc_set_hvm_param(
+        xen_get_xchandle(vmi), xen_get_domainid(vmi),
+        HVM_PARAM_MEMORY_EVENT_INT3, param);
+}
+
+status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
+{
+    xc_interface * xch;
+    xen_events_t * xe;
+    mem_event_request_t req;
+    mem_event_response_t rsp;
+    unsigned long dom;
+
+    int rc = -1;
+    status_t vrc = VMI_FAILURE;
+
+    /* TODO determine whether we should force the required=1 for
+     *   singlestep and int3, for which that is a necessity.
+     * Alternatively, an error could be issued
+     */
+    int required = 0;
+
+    // Get xen handle and domain.
+    xch = xen_get_xchandle(vmi);
+    dom = xen_get_domainid(vmi);
+    xe = xen_get_events(vmi);
+
+    // Set whether the access listener is required
+    rc = xc_domain_set_access_required(xch, dom, required);
+    if ( rc < 0 ) {
+        errprint("Error %d setting mem_access listener required\n", rc);
+    }
+
+
+    dbprint("--Waiting for xen events...(%lu ms)\n", timeout);
+    rc = wait_for_event_or_timeout(xch, xe->mem_event.xce_handle, timeout);
+    if ( rc < -1 ) {
+        errprint("Error while waiting for event.\n");
+        return VMI_FAILURE;
+    }
+
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring) ) {
+        rc = get_mem_event(&xe->mem_event, &req);
+        if ( rc != 0 ) {
+            errprint("Error getting event.\n");
+            return VMI_FAILURE;
+        }
+
+        memset( &rsp, 0, sizeof (rsp) );
+        rsp.vcpu_id = req.vcpu_id;
+        rsp.flags = req.flags;
+
+        switch(req.reason){
+            case MEM_EVENT_REASON_VIOLATION:
+                dbprint("--Caught mem event!\n");
+                rsp.gfn = req.gfn;
+                rsp.p2mt = req.p2mt;
+                vrc = process_mem(vmi, req);
+
+                /*MARESCA do we need logic here to reset flags on a page? see xen-access.c
+                 *    specifically regarding write/exec/int3 inspection and the code surrounding
+                 *    the variables default_access and after_first_access
+                 */
+
+                break;
+            case MEM_EVENT_REASON_CR0:
+                vrc = process_register(vmi, CR0, req);
+                break;
+            case MEM_EVENT_REASON_CR3:
+                dbprint("--Caught CR3 event!\n");
+                vrc = process_register(vmi, CR3, req);
+                break;
+            case MEM_EVENT_REASON_CR4:
+                vrc = process_register(vmi, CR4, req);
+                break;
+            case MEM_EVENT_REASON_INT3:
+                /* TODO MARESCA need to handle this;
+                 * see xen-unstable.hg/tools/include/xen/mem_event.h
+                 */
+            case MEM_EVENT_REASON_SINGLESTEP:
+                /* TODO MARESCA need to handle this;
+                 * see xen-unstable.hg/tools/include/xen/mem_event.h
+                 */
+            default:
+                errprint("UNKNOWN REASON CODE %d\n", req.reason);
+                vrc = VMI_FAILURE;
+        }
+
+        rc = resume_domain(vmi, &rsp);
+        if ( rc != 0 ) {
+            errprint("Error resuming domain.\n");
+            return VMI_FAILURE;
+        }
+    }
+
+    dbprint("--Finished handling event.\n");
+    return vrc;
+}
+#else
+status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout){
+	return VMI_FAILURE;
+}
+
+status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event){
+	return VMI_FAILURE;
+}
+
+status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event){
+	return VMI_FAILURE;
+}
+#endif /* ENABLE_XEN */

--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -1,0 +1,96 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * This file is part of LibVMI.
+ *
+ * Author: Nasser Salim (njsalim@sandia.gov)
+ * Author: Steven Maresca (steve@zentific.com)
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Portions of this header and dependent code is based upon that in xen-access, 
+ *    from the official Xen source distribution.  That code carries the 
+ *    following copyright notices and license.
+ *  
+ * Copyright (c) 2011 Virtuata, Inc.
+ * Copyright (c) 2009 by Citrix Systems, Inc. (Patrick Colp), based on
+ *   xenpaging.c
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#ifndef XEN_EVENTS_H
+#define XEN_EVENTS_H
+
+#include <sys/poll.h>
+
+#if ENABLE_XEN == 1
+#include <xenctrl.h>
+#include <xen/mem_event.h>
+#include <xen/hvm/save.h>
+
+typedef int spinlock_t;
+
+typedef struct {
+    xc_evtchn *xce_handle;
+    int port;
+    mem_event_back_ring_t back_ring;
+#ifdef XENEVENT41
+    mem_event_shared_page_t *shared_page;
+#elif XENEVENT42    
+    uint32_t evtchn_port;
+#endif
+    void *ring_page;
+    spinlock_t ring_lock;
+    unsigned long long max_pages;
+} xen_mem_event_t;
+#else
+typedef struct {
+} xen_mem_event_t;
+#endif /* ENABLE_XEN */
+
+
+typedef struct xen_events {
+    xen_mem_event_t mem_event;
+} xen_events_t;
+
+status_t xen_events_init(vmi_instance_t vmi);
+void xen_events_destroy(vmi_instance_t vmi);
+status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
+status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event);
+status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event);
+
+#endif

--- a/libvmi/driver/xen_private.h
+++ b/libvmi/driver/xen_private.h
@@ -1,0 +1,36 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Bryan D. Payne (bdpayne@acm.org)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libvmi.h"
+
+xen_instance_t *xen_get_instance (vmi_instance_t vmi); 
+
+#ifdef XENCTRL_HAS_XC_INTERFACE // Xen >= 4.1
+xc_interface *
+#else
+int
+#endif
+xen_get_xchandle (vmi_instance_t vmi);

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -1,0 +1,217 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Nasser Salim (njsalim@sandia.gov)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libvmi.h"
+#include "private.h"
+
+#define _GNU_SOURCE
+#include <glib.h>
+
+/* XXX This is likely not be the best data structure arrangement to
+   keep track of events and callback registrations.  Namely,
+
+   1. There really can only be 1 event registration per page or register.
+      This data structure allows multiple registrations and at the moment,
+      a new registration simply stomps on the low level settings.
+   2. It is probably better to keep a seperate structure per event type.
+
+   Right now I am just trying to get something out the door.
+ 
+ */
+
+//----------------------------------------------------------------------------
+//  General event callback management.
+
+static void event_entry_free (gpointer key)
+{
+    vmi_event_t * entry = (vmi_event_t*) key;
+    if (entry) free(entry);
+}
+
+void events_init (vmi_instance_t vmi)
+{
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return;
+    }
+
+    vmi->event_handlers = g_hash_table_new_full(
+            g_int_hash, g_int_equal, event_entry_free, NULL);
+}
+
+void event_handler_clear (vmi_instance_t vmi)
+{
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return;
+    }
+
+    event_iter_t i;
+    vmi_event_t *stored_event;
+    event_callback_t stored_callback;
+    GSList *to_delete = NULL;
+
+    for_each_event(vmi, i, stored_event, stored_callback){
+        to_delete=g_slist_append(to_delete, (gpointer)stored_event);
+    }
+
+    while(to_delete != NULL) {
+        vmi_clear_event(vmi, *(vmi_event_t *)(to_delete->data) );
+
+        GSList *temp = to_delete->next;
+        g_slist_free(to_delete);
+        to_delete = temp;
+    }
+}
+
+void events_destroy (vmi_instance_t vmi)
+{
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return;
+    }
+
+    event_handler_clear(vmi);
+    g_hash_table_destroy(vmi->event_handlers);
+}
+
+void event_handler_set (vmi_instance_t vmi, vmi_event_t event, event_callback_t cb)
+{
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return;
+    }
+
+    vmi_event_t * pe = safe_malloc(sizeof(vmi_event_t));
+    *pe = event;
+    g_hash_table_insert(vmi->event_handlers, pe, cb);
+}
+
+status_t event_handler_del (vmi_instance_t vmi, gpointer key)
+{
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return VMI_FAILURE;
+    }
+
+    if (g_hash_table_remove(vmi->event_handlers, key))
+        return VMI_SUCCESS;
+    return VMI_FAILURE;
+}
+
+//----------------------------------------------------------------------------
+// Public event functions.
+
+status_t vmi_handle_event (vmi_instance_t vmi, 
+                           vmi_event_t event,
+                           event_callback_t callback)
+{
+    status_t rc = VMI_FAILURE;
+    
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return VMI_FAILURE;
+    }
+
+    switch(event.type){
+        case VMI_REGISTER_EVENT:
+            dbprint("Enabling register event on reg: %d\n",
+                event.reg_event.reg);
+            rc = driver_set_reg_access(vmi, event.reg_event);
+            break;
+        case VMI_MEMORY_EVENT:
+            dbprint("Enabling memory event on pages: %llx + %d\n",
+                event.mem_event.page, event.mem_event.npages);
+            rc = driver_set_mem_access(vmi, event.mem_event);
+            break;
+        default:
+            errprint("Unknown event type: %d\n", event.type);
+    }
+
+    if(rc == VMI_SUCCESS)
+        event_handler_set(vmi, event, callback);
+    return rc;
+}
+
+status_t vmi_clear_event (vmi_instance_t vmi, 
+                          vmi_event_t event)
+{
+    status_t rc = VMI_FAILURE;
+    event_iter_t i;
+    vmi_event_t *stored_event, *todelete = NULL;
+    event_callback_t stored_callback;
+    
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return VMI_FAILURE;
+    }
+
+    for_each_event(vmi, i, stored_event, stored_callback){
+        if(stored_event->type == event.type){
+            switch(event.type){
+                case VMI_REGISTER_EVENT:
+                    if(stored_event->type == VMI_REGISTER_EVENT){
+                        if(stored_event->reg_event.reg == event.reg_event.reg){
+                            dbprint("Disabling register event on reg: %d\n",
+                                    event.reg_event.reg);
+                            todelete = stored_event;
+                            todelete->reg_event.in_access = VMI_REG_N;
+                            rc = driver_set_reg_access(vmi, todelete->reg_event);
+                        }
+                    }
+                    break;
+                case VMI_MEMORY_EVENT:
+                    if(stored_event->type == VMI_MEMORY_EVENT){
+                        if(stored_event->mem_event.page == event.mem_event.page){
+                            dbprint("Disabling memory event on page: %llu\n",
+                                    event.mem_event.page);
+                            todelete = stored_event;
+                            todelete->mem_event.in_access = VMI_MEM_N;
+                            rc = driver_set_mem_access(vmi, todelete->mem_event);
+                        }
+                    }
+                    break;
+                default:
+                    errprint("Cannot clear unknown event: %d\n", event.type);
+                    return VMI_FAILURE;
+            }
+        }
+    }
+
+    if(!todelete){
+        warnprint("Could not find event to delete!\n");
+        return VMI_FAILURE;
+    }
+
+    if(rc != VMI_SUCCESS){
+        errprint("Could not disable event!\n");
+        return rc;
+    }
+
+    return event_handler_del(vmi, todelete);
+}
+
+status_t vmi_events_listen(vmi_instance_t vmi, uint32_t timeout){
+    
+    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        return VMI_FAILURE;
+    }
+
+    return driver_events_listen(vmi, timeout);
+}

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -146,6 +146,8 @@ struct vmi_instance {
     uint32_t memory_cache_size_max;/**< max size of memory cache */
 
     unsigned int num_vcpus; /**< number of VCPUs used by this instance */
+
+    GHashTable *event_handlers; /**< event->functions mapping for events */
 };
 
 /** Windows' UNICODE_STRING structure (x86) */
@@ -337,4 +339,26 @@ typedef struct _windows_unicode_string32 {
     void timer_stop(
     const char *id);
 
+/*----------------------------------------------
+ * events.c
+ */
+    void events_init(
+        vmi_instance_t vmi);
+    void events_destroy(
+        vmi_instance_t vmi);
+    void event_handler_set(
+        vmi_instance_t vmi,
+        vmi_event_t event,
+        event_callback_t cb);
+    status_t event_handler_del(
+        vmi_instance_t vmi,
+        gpointer key);
+    void event_handler_clear(
+        vmi_instance_t vmi);
+
+    typedef GHashTableIter event_iter_t;
+    #define for_each_event(vmi, iter, key, val) \
+        g_hash_table_iter_init(&iter, vmi->event_handlers); \
+        while(g_hash_table_iter_next(&iter,(void**)&key,(void**)&val))
+    
 #endif /* PRIVATE_H */


### PR DESCRIPTION
This code is 95% the work of Nassir Salim. I've updated it, refactored some components, added some missing features, and expanded the events example.

Changes from the events branch originally hosted at Google code
        1) Refactor to support Xen 4.2 (and Xen 4.1 mem_events). This may be simplified to be Xen 4.2 only, per discussion with Bryan and Nassir. However, there are new mem_events features headed into 4.3 that warrant retention of the checks in the configure.ac
        2) Add vcpu ID to mem_event structure
        3) Add int3 handler
        4) A handful of bugfixes relative to the HVM_onchangeonly flag (e.g. it needed to be OR'd into the flag, rather than assignment)
        5) General refactoring to track the upstream xen-access.c mem_events example
        6) A bit of a rewrite of the event_example.c code
        7) Fix unconditional initialization of memory events. (Now only upon request and IFF hvm).

```
Changes that are necessary in the future include improved event registration functionality per discussion on vmitools mailing list and via email

Important enhancements that should be pursued:
    1) detection of EPT to validate that events are possible to initialize.
    2) determination of AMD support using RVI
    3) support for the newly added MSR write monitoring (to appear in Xen 4.3)
    4) possibility of a KVM equivalent of memory events
```
