### PR TITLE
Better KVM detection in autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,18 +92,51 @@ have_kvm='no'
 kvm_space=' '
 [if test "$enable_kvm" = "yes"]
 [then]
-    kvm_space=''
-    AC_CHECK_LIB(virt, virConnectOpen, [], [missing="yes"])
-    [if test "$missing" = "yes"]
+    AC_PATH_PROG(GREP, grep)
+    [if test "x$GREP" = "x"]
     [then]
         AC_DEFINE([ENABLE_KVM], [0], [Define to 1 to enable KVM support.])
         missing='no'
         enable_kvm='no'
         kvm_space=' '
-        have_kvm='missing libvirt'
-    [else]
-        AC_DEFINE([ENABLE_KVM], [1], [Define to 1 to enable KVM support.])
-        have_kvm='yes'
+        have_kvm='grep missing'
+    [fi]
+
+    AC_PATH_PROG(LSMOD, lsmod)
+    [if test "x$LSMOD" = "x"]
+    [then]
+        AC_DEFINE([ENABLE_KVM], [0], [Define to 1 to enable KVM support.])
+        missing='no'
+        enable_kvm='no'
+        kvm_space=' '
+        have_kvm='lsmod missing'
+    [fi]
+    
+    [if test "x$LSMOD" != "x" && test "x$GREP" != "x"]
+    [then]
+        KVM_PRESENT=$($LSMOD | $GREP kvm)
+        [if test "x$KVM_PRESENT" != "x"]
+        [then]
+            AC_CHECK_LIB(virt, virConnectOpen, [], [missing="yes"])
+            [if test "$missing" = "yes"]
+            [then]
+                AC_DEFINE([ENABLE_KVM], [0], [Define to 1 to enable KVM support.])
+                missing='no'
+                enable_kvm='no'
+                kvm_space=' '
+                have_kvm='libvirt missing'
+            [else]
+                AC_DEFINE([ENABLE_KVM], [1], [Define to 1 to enable KVM support.])
+                have_kvm='yes'
+                kvm_space=''
+            [fi]
+        [else]
+            AC_DEFINE([ENABLE_KVM], [0], [Define to 1 to enable KVM support.])
+            missing='no'
+            enable_kvm='no'
+            kvm_space=' '
+            have_kvm='kernel module is not loaded'
+        [fi]
     [fi]
 [fi]
 


### PR DESCRIPTION
Beside searching for libvirt, check if the kvm module is actually loaded into the kernel. It's still not perfect, but since that's what the kvm FAQ recommends to do, it's a OK (http://www.linux-kvm.org/page/FAQ#How_can_I_check_that_I.27m_not_falling_back_to_QEMU_with_no_hardware_acceleration.3F)
