### PR TITLE
Allow building libvmi without xenstore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,13 @@ AC_ARG_ENABLE([vmifs],
       [enable_vmifs=yes])
 AM_CONDITIONAL([VMIFS], [test x$enable_vmifs = xyes])
 
+AC_ARG_WITH([xenstore],
+      [AS_HELP_STRING([--without-xenstore],
+         [Build LibVMI without Xenstore])],
+      [with_xenstore=$withval],
+      [with_xenstore=yes])
+AM_CONDITIONAL([XENSTORE], [test x$with_xenstore = xyes])
+
 dnl -----------------------------------------------
 dnl Checks for programs, libraries, etc.
 dnl -----------------------------------------------
@@ -94,8 +101,15 @@ have_xen_events='no'
 xen_event_space=' '
 [if test "$enable_xen" = "yes"]
 [then]
-    AC_CHECK_LIB(xenstore, xs_read, [], [missing="yes"])
-    [if test "$missing" = "yes"]
+
+    [if test "$with_xenstore" = "yes"]
+    [then]
+        AC_CHECK_LIB(xenstore, xs_read, [], [missing="yes"])
+        AC_CHECK_HEADERS([xenstore.h])
+        AC_CHECK_HEADERS([xs.h])
+    [fi]
+
+    [if test "$with_xenstore" = "yes" -a "$missing" = "yes"]
     [then]
         AC_DEFINE([ENABLE_XEN], [0], [Define to 1 to enable Xen support.])
         missing='no'
@@ -113,8 +127,6 @@ xen_event_space=' '
             AC_DEFINE([ENABLE_XEN], [1], [Define to 1 to enable Xen support.])
             have_xen='yes'
             xen_space='     '
-
-            AC_CHECK_HEADERS([xenstore.h])
 
             [if test "$enable_xen_events" = "yes"]
             [then]

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -41,7 +41,7 @@
 #include <stdint.h>
 #if HAVE_XENSTORE_H
   #include <xenstore.h>
-#else
+#elif HAVE_XS_H
   #include <xs.h>
 #endif
 #include <xen/hvm/save.h>
@@ -169,6 +169,11 @@ xen_get_domainid_from_name(
     char *name)
 {
 
+// This function is only usable with xenstore
+#ifndef HAVE_LIBXENSTORE
+    return VMI_INVALID_DOMID;
+#else
+
     if (name == NULL) {
         return VMI_INVALID_DOMID;
     }
@@ -217,6 +222,7 @@ _bail:
     if (xsh)
         CLOSE_XS_DAEMON(xsh);
     return domainid;
+#endif
 }
 
 status_t
@@ -225,6 +231,12 @@ xen_get_name_from_domainid(
     unsigned long domid,
     char **name)
 {
+
+// This function is only usable with xenstore
+#ifndef HAVE_LIBXENSTORE
+    return VMI_FAILURE;
+#else
+
     status_t ret = VMI_FAILURE;
     if (domid == VMI_INVALID_DOMID) {
         return ret;
@@ -255,7 +267,7 @@ _bail:
     if (xsh)
         CLOSE_XS_DAEMON(xsh);
     return ret;
-
+#endif
 }
 
 unsigned long
@@ -402,11 +414,13 @@ xen_init(
         goto _bail;
     }
 
+#ifdef HAVE_LIBXENSTORE
     xen_get_instance(vmi)->xshandle = OPEN_XS_DAEMON();
     if (!xen_get_instance(vmi)->xshandle) {
         errprint("xs_domain_open failed\n");
         goto _bail;
     }
+#endif
 
     /* record the count of VCPUs used by this instance */
     vmi->num_vcpus = xen_get_instance(vmi)->info.max_vcpu_id + 1;
@@ -459,9 +473,12 @@ xen_destroy(
         xc_interface_close(xchandle);
     }
 
+#ifdef HAVE_LIBXENSTORE
     if(xen_get_instance(vmi)->xshandle) {
         CLOSE_XS_DAEMON(xen_get_instance(vmi)->xshandle);
     }
+#endif
+
 }
 
 status_t
@@ -469,6 +486,12 @@ xen_get_domainname(
     vmi_instance_t vmi,
     char **name)
 {
+
+// This function is only usable with Xenstore
+#ifndef HAVE_LIBXENSTORE
+    return VMI_FAILURE;
+#else
+
     status_t ret = VMI_FAILURE;
     xs_transaction_t xth = XBT_NULL;
 
@@ -491,6 +514,7 @@ xen_get_domainname(
 
 _bail:
     return ret;
+#endif
 }
 
 void

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -47,16 +47,20 @@ typedef xc_interface *libvmi_xenctrl_handle_t;
 #define XENCTRL_HANDLE_INVALID NULL
 
     // new way to open/close XS daemon
+#ifdef HAVE_LIBXENSTORE
 #define OPEN_XS_DAEMON()    xs_open(0)
 #define CLOSE_XS_DAEMON(h)  xs_close(h)
+#endif
 #else
 typedef int libvmi_xenctrl_handle_t;
 
 #define XENCTRL_HANDLE_INVALID (-1)
 
+#ifdef HAVE_LIBXENSTORE
     // these are supported, but deprecated in xen 4.1
 #define OPEN_XS_DAEMON()     xs_daemon_open()
 #define CLOSE_XS_DAEMON(h)   xs_daemon_close(h)
+#endif
 #endif
 
 typedef struct xen_instance {
@@ -73,7 +77,10 @@ typedef struct xen_instance {
 
     uint8_t addr_width;     /**< guest's address width in bytes: 4 or 8 */
 
+#ifdef HAVE_LIBXENSTORE
     struct xs_handle *xshandle;  /**< handle to xenstore daemon */
+#endif
+
     char *name;
 
 #if ENABLE_XEN_EVENTS==1


### PR DESCRIPTION
As Xenstore is no longer a critical element of LibVMI, this patch allows building it without requiring Xenstore to be installed. It is still left in as a required component of the default configuration process.
