### PR TITLE
Update pyvmi and associated tools to take advantage of the new custom-init functions

### DIFF
--- a/tools/pyvmi/pyvmiaddressspace.py
+++ b/tools/pyvmi/pyvmiaddressspace.py
@@ -47,8 +47,17 @@ class PyVmiAddressSpace(addrspace.BaseAddressSpace):
         self.as_assert(
                 config.LOCATION.startswith("vmi://"),
                 "Location doesn't start with vmi://")
-        self.name = urllib.url2pathname(config.LOCATION[6:])
-        self.vmi = pyvmi.init(self.name, "partial")
+        self.config = dict(inittype="partial")
+        if config.LOCATION.find("domid/") == 6:
+            self.domid = int(urllib.url2pathname(config.LOCATION[12:]))
+            self.config['domid']=self.domid
+        elif config.LOCATION.find("name/") == 6:
+            self.name = urllib.url2pathname(config.LOCATION[11:])
+            self.config['name'] = self.name
+        else:
+            self.name = urllib.url2pathname(config.LOCATION[6:])
+            self.config['name'] = self.name
+        self.vmi = pyvmi.init(self.config)
         self.as_assert(not self.vmi is None, "VM not found")
         self.dtb = self.get_cr3()
 

--- a/tools/pyvmi/setup.py
+++ b/tools/pyvmi/setup.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python
-
+import commands
 from distutils.core import setup, Extension
 
+pkgconfig_cflags = commands.getoutput ("pkg-config --cflags glib-2.0 libvmi")
+pkgconfig_include_flags = commands.getoutput ("pkg-config --cflags-only-I glib-2.0 libvmi")
+pkgconfig_include_dirs = [ t[2:] for t in pkgconfig_include_flags.split() ]
+pkgconfig_lflags = commands.getoutput ("pkg-config --libs-only-l glib-2.0 libvmi")
+pkgconfig_libs = [ t[2:] for t in pkgconfig_lflags.split() ]
+pkgconfig_biglflags = commands.getoutput ("pkg-config --libs-only-L glib-2.0 libvmi")
+pkgconfig_ldirs = [ t[2:] for t in pkgconfig_biglflags.split() ]
+
 pyvmimod = Extension('pyvmi', sources=['pyvmi.c'],
-                    include_dirs = ['/usr/local/include'],
-                    library_dirs = ['/usr/local/lib'],
-                    libraries = ['vmi'])
+                    include_dirs = pkgconfig_include_dirs,
+                    library_dirs = pkgconfig_ldirs,
+                    libraries = pkgconfig_libs,
+                    extra_compile_args=[pkgconfig_cflags])
 
-
-setup(name='PyVmi', version='1.0',
+setup(name='PyVmi', version='1.1',
       description = 'Python interface to LibVMI',
       ext_modules = [pyvmimod])


### PR DESCRIPTION
This PR depends on the prior Xenstore branch, will be rebased once it gets merged.

---

In order to be able to target domains through their ID instead of just their names, PyVMI had to be updated to support the new custom-init functions. This involved:
- Adding glib to setup.py (and fix the hard-coded paths in there)
- Check if the input given to pyvmi_init is the regular two strings (mode & vmname) or if a dict was passed with the configuration
- Translate the dict to a GHashTable and pass it to custom-init

For pyvmiaddressspace.py a new method was derived to target a domain based on its name or id with the syntax vmi://domid/<domid> or vmi://name/<name>. If no domid/ or name/ was provided it falls back to the default mode. Here are some example:
python ~/volatility-svn/vol.py -l vmi://domid/28 pslist
python ~/volatility-svn/vol.py -l vmi://name/tamas-windows-xp-sp2 pslist
python ~/volatility-svn/vol.py -l vmi://tamas-windows-xp-sp2 pslist
