### PR TITLE
Make find_windows_version accessible during partial init

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -53,12 +53,13 @@ win_ver_t
 vmi_get_winver(
     vmi_instance_t vmi)
 {
-    if (VMI_OS_WINDOWS != vmi->os_type)
+
+    if (VMI_OS_WINDOWS != vmi->os_type || VMI_INIT_PARTIAL & vmi->init_mode)
         return VMI_OS_WINDOWS_NONE;
 
     if (!vmi->os.windows_instance.version ||
         vmi->os.windows_instance.version == VMI_OS_WINDOWS_UNKNOWN) {
-        find_windows_version(vmi,
+        vmi->os.windows_instance.version = find_windows_version(vmi,
                              vmi->os.windows_instance.kdversion_block);
     }
     return vmi->os.windows_instance.version;
@@ -90,6 +91,14 @@ vmi_get_winver_str(
     default:
         return "<Illegal value for Windows version>";
     }   // switch
+}
+
+win_ver_t
+vmi_get_winver_manual(
+    vmi_instance_t vmi,
+    addr_t kdvb_pa)
+{
+    return find_windows_version(vmi, kdvb_pa);
 }
 
 unsigned long

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1102,6 +1102,21 @@ const char *vmi_get_winver_str(
     vmi_instance_t vmi);
 
 /**
+ * Get the version of Windows based on the provided KDVB address.  This is the
+ * simple Windows version - no service pack or patch level is provided.
+ *
+ * This function is intended to be used during partial init as an aid to elevate
+ * to full init.
+ *
+ * @param[in] vmi       LibVMI instance
+ * @param[in] kdvb_pa   The physical address of the KDVB
+ * @return Windows version
+ */
+win_ver_t vmi_get_winver_manual(
+    vmi_instance_t vmi,
+    addr_t kdvb_pa);
+
+/**
  * Get the memory offset associated with the given offset_name.
  * Valid names include everything in the /etc/libvmi.conf file.
  *

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -302,7 +302,7 @@ typedef struct _windows_unicode_string32 {
     int find_pname_offset(
     vmi_instance_t vmi,
     check_magic_func check);
-    void find_windows_version(
+    win_ver_t find_windows_version(
     vmi_instance_t vmi,
     addr_t KdVersionBlock);
     status_t validate_pe_image(


### PR DESCRIPTION
In order to verify results of a manual KDBG search and elevate automatically from partial to full, finding out the version of Windows is necessary.
