### PR TITLE
Update Xen Events

### DIFF
--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -8,6 +8,7 @@
  *
  * Author: Nasser Salim (njsalim@sandia.gov)
  * Author: Steven Maresca (steve@zentific.com)
+ * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
  *
  * This file is part of LibVMI.
  *
@@ -32,6 +33,7 @@
 #include <sys/mman.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <signal.h>
 
 #define PAGE_SIZE 1 << 12
 
@@ -57,7 +59,7 @@ void print_event(vmi_event_t event){
 	event.vcpu_id
     );
 }
-    
+
 
 /* MSR registers used to hold system calls in x86_64. Note that compat mode is
  *	used in concert with long mode for certain system calls.
@@ -70,105 +72,115 @@ void print_event(vmi_event_t event){
  *    performance reasons.
  */
 
-void msr_syscall_sysenter_cb(vmi_instance_t vmi, vmi_event_t event){
+void msr_syscall_sysenter_cb(vmi_instance_t vmi, vmi_event_t *event){
     reg_t rdi, rax;
-    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
-    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rax, RAX, event->vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event->vcpu_id);
 
     printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
 
-    print_event(event);   
- 
-    vmi_clear_event(vmi, msr_syscall_sysenter_event);
+    print_event(*event);
+
+    vmi_clear_event(vmi, &msr_syscall_sysenter_event);
 }
 
-void syscall_compat_cb(vmi_instance_t vmi, vmi_event_t event){
+void syscall_compat_cb(vmi_instance_t vmi, vmi_event_t *event){
     reg_t rdi, rax;
-    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
-    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rax, RAX, event->vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event->vcpu_id);
 
     printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
-    
-    print_event(event);   
-    
-    vmi_clear_event(vmi, msr_syscall_compat_event);
+
+    print_event(*event);
+
+    vmi_clear_event(vmi, &msr_syscall_compat_event);
 }
 
-void vsyscall_cb(vmi_instance_t vmi, vmi_event_t event){
+void vsyscall_cb(vmi_instance_t vmi, vmi_event_t *event){
     reg_t rdi, rax;
-    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
-    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rax, RAX, event->vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event->vcpu_id);
 
     printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
-    
-    print_event(event);   
-   
-    vmi_clear_event(vmi, kernel_vsyscall_event);
+
+    print_event(*event);
+
+    vmi_clear_event(vmi, &kernel_vsyscall_event);
 }
 
-void ia32_sysenter_target_cb(vmi_instance_t vmi, vmi_event_t event){
+void ia32_sysenter_target_cb(vmi_instance_t vmi, vmi_event_t *event){
     reg_t rdi, rax;
-    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
-    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rax, RAX, event->vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event->vcpu_id);
 
     printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
-    
-    print_event(event);   
-   
-    vmi_clear_event(vmi, kernel_sysenter_target_event);
+
+    print_event(*event);
+
+    vmi_clear_event(vmi, &kernel_sysenter_target_event);
 }
 
