### PR TITLE
Compiling with Xen 4.1.x.

### DIFF
--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -68,10 +68,12 @@ typedef struct {
     xc_evtchn *xce_handle;
     int port;
     mem_event_back_ring_t back_ring;
-#ifdef XENEVENT41
-    mem_event_shared_page_t *shared_page;
-#elif XENEVENT42    
+#ifdef XENEVENT42
     uint32_t evtchn_port;
+#elif XENEVENT41
+    mem_event_shared_page_t *shared_page;
+#else
+#error "Unsupported Xen version for events"
 #endif
     void *ring_page;
     spinlock_t ring_lock;

--- a/libvmi/driver/xen_private.h
+++ b/libvmi/driver/xen_private.h
@@ -23,6 +23,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef XEN_PRIVATE_H
+#define XEN_PRIVATE_H
 
 #include "libvmi.h"
 
@@ -34,3 +36,5 @@ xc_interface *
 int
 #endif
 xen_get_xchandle (vmi_instance_t vmi);
+
+#endif


### PR DESCRIPTION
It looks like mostly set up and teardown are affected by the changes to Xen's API.

Added guards to xen_private.h.

Including string.h to fix warnings about memset/memcmp being undeclared.
