### PR TITLE
Add -lvmi to pkg config

### DIFF
--- a/libvmi.pc.in
+++ b/libvmi.pc.in
@@ -7,5 +7,5 @@ Name: LibVMI Library
 Description: A virtual machine introspection library for Xen and KVM.
 Requires: 
 Version: @VERSION@
-Libs: -L@libdir@ @LIBS@
+Libs: -L@libdir@ @LIBS@ -lvmi
 Cflags: -I@includedir@ 


### PR DESCRIPTION
Currently the pkg config configuration doesn't include -lvmi, hence when trying to build a third-party tool with "pkg-config --cflags --libs libvmi" will fail to properly link against the library.