-void syscall_lm_cb(vmi_instance_t vmi, vmi_event_t event){
+void syscall_lm_cb(vmi_instance_t vmi, vmi_event_t *event){
     reg_t rdi, rax;
-    vmi_get_vcpureg(vmi, &rax, RAX, event.vcpu_id);
-    vmi_get_vcpureg(vmi, &rdi, RDI, event.vcpu_id);
+    vmi_get_vcpureg(vmi, &rax, RAX, event->vcpu_id);
+    vmi_get_vcpureg(vmi, &rdi, RDI, event->vcpu_id);
 
     printf("Syscall happened: RAX(syscall#)=%u RDI(1st argument)=%u\n", (unsigned int)rax, (unsigned int)rdi);
-    
-    print_event(event);   
-   
-    vmi_clear_event(vmi, msr_syscall_lm_event);
+
+    print_event(*event);
+
+    vmi_clear_event(vmi, &msr_syscall_lm_event);
 }
 
-void cr3_one_task_callback(vmi_instance_t vmi, vmi_event_t event){
+void cr3_one_task_callback(vmi_instance_t vmi, vmi_event_t *event){
 
-    int pid = vmi_dtb_to_pid(vmi, event.reg_event.value);
+    int pid = vmi_dtb_to_pid(vmi, event->reg_event.value);
 
     printf("one_task callback\n");
-    if(event.reg_event.value == cr3){
-        printf("My process (PID %i) is executing on vcpu %lu\n", pid, event.vcpu_id);
-        
+    if(event->reg_event.value == cr3){
+        printf("My process (PID %i) is executing on vcpu %lu\n", pid, event->vcpu_id);
         msr_syscall_sysenter_event.mem_event.in_access = VMI_MEM_X;
+        msr_syscall_sysenter_event.callback=msr_syscall_sysenter_cb;
         kernel_sysenter_target_event.mem_event.in_access = VMI_MEM_X;
+        kernel_sysenter_target_event.callback=ia32_sysenter_target_cb;
         kernel_vsyscall_event.mem_event.in_access = VMI_MEM_X;
+        kernel_vsyscall_event.callback=vsyscall_cb;
 
-        if(vmi_handle_event(vmi, msr_syscall_sysenter_event, msr_syscall_sysenter_cb) == VMI_FAILURE)
+        if(vmi_register_event(vmi, &msr_syscall_sysenter_event) == VMI_FAILURE)
             fprintf(stderr, "Could not install sysenter syscall handler.\n");
-        if(vmi_handle_event(vmi, kernel_sysenter_target_event, ia32_sysenter_target_cb) == VMI_FAILURE)
+        if(vmi_register_event(vmi, &kernel_sysenter_target_event) == VMI_FAILURE)
             fprintf(stderr, "Could not install sysenter syscall handler.\n");
-        if(vmi_handle_event(vmi, kernel_vsyscall_event, vsyscall_cb) == VMI_FAILURE)
+        if(vmi_register_event(vmi, &kernel_vsyscall_event) == VMI_FAILURE)
             fprintf(stderr, "Could not install sysenter syscall handler.\n");
     }
     else{
         printf("PID %i is executing, not my process!\n", pid);
-        vmi_clear_event(vmi, msr_syscall_sysenter_event);
+        vmi_clear_event(vmi, &msr_syscall_sysenter_event);
     }
 }
 
-void cr3_all_tasks_callback(vmi_instance_t vmi, vmi_event_t event){
-    int pid = vmi_dtb_to_pid(vmi, event.reg_event.value);
-    printf("PID %i with CR3=%lx executing on vcpu %lu.\n", pid, event.reg_event.value, event.vcpu_id);
+void cr3_all_tasks_callback(vmi_instance_t vmi, vmi_event_t *event){
+    int pid = vmi_dtb_to_pid(vmi, event->reg_event.value);
+    printf("PID %i with CR3=%lx executing on vcpu %lu.\n", pid, event->reg_event.value, event->vcpu_id);
 
 	msr_syscall_sysenter_event.mem_event.in_access = VMI_MEM_X;
+	msr_syscall_sysenter_event.callback=msr_syscall_sysenter_cb;
 
-	if(vmi_handle_event(vmi, msr_syscall_sysenter_event, msr_syscall_sysenter_cb) == VMI_FAILURE)
+	if(vmi_register_event(vmi, &msr_syscall_sysenter_event) == VMI_FAILURE)
 	    fprintf(stderr, "Could not install sysenter syscall handler.\n");
-	vmi_clear_event(vmi, msr_syscall_sysenter_event);
+	vmi_clear_event(vmi, &msr_syscall_sysenter_event);
+}
+
+static int interrupted = 0;
+static void close_handler(int sig){
+    interrupted = sig;
 }
 
 int main (int argc, char **argv)
 {
     vmi_instance_t vmi;
+
+    struct sigaction act;
 
     reg_t lstar;
     addr_t phys_lstar;
@@ -176,27 +188,35 @@ int main (int argc, char **argv)
     addr_t phys_cstar;
     reg_t sysenter_ip;
     addr_t phys_sysenter_ip;
-    
+
     addr_t ia32_sysenter_target;
     addr_t phys_ia32_sysenter_target;
     addr_t vsyscall;
     addr_t phys_vsyscall;
 
     char *name = NULL;
-    int i=50;
     int pid=-1;
 
     if(argc < 2){
         fprintf(stderr, "Usage: events_example <name of VM> <PID of process to track {optional}>\n");
         exit(1);
     }
-   
+
     // Arg 1 is the VM name.
     name = argv[1];
-    
+
     // Arg 2 is the pid of the process to track.
     if(argc == 3)
         pid = (int) strtoul(argv[2], NULL, 0);
+
+    /* for a clean exit */
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
 
     // Initialize the libvmi library.
     if (vmi_init(&vmi, VMI_XEN | VMI_INIT_COMPLETE | VMI_INIT_EVENTS, name) == VMI_FAILURE){
@@ -208,8 +228,10 @@ int main (int argc, char **argv)
     }
 
     // Get the cr3 for this process.
-    cr3 = vmi_pid_to_dtb(vmi, pid);
-    printf("CR3 for process (%d) == %llx\n", pid, (unsigned long long)cr3);
+    if(pid != -1) {
+        cr3 = vmi_pid_to_dtb(vmi, pid);
+        printf("CR3 for process (%d) == %llx\n", pid, (unsigned long long)cr3);
+    }
 
     // Get the value of lstar and cstar for the system.
     // NOTE: all vCPUs have the same value for these registers
@@ -223,15 +245,19 @@ int main (int argc, char **argv)
     ia32_sysenter_target = vmi_translate_ksym2v(vmi, "ia32_sysenter_target");
     printf("ksym ia32_sysenter_target == %llx\n", (unsigned long long)ia32_sysenter_target);
 
+    /* Per Linux ABI, this VA represents the start of the vsyscall page 
+     *  If vsyscall support is enabled (deprecated or disabled on many newer 
+     *  3.0+ kernels), it is accessible at this address in every process.
+     */ 
     vsyscall = 0xffffffffff600000;
 
     // Translate to a physical address.
     phys_lstar= vmi_translate_kv2p(vmi, lstar);
     printf("Physical LSTAR == %llx\n", (unsigned long long)phys_lstar);
-    
+
     phys_cstar= vmi_translate_kv2p(vmi, cstar);
     printf("Physical CSTAR == %llx\n", (unsigned long long)phys_cstar);
-    
+
     phys_sysenter_ip= vmi_translate_kv2p(vmi, sysenter_ip);
     printf("Physical SYSENTER_IP == %llx\n", (unsigned long long)phys_sysenter_ip);
 
@@ -240,7 +266,7 @@ int main (int argc, char **argv)
     phys_vsyscall = vmi_translate_kv2p(vmi,vsyscall);
     printf("Physical phys_vsyscall == %llx\n", (unsigned long long)phys_vsyscall);
 
-    
+
     // Get only the page that the handler starts.
     phys_lstar >>= 12;
     printf("LSTAR Physical PFN == %llx\n", (unsigned long long)phys_lstar);
@@ -253,40 +279,63 @@ int main (int argc, char **argv)
     phys_ia32_sysenter_target >>= 12;
     printf("phys_ia32_sysenter_target Physical PFN == %llx\n", (unsigned long long)phys_ia32_sysenter_target);
 
-    // Setup cr3 event to track when the process is running.
+    /* Configure an event to track when the process is running.
+     * (The CR3 register is updated on task context switch, allowing
+     *  us to follow as various tasks are scheduled and run upon the CPU)
+     */
     memset(&cr3_event, 0, sizeof(vmi_event_t));
-    cr3_event.type = VMI_REGISTER_EVENT;
+    cr3_event.type = VMI_EVENT_REGISTER;
     cr3_event.reg_event.reg = CR3;
- //   cr3_event.reg_event.onchange =1;
-    //cr3_event.reg_event.async =1;
-    cr3_event.reg_event.equal = cr3;
+
+    /* Observe only write events to the given register. 
+     *   NOTE: read events are unsupported at this time.
+     */
     cr3_event.reg_event.in_access = VMI_REG_W;
 
+    /* Optional (default = 0): Trigger on change 
+     *  Causes events to be delivered by the hypervisor to this monitoring
+     *   program if and only if the register value differs from that previously 
+     *   observed.
+     *  Usage: cr3_event.reg_event.onchange = 1;
+     *
+     * Optional (default = 0): Asynchronous event delivery
+     *  Causes events to be delivered by the hypervisor to this monitoring
+     *   program if and only if the register value differs from that previously
+     *   observed.
+     *  Usage: cr3_event.reg_event.async =1;
+     */
+
     if(pid == -1){
-        vmi_handle_event(vmi, cr3_event, cr3_all_tasks_callback);
+        cr3_event.callback = cr3_all_tasks_callback;
+        vmi_register_event(vmi, &cr3_event);
     } else {
-        vmi_handle_event(vmi, cr3_event, cr3_one_task_callback);
+        cr3_event.callback = cr3_one_task_callback;
+        /* This acts as a filter: if the CR3 value at time of event == the CR3
+         *  we wish to inspect, then the callback will be invoked. Otherwise,
+         *  no action is taken.
+         */
+        cr3_event.reg_event.equal = cr3;
+        vmi_register_event(vmi, &cr3_event);
     }
 
     // Setup a default event for tracking memory at the syscall handler.
     // But don't install it; that will be done by the cr3 handler.
     memset(&msr_syscall_sysenter_event, 0, sizeof(vmi_event_t));
-    msr_syscall_sysenter_event.type = VMI_MEMORY_EVENT;
+    msr_syscall_sysenter_event.type = VMI_EVENT_MEMORY;
     msr_syscall_sysenter_event.mem_event.page = phys_sysenter_ip;
     msr_syscall_sysenter_event.mem_event.npages = 1;
 
     memset(&kernel_sysenter_target_event, 0, sizeof(vmi_event_t));
-    kernel_sysenter_target_event.type = VMI_MEMORY_EVENT;
+    kernel_sysenter_target_event.type = VMI_EVENT_MEMORY;
     kernel_sysenter_target_event.mem_event.page = phys_ia32_sysenter_target;
     kernel_sysenter_target_event.mem_event.npages = 1;
 
     memset(&kernel_vsyscall_event, 0, sizeof(vmi_event_t));
-    kernel_vsyscall_event.type = VMI_MEMORY_EVENT;
+    kernel_vsyscall_event.type = VMI_EVENT_MEMORY;
     kernel_vsyscall_event.mem_event.page = phys_vsyscall;
     kernel_vsyscall_event.mem_event.npages = 1;
 
-   
-    while(i--){
+    while(!interrupted){
         printf("Waiting for events...\n");
         vmi_events_listen(vmi,500);
     }

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -885,6 +885,7 @@ status_t
 vmi_destroy(
     vmi_instance_t vmi)
 {
+    vmi->shutting_down = TRUE;
     if(vmi->init_mode & VMI_INIT_EVENTS){
         events_destroy(vmi);
     }

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -479,6 +479,8 @@ xen_destroy(
     }
 #endif
 
+    free(xen_get_instance(vmi)->name);
+
 }
 
 status_t

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -1,5 +1,5 @@
-/* The LibVMI Library is an introspection library that simplifies access to 
- * memory in a target virtual machine or in a file containing a dump of 
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
  * a system's physical memory.  LibVMI is based on the XenAccess Library.
  *
  * Copyright 2011 Sandia Corporation. Under the terms of Contract
@@ -7,6 +7,8 @@
  * retains certain rights in this software.
  *
  * Author: Nasser Salim (njsalim@sandia.gov)
+ * Author: Steven Maresca (steven.maresca@zentific.com)
+ * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
  *
  * This file is part of LibVMI.
  *
@@ -31,25 +33,15 @@
 #define _GNU_SOURCE
 #include <glib.h>
 
-/* XXX This is likely not be the best data structure arrangement to
-   keep track of events and callback registrations.  Namely,
-
-   1. There really can only be 1 event registration per page or register.
-      This data structure allows multiple registrations and at the moment,
-      a new registration simply stomps on the low level settings.
-   2. It is probably better to keep a seperate structure per event type.
-
-   Right now I am just trying to get something out the door.
- 
- */
-
 //----------------------------------------------------------------------------
 //  General event callback management.
 
-static void event_entry_free (gpointer key)
+gboolean event_entry_free (gpointer key, gpointer value, gpointer data)
 {
-    vmi_event_t * entry = (vmi_event_t*) key;
-    if (entry) free(entry);
+    vmi_instance_t vmi=(vmi_instance_t)data;
+    vmi_event_t *event = (vmi_event_t*)value;
+    vmi_clear_event(vmi, event);
+    return TRUE;
 }
 
 void events_init (vmi_instance_t vmi)
@@ -58,32 +50,8 @@ void events_init (vmi_instance_t vmi)
         return;
     }
 
-    vmi->event_handlers = g_hash_table_new_full(
-            g_int_hash, g_int_equal, event_entry_free, NULL);
-}
-
-void event_handler_clear (vmi_instance_t vmi)
-{
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
-        return;
-    }
-
-    event_iter_t i;
-    vmi_event_t *stored_event;
-    event_callback_t stored_callback;
-    GSList *to_delete = NULL;
-
-    for_each_event(vmi, i, stored_event, stored_callback){
-        to_delete=g_slist_append(to_delete, (gpointer)stored_event);
-    }
-
-    while(to_delete != NULL) {
-        vmi_clear_event(vmi, *(vmi_event_t *)(to_delete->data) );
-
-        GSList *temp = to_delete->next;
-        g_slist_free(to_delete);
-        to_delete = temp;
-    }
+    vmi->mem_events = g_hash_table_new(g_int64_hash, g_int64_equal);
+    vmi->reg_events = g_hash_table_new(g_int_hash, g_int_equal);
 }
 
 void events_destroy (vmi_instance_t vmi)
@@ -92,124 +60,123 @@ void events_destroy (vmi_instance_t vmi)
         return;
     }
 
-    event_handler_clear(vmi);
-    g_hash_table_destroy(vmi->event_handlers);
-}
+    g_hash_table_foreach_steal(vmi->mem_events, event_entry_free, vmi);
+    g_hash_table_foreach_steal(vmi->reg_events, event_entry_free, vmi);
 
-void event_handler_set (vmi_instance_t vmi, vmi_event_t event, event_callback_t cb)
-{
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
-        return;
-    }
-
-    vmi_event_t * pe = safe_malloc(sizeof(vmi_event_t));
-    *pe = event;
-    g_hash_table_insert(vmi->event_handlers, pe, cb);
-}
-
-status_t event_handler_del (vmi_instance_t vmi, gpointer key)
-{
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
-        return VMI_FAILURE;
-    }
-
-    if (g_hash_table_remove(vmi->event_handlers, key))
-        return VMI_SUCCESS;
-    return VMI_FAILURE;
+    g_hash_table_destroy(vmi->mem_events);
+    g_hash_table_destroy(vmi->reg_events);
 }
 
 //----------------------------------------------------------------------------
 // Public event functions.
 
