### PR TITLE
Xen single step mem_events

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(GLIB_CFLAGS)
 AM_LDFLAGS = -L$(top_srcdir)/libvmi/.libs/
 LDADD = -lvmi -lm $(LIBS) $(GLIB_LIBS)
 
-bin_PROGRAMS = module-list process-list map-symbol map-addr dump-memory win-guid event-example msr-event-example
+bin_PROGRAMS = module-list process-list map-symbol map-addr dump-memory win-guid event-example msr-event-example singlestep-event-example
 module_list_SOURCES = module-list.c
 process_list_SOURCES = process-list.c
 map_symbol_SOURCES = map-symbol.c
@@ -14,5 +14,6 @@ map_addr_SOURCES = map-addr.c
 dump_memory_SOURCES = dump-memory.c
 event_example_SOURCES = event-example.c
 msr_event_example_SOURCES = msr-event-example.c
+singlestep_event_example_SOURCES = singlestep-event-example.c
 win_guid_SOURCES = win-guid.c
 

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -48,7 +48,7 @@ vmi_event_t kernel_vsyscall_event;
 vmi_event_t kernel_sysenter_target_event;
 
 void print_event(vmi_event_t event){
-    printf("PAGE %lx ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %lu)\n",
+    printf("PAGE %lx ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %u)\n",
         event.mem_event.page,
         (event.mem_event.out_access == VMI_MEM_R) ? 'r' : '-',
         (event.mem_event.out_access == VMI_MEM_W) ? 'w' : '-',
@@ -138,7 +138,7 @@ void cr3_one_task_callback(vmi_instance_t vmi, vmi_event_t *event){
 
     printf("one_task callback\n");
     if(event->reg_event.value == cr3){
-        printf("My process (PID %i) is executing on vcpu %lu\n", pid, event->vcpu_id);
+        printf("My process (PID %i) is executing on vcpu %u\n", pid, event->vcpu_id);
         msr_syscall_sysenter_event.mem_event.in_access = VMI_MEM_X;
         msr_syscall_sysenter_event.callback=msr_syscall_sysenter_cb;
         kernel_sysenter_target_event.mem_event.in_access = VMI_MEM_X;
@@ -161,7 +161,7 @@ void cr3_one_task_callback(vmi_instance_t vmi, vmi_event_t *event){
 
 void cr3_all_tasks_callback(vmi_instance_t vmi, vmi_event_t *event){
     int pid = vmi_dtb_to_pid(vmi, event->reg_event.value);
-    printf("PID %i with CR3=%lx executing on vcpu %lu.\n", pid, event->reg_event.value, event->vcpu_id);
+    printf("PID %i with CR3=%lx executing on vcpu %u.\n", pid, event->reg_event.value, event->vcpu_id);
 
 	msr_syscall_sysenter_event.mem_event.in_access = VMI_MEM_X;
 	msr_syscall_sysenter_event.callback=msr_syscall_sysenter_cb;

--- a/examples/singlestep-event-example.c
+++ b/examples/singlestep-event-example.c
@@ -1,0 +1,100 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Matthew Fusaro (matthew.fusaro@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libvmi/libvmi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+
+vmi_event_t single_event;
+
+static int interrupted = 0;
+static void close_handler(int sig){
+    interrupted = sig;
+}
+
+void single_step_callback(vmi_instance_t vmi, vmi_event_t *event){
+    printf("Single-step event: VCPU:%u  GFN %"PRIx64" GLA %016"PRIx64"\n",
+        event->vcpu_id,
+        event->ss_event.gfn,
+        event->ss_event.gla);
+    reg_t rip;
+    
+    vmi_get_vcpureg(vmi, &rip, RIP, event->vcpu_id);
+    printf("\tRIP: %"PRIx64"\n", rip);
+    
+}
+
+int main (int argc, char **argv) {
+    vmi_instance_t vmi;
+
+    struct sigaction act;
+
+    char *name = NULL;
+
+    if(argc < 2){
+        fprintf(stderr, "Usage: single_step_example <name of VM> \n");
+        exit(1);
+    }
+
+    // Arg 1 is the VM name.
+    name = argv[1];
+
+    /* for a clean exit */
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    // Initialize the libvmi library.
+    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_PARTIAL | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+        printf("Failed to init LibVMI library.\n");
+        return 1;
+    }
+    else{
+        printf("LibVMI init succeeded!\n");
+    }
+    
+    //Single step setup
+    memset(&single_event, 0, sizeof(vmi_event_t));
+    single_event.type = VMI_EVENT_SINGLESTEP;
+    single_event.callback = single_step_callback;
+    SET_VCPU_SINGLESTEP(single_event.ss_event, 0);
+    vmi_register_event(vmi, &single_event);
+    while(!interrupted ){
+        printf("Waiting for events...\n");
+        vmi_events_listen(vmi,500);
+    }
+    printf("Finished with test.\n");
+
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -118,6 +118,17 @@ struct driver_instance {
     *set_mem_access_ptr)(
     vmi_instance_t,
     mem_event_t);
+    status_t (
+    *start_single_step_ptr)(
+    vmi_instance_t,
+    single_step_event_t);
+    status_t (
+    *stop_single_step_ptr)(
+    vmi_instance_t,
+    uint32_t);
+    status_t (
+    *shutdown_single_step_ptr)(
+    vmi_instance_t);
 };
 typedef struct driver_instance *driver_instance_t;
 
@@ -151,6 +162,9 @@ driver_xen_setup(
     instance->events_listen_ptr = &xen_events_listen;
     instance->set_reg_access_ptr = &xen_set_reg_access;
     instance->set_mem_access_ptr = &xen_set_mem_access;
+    instance->start_single_step_ptr = &xen_start_single_step;
+    instance->stop_single_step_ptr = &xen_stop_single_step;
+    instance->shutdown_single_step_ptr = &xen_shutdown_single_step;
 #endif
 }
 
@@ -181,6 +195,9 @@ driver_kvm_setup(
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
+    instance->start_single_step_ptr = NULL;
+    instance->stop_single_step_ptr = NULL;
+    instance->shutdown_single_step_ptr = NULL;
 }
 
 static void
@@ -210,6 +227,9 @@ driver_file_setup(
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
+    instance->start_single_step_ptr = NULL;
+    instance->stop_single_step_ptr = NULL;
+    instance->shutdown_single_step_ptr = NULL;
 }
 
 static void
@@ -237,6 +257,9 @@ driver_null_setup(
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
+    instance->start_single_step_ptr = NULL;
+    instance->stop_single_step_ptr = NULL;
+    instance->shutdown_single_step_ptr = NULL;
 }
 
 static driver_instance_t
@@ -646,6 +669,47 @@ status_t driver_set_mem_access(
     }
     else{
         dbprint("WARNING: driver_set_mem_access function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_start_single_step(
+    vmi_instance_t vmi, 
+    single_step_event_t event)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->start_single_step_ptr){
+        return ptrs->start_single_step_ptr(vmi, event);
+    }
+    else{
+        dbprint("WARNING: driver_start_single_step function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_stop_single_step(
+    vmi_instance_t vmi, 
+    unsigned long vcpu)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->stop_single_step_ptr){
+        return ptrs->stop_single_step_ptr(vmi, vcpu);
+    }
+    else{
+        dbprint("WARNING: driver_stop_single_step function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_shutdown_single_step(
+    vmi_instance_t vmi)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->shutdown_single_step_ptr){
+        return ptrs->shutdown_single_step_ptr(vmi);
+    }
+    else{
+        dbprint("WARNING: driver_shutdown_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
 }

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -95,6 +95,14 @@ status_t driver_set_mem_access(
 status_t driver_set_reg_access(
     vmi_instance_t vmi,
     reg_event_t event);
+status_t driver_start_single_step(
+    vmi_instance_t vmi, 
+    single_step_event_t event);
+status_t driver_stop_single_step(
+    vmi_instance_t vmi, 
+    unsigned long vcpu);
+status_t driver_shutdown_single_step(
+    vmi_instance_t vmi);
 status_t
 driver_get_address_width(
     vmi_instance_t vmi,

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -159,6 +159,8 @@ xen_put_memory(
     return VMI_SUCCESS;
 }
 
+
+
 //----------------------------------------------------------------------------
 // General Interface Functions (1-1 mapping to driver_* function)
 
@@ -1706,6 +1708,25 @@ xen_resume_vm(
     return VMI_SUCCESS;
 }
 
+status_t
+xen_set_domain_debug_control(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    int enable)
+{
+    status_t ret = VMI_FAILURE;
+    int rc = -1;
+    
+    uint32_t op = (enable) ? 
+        XEN_DOMCTL_DEBUG_OP_SINGLE_STEP_ON : XEN_DOMCTL_DEBUG_OP_SINGLE_STEP_OFF;
+
+    ret = xc_domain_debug_control(
+        xen_get_xchandle(vmi), xen_get_domainid(vmi), 
+        op, vcpu);
+
+    return ret;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 #else
 
@@ -1858,6 +1879,15 @@ xen_pause_vm(
 status_t
 xen_resume_vm(
     vmi_instance_t vmi)
+{
+    return VMI_FAILURE;
+}
+
+status_t
+xen_set_domain_debug_control(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    int enable)
 {
     return VMI_FAILURE;
 }

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -154,3 +154,7 @@ status_t xen_pause_vm(
     vmi_instance_t vmi);
 status_t xen_resume_vm(
     vmi_instance_t vmi);
+status_t xen_set_domain_debug_control(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    int enable);

--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -103,5 +103,9 @@ void xen_events_destroy(vmi_instance_t vmi);
 status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
 status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event);
 status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event);
+status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t event);
+status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu);
+status_t xen_shutdown_single_step(vmi_instance_t vmi);
+
 
 #endif

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -153,6 +153,8 @@ struct vmi_instance {
     GHashTable *mem_events; /**< mem event to functions mapping (key: reg) */
 
     GHashTable *reg_events; /**< reg event to functions mapping (key: page) */
+    
+    GHashTable *ss_events; /**< single step event to functions mapping (key: vcpu_id) */
 
     gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
 };


### PR DESCRIPTION
Introduces single-step memory events for Xen. This currently will accept a vcpu id that you wish to single step and sets the MTF flag on the vcpu.
