### PR TITLE
translate rva to exported symbol (windows)

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -645,6 +645,7 @@ vmi_init_private(
     /* setup the caches */
     pid_cache_init(*vmi);
     sym_cache_init(*vmi);
+    rva_cache_init(*vmi);
     v2p_cache_init(*vmi);
 
     /* connecting to xen, kvm, file, etc */
@@ -890,6 +891,7 @@ vmi_destroy(
     driver_destroy(vmi);
     pid_cache_destroy(vmi);
     sym_cache_destroy(vmi);
+    rva_cache_destroy(vmi);
     v2p_cache_destroy(vmi);
     memory_cache_destroy(vmi);
     if (vmi->sysmap)

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -402,6 +402,23 @@ addr_t vmi_translate_sym2v(
     char *symbol);
 
 /**
+ * Performs the translation from an RVA to a symbol
+ * On Windows this function walks the PE export table.
+ * Linux is unimplemented at this time.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] base_vaddr Base virtual address (beginning of PE header in Windows)
+ * @param[in] pid PID
+ * @param[in] rva RVA to translate
+ * @return Symbol, or NULL on error
+ */
+const char* vmi_translate_v2sym(
+    vmi_instance_t vmi,
+    addr_t base_vaddr,
+    uint32_t pid,
+    addr_t rva);
+
+/**
  * Given a pid, this function returns the virtual address of the
  * directory table base for this process' address space.  This value
  * is effectively what would be in the CR3 register while this process

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -591,6 +591,28 @@ addr_t vmi_translate_sym2v (vmi_instance_t vmi, addr_t base_vaddr, uint32_t pid,
 
     return ret;
 }
+/* convert an RVA into a symbol */
+const char* vmi_translate_v2sym(vmi_instance_t vmi, addr_t base_vaddr, uint32_t pid, addr_t rva)
+{
+    char *ret = NULL;
+
+    if (VMI_FAILURE == rva_cache_get(vmi, base_vaddr, pid, rva, &ret)) {
+
+        if (VMI_OS_LINUX == vmi->os_type) {
+            // TODO
+            return VMI_FAILURE;
+        }
+        else if (VMI_OS_WINDOWS == vmi->os_type) {
+            windows_rva_to_export(vmi, rva, base_vaddr, pid, &ret);
+        }
+
+        if (ret) {
+            rva_cache_set(vmi, base_vaddr, pid, rva, ret);
+        }
+    }
+
+    return ret;
+}
 
 /* finds the address of the page global directory for a given pid */
 addr_t vmi_pid_to_dtb (vmi_instance_t vmi, int pid)

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -132,6 +132,8 @@ struct vmi_instance {
 
     GHashTable *sym_cache;  /**< hash table to hold the sym cache data */
 
+    GHashTable *rva_cache;  /**< hash table to hold the rva cache data */
+
     GHashTable *v2p_cache;  /**< hash table to hold the v2p cache data */
 
     void *driver;           /**< driver-specific information */


### PR DESCRIPTION
Currently LibVMI allows translating a symbol to a VA, but not the other way around. This can be easily implemented using existing techniques on the Windows side by walking the Export Table of the PE header and reusing some of the cache mechanism of sym_cache. Mapping an RVA to a symbol is extremely useful for example when we examine the stack of a process or in any other instances when we need to map an EIP to a symbol.

FYI: this approach does not map unexported symbols as that requires debug data, which would be more easily implemented in Python (or directly with Volatility https://code.google.com/p/volatility/issues/detail?id=149). Nevertheless, when no debug data is available, this can still be used as a fall-back mechanism.
