### PR TITLE
Fixed compilation error for VMI_DEBUG.

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -431,7 +431,7 @@ rva_cache_set(
     }
 
     g_hash_table_insert(rva_table, GUINT_TO_POINTER(rva), entry);
-    dbprint("--RVA cache set %s -- 0x%.16"PRIx64"\n", key, va);
+    dbprint("--RVA cache set %s -- 0x%.16"PRIx64"\n", key, rva);
 }
 
 status_t


### PR DESCRIPTION
The variable `va` does not exist within this function and hence caused compilation errors when using VMI_DEBUG.