-status_t vmi_handle_event (vmi_instance_t vmi, 
-                           vmi_event_t event,
-                           event_callback_t callback)
+vmi_event_t *vmi_get_reg_event (vmi_instance_t vmi,
+                              registers_t reg) {
+    return g_hash_table_lookup(vmi->reg_events, &reg);
+}
+
+vmi_event_t *vmi_get_mem_event (vmi_instance_t vmi,
+                              addr_t page) {
+    return g_hash_table_lookup(vmi->mem_events, &page);
+}
+
+status_t vmi_register_event (vmi_instance_t vmi,
+                           vmi_event_t* event)
 {
     status_t rc = VMI_FAILURE;
-    
+
     if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+        dbprint("LibVMI wasn't initialized with events!\n");
+        return VMI_FAILURE;
+    }
+    if(!event) {
+        dbprint("No event given!\n");
+        return VMI_FAILURE;
+    }
+    if(!event->callback) {
+        dbprint("No event callback function specified!\n");
         return VMI_FAILURE;
     }
 
-    switch(event.type){
-        case VMI_REGISTER_EVENT:
-            dbprint("Enabling register event on reg: %d\n",
-                event.reg_event.reg);
-            rc = driver_set_reg_access(vmi, event.reg_event);
+    switch(event->type){
+        case VMI_EVENT_REGISTER:
+            if(NULL!=g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg))) {
+                dbprint("An event is already registered on this reg: %d\n",
+                    event->reg_event.reg);
+            } else {
+                if(VMI_SUCCESS == driver_set_reg_access(vmi, event->reg_event)){
+                    g_hash_table_insert(vmi->reg_events, &(event->reg_event.reg), event);
+                    dbprint("Enabled register event on reg: %d\n",
+                        event->reg_event.reg);
+                    rc = VMI_SUCCESS;
+                }
+            }
+
             break;
