### PR TITLE
xen fix domid check

### DIFF
--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -308,7 +308,7 @@ xen_check_domainid(
     int rc = xc_domain_getinfo(xchandle, domainid, 1,
                            &info);
 
-    if(rc>0) {
+    if(rc==1 && info.domid==domainid) {
         ret = VMI_SUCCESS;
     }
 


### PR DESCRIPTION
xc_domain_getinfo may return an rc>0 even if the domain id provided was not found but a domain with a higher id exists, resulting in a bogus init.
