### PR TITLE
add vmi_set_vcpureg function for both PV and HVM Xen VMs

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -181,6 +181,16 @@ vmi_get_vcpureg(
 }
 
 status_t
+vmi_set_vcpureg(
+    vmi_instance_t vmi,
+    reg_t value,
+    registers_t reg,
+    unsigned long vcpu)
+{
+    return driver_set_vcpureg(vmi, value, reg, vcpu);
+}
+
+status_t
 vmi_pause_vm(
     vmi_instance_t vmi)
 {

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -77,6 +77,12 @@ struct driver_instance {
     reg_t *,
     registers_t,
     unsigned long);
+    status_t(
+    *set_vcpureg_ptr) (
+    vmi_instance_t,
+    reg_t,
+    registers_t,
+    unsigned long);
     status_t (
     *get_address_width_ptr) (
     vmi_instance_t vmi,
@@ -134,6 +140,7 @@ driver_xen_setup(
     instance->set_name_ptr = &xen_set_domainname;
     instance->get_memsize_ptr = &xen_get_memsize;
     instance->get_vcpureg_ptr = &xen_get_vcpureg;
+    instance->set_vcpureg_ptr = &xen_set_vcpureg;
     instance->get_address_width_ptr = &xen_get_address_width;
     instance->read_page_ptr = &xen_read_page;
     instance->write_ptr = &xen_write;
@@ -164,6 +171,7 @@ driver_kvm_setup(
     instance->set_name_ptr = &kvm_set_name;
     instance->get_memsize_ptr = &kvm_get_memsize;
     instance->get_vcpureg_ptr = &kvm_get_vcpureg;
+    instance->set_vcpureg_ptr = NULL;
     instance->get_address_width_ptr = NULL;
     instance->read_page_ptr = &kvm_read_page;
     instance->write_ptr = &kvm_write;
@@ -193,6 +201,7 @@ driver_file_setup(
     instance->get_memsize_ptr = &file_get_memsize;
     instance->get_address_width_ptr = NULL;
     instance->get_vcpureg_ptr = &file_get_vcpureg;
+    instance->set_vcpureg_ptr = NULL;
     instance->read_page_ptr = &file_read_page;
     instance->write_ptr = &file_write;
     instance->is_pv_ptr = &file_is_pv;
@@ -220,6 +229,7 @@ driver_null_setup(
     instance->get_memsize_ptr = NULL;
     instance->get_address_width_ptr = NULL;
     instance->get_vcpureg_ptr = NULL;
+    instance->set_vcpureg_ptr = NULL;
     instance->read_page_ptr = NULL;
     instance->is_pv_ptr = NULL;
     instance->pause_vm_ptr = NULL;
@@ -479,6 +489,23 @@ driver_get_vcpureg(
     else {
         dbprint
             ("WARNING: driver_get_vcpureg function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t
+driver_set_vcpureg(
+    vmi_instance_t vmi,
+    reg_t value,
+    registers_t reg,
+    unsigned long vcpu)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->set_vcpureg_ptr){
+        return ptrs->set_vcpureg_ptr(vmi, value, reg, vcpu);
+    }
+    else{
+        dbprint("WARNING: driver_set_vcpureg function not implemented.\n");
         return VMI_FAILURE;
     }
 }

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -64,6 +64,11 @@ status_t driver_get_vcpureg(
     reg_t *value,
     registers_t reg,
     unsigned long vcpu);
+status_t driver_set_vcpureg(
+    vmi_instance_t vmi,
+    reg_t value,
+    registers_t reg,
+    unsigned long vcpu);
 status_t xen_get_address_width(
     vmi_instance_t vmi,
     uint8_t * width);

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -128,6 +128,12 @@ status_t xen_get_vcpureg(
     reg_t *value,
     registers_t reg,
     unsigned long vcpu);
+status_t
+xen_set_vcpureg(
+    vmi_instance_t vmi,
+    reg_t value,
+    registers_t reg,
+    unsigned long vcpu);
 status_t xen_get_address_width(
     vmi_instance_t vmi,
     uint8_t * width_in_bytes);

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1202,6 +1202,24 @@ status_t vmi_get_vcpureg(
     unsigned long vcpu);
 
 /**
+ * Sets the current value of a VCPU register.  This currently only
+ * supports control registers.  When LibVMI is accessing a raw
+ * memory file, this function will fail. Operating upon an unpaused
+ * VM with this function is likely to have unexpected results.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] value Value to assign to the register
+ * @param[in] reg The register to access
+ * @param[in] vcpu The index of the VCPU to access, use 0 for single VCPU systems
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_set_vcpureg(
+    vmi_instance_t vmi,
+    reg_t value,
+    registers_t reg,
+    unsigned long vcpu);
+
+/**
  * Pauses the VM.  Use vmi_resume_vm to resume the VM after pausing
  * it.  If accessing a memory file, this has no effect.
  *


### PR DESCRIPTION
This PR adds the ability to modify vCPU registers as a complement to existing register access functions. This feature is only available for Xen; KVM lacks register modification capabilities via QMP, so we're largely out of options in that respect until qemu upstream improves or an alternative is made available.
