### PR TITLE
Bug of the src/libvmi/events.c:events_init ()

### DIFF
--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -58,8 +58,12 @@ void events_init (vmi_instance_t vmi)
         return;
     }
 
+    /* FIX: the 2nd argument is the  GEqualFunc who will compare two gpoints
+    * g_int_equal will take the value of gint type pointed by the gpoint as a argument,
+    * g_direct_equal will take the value of gpoint itself 
+    */
     vmi->event_handlers = g_hash_table_new_full(
-            g_int_hash, g_int_equal, event_entry_free, NULL);
+            g_int_hash, g_direct_equal, event_entry_free, NULL);
 }
 
 void event_handler_clear (vmi_instance_t vmi)


### PR DESCRIPTION
If function g_hash_table_new_full in events_init()  has the 2nd argument to be set as g_int_equal, the ffunction  g_hash_table_insert in event_handler_set() will cause the event_entry_free to be called even if  the event entry to be inserted is different from those
in the  vmi->event_handlers.
