### PR TITLE
Refactor get_memory_layout so that it is accessible during partial init

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -32,7 +32,13 @@ page_mode_t
 vmi_get_page_mode(
     vmi_instance_t vmi)
 {
-    return vmi->page_mode;
+    if(vmi->page_mode == VMI_PM_UNKNOWN) {
+        page_mode_t ret=VMI_PM_UNKNOWN;
+        get_memory_layout(vmi, &ret, NULL, NULL, NULL, NULL);
+        return ret;
+    } else {
+        return vmi->page_mode;
+    }
 }
 
 uint32_t


### PR DESCRIPTION
Currently get_memory_layout is tied into the full init process. This refactor makes it accessible during partial init using the vmi_get_page_mode accessor.