-        case VMI_MEMORY_EVENT:
-            dbprint("Enabling memory event on pages: %"PRIu64" + %"PRIu64"\n",
-                event.mem_event.page, event.mem_event.npages);
-            rc = driver_set_mem_access(vmi, event.mem_event);
+        case VMI_EVENT_MEMORY:
+            if(NULL!=g_hash_table_lookup(vmi->mem_events, &(event->mem_event.page))) {
+                dbprint("An event is already registered on this page: %"PRIu64"\n",
+                    event->mem_event.page);
+            } else {
+                if(VMI_SUCCESS == driver_set_mem_access(vmi, event->mem_event)){
+                    g_hash_table_insert(vmi->mem_events, &(event->mem_event.page), event);
+
+                    dbprint("Enabling memory event on pages: %"PRIu64" + %"PRIu64"\n",
+                        event->mem_event.page, event->mem_event.npages);
+                    rc = VMI_SUCCESS;
+                }
+            }
+
             break;
         default:
-            errprint("Unknown event type: %d\n", event.type);
+            errprint("Unknown event type: %d\n", event->type);
     }
 
-    if(rc == VMI_SUCCESS)
-        event_handler_set(vmi, event, callback);
     return rc;
 }
 
-status_t vmi_clear_event (vmi_instance_t vmi, 
-                          vmi_event_t event)
+status_t vmi_clear_event (vmi_instance_t vmi,
+                          vmi_event_t* event)
 {
     status_t rc = VMI_FAILURE;
-    event_iter_t i;
-    vmi_event_t *stored_event, *todelete = NULL;
-    event_callback_t stored_callback;
-    
+
     if(!(vmi->init_mode & VMI_INIT_EVENTS)){
         return VMI_FAILURE;
     }
 
-    for_each_event(vmi, i, stored_event, stored_callback){
-        if(stored_event->type == event.type){
-            switch(event.type){
-                case VMI_REGISTER_EVENT:
-                    if(stored_event->type == VMI_REGISTER_EVENT){
-                        if(stored_event->reg_event.reg == event.reg_event.reg){
-                            dbprint("Disabling register event on reg: %d\n",
-                                    event.reg_event.reg);
-                            todelete = stored_event;
-                            todelete->reg_event.in_access = VMI_REG_N;
-                            rc = driver_set_reg_access(vmi, todelete->reg_event);
-                        }
-                    }
-                    break;
-                case VMI_MEMORY_EVENT:
-                    if(stored_event->type == VMI_MEMORY_EVENT){
-                        if(stored_event->mem_event.page == event.mem_event.page){
-                            dbprint("Disabling memory event on page: %"PRIu64"\n",
-                                    event.mem_event.page);
-                            todelete = stored_event;
-                            todelete->mem_event.in_access = VMI_MEM_N;
-                            rc = driver_set_mem_access(vmi, todelete->mem_event);
-                        }
-                    }
-                    break;
-                default:
-                    errprint("Cannot clear unknown event: %d\n", event.type);
-                    return VMI_FAILURE;
+    switch(event->type) {
+        case VMI_EVENT_REGISTER:
+            if(NULL!=g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg))) {
+                dbprint("Disabling register event on reg: %d\n",
+                    event->reg_event.reg);
+                event->reg_event.in_access = VMI_REG_N;
+                rc = driver_set_reg_access(vmi, event->reg_event);
+                if(!vmi->shutting_down && rc==VMI_SUCCESS) {
+                    g_hash_table_remove(vmi->reg_events, &(event->reg_event.reg));
+                }
             }
-        }
+            break;
+        case VMI_EVENT_MEMORY:
+            if(NULL!=g_hash_table_lookup(vmi->mem_events, &(event->mem_event.page))) {
+                dbprint("Disabling memory event on page: %"PRIu64"\n",
+                    event->mem_event.page);
+                event->mem_event.in_access = VMI_MEM_N;
+                rc = driver_set_mem_access(vmi, event->mem_event);
+                if(!vmi->shutting_down && rc==VMI_SUCCESS) {
+                    g_hash_table_remove(vmi->mem_events, &(event->mem_event.page));
+                }
+            }
+            break;
+        default:
+            errprint("Cannot clear unknown event: %d\n", event->type);
+            return VMI_FAILURE;
     }
 
-    if(!todelete){
-        warnprint("Could not find event to delete!\n");
-        return VMI_FAILURE;
-    }
-
-    if(rc != VMI_SUCCESS){
-        errprint("Could not disable event!\n");
-        return rc;
-    }
-
-    return event_handler_del(vmi, todelete);
+    return rc;
 }
 
 status_t vmi_events_listen(vmi_instance_t vmi, uint32_t timeout){
-    
+
     if(!(vmi->init_mode & VMI_INIT_EVENTS)){
         return VMI_FAILURE;
     }

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -150,7 +150,11 @@ struct vmi_instance {
 
     unsigned int num_vcpus; /**< number of VCPUs used by this instance */
 
-    GHashTable *event_handlers; /**< event->functions mapping for events */
+    GHashTable *mem_events; /**< mem event to functions mapping (key: reg) */
+
+    GHashTable *reg_events; /**< reg event to functions mapping (key: page) */
+
+    gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
 };
 
 /** Windows' UNICODE_STRING structure (x86) */
@@ -387,19 +391,9 @@ typedef struct _windows_unicode_string32 {
         vmi_instance_t vmi);
     void events_destroy(
         vmi_instance_t vmi);
-    void event_handler_set(
-        vmi_instance_t vmi,
-        vmi_event_t event,
-        event_callback_t cb);
-    status_t event_handler_del(
-        vmi_instance_t vmi,
-        gpointer key);
-    void event_handler_clear(
-        vmi_instance_t vmi);
+    gboolean event_entry_free (
+        gpointer key,
+        gpointer value,
+        gpointer data);
 
-    typedef GHashTableIter event_iter_t;
-    #define for_each_event(vmi, iter, key, val) \
-        g_hash_table_iter_init(&iter, vmi->event_handlers); \
-        while(g_hash_table_iter_next(&iter,(void**)&key,(void**)&val))
-    
 #endif /* PRIVATE_H */


### PR DESCRIPTION
This PR in an overhaul of the entire Xen Events subsystem. Several changes are introduced to both the internal system and to the events API as well.

Summary:
- Introduce separate GHashTables for mem events and reg events (as per Nasser's suggestion)
- Switch to using vmi_event_t pointers, instead of duplicating the events internally.
- Include the callback function pointer in the vmi_event_t structure for consistency
- Check for duplicate event registrations and expose API functions to manually check as well
- Fix VM hang issue when events are destroyed but the ringbuffer is non-empty.
