### PR TITLE
Xen Events Update extension: byte-level events

### DIFF
--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -49,7 +49,7 @@ vmi_event_t kernel_sysenter_target_event;
 
 void print_event(vmi_event_t event){
     printf("PAGE %lx ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %lu)\n",
-        event.mem_event.pa,
+        event.mem_event.physical_address,
         (event.mem_event.out_access & VMI_MEMACCESS_R) ? 'r' : '-',
         (event.mem_event.out_access & VMI_MEMACCESS_W) ? 'w' : '-',
         (event.mem_event.out_access & VMI_MEMACCESS_X) ? 'x' : '-',
@@ -268,16 +268,11 @@ int main (int argc, char **argv)
 
 
     // Get only the page that the handler starts.
-    phys_lstar >>= 12;
-    printf("LSTAR Physical PFN == %llx\n", (unsigned long long)phys_lstar);
-    phys_cstar >>= 12;
-    printf("CSTAR Physical PFN == %llx\n", (unsigned long long)phys_cstar);
-    phys_sysenter_ip >>= 12;
-    printf("SYSENTER_IP Physical PFN == %llx\n", (unsigned long long)phys_sysenter_ip);
-    phys_vsyscall >>= 12;
-    printf("phys_vsyscall Physical PFN == %llx\n", (unsigned long long)phys_vsyscall);
-    phys_ia32_sysenter_target >>= 12;
-    printf("phys_ia32_sysenter_target Physical PFN == %llx\n", (unsigned long long)phys_ia32_sysenter_target);
+    printf("LSTAR Physical PFN == %llx\n", (unsigned long long)(phys_lstar >> 12));
+    printf("CSTAR Physical PFN == %llx\n", (unsigned long long)(phys_cstar >> 12));
+    printf("SYSENTER_IP Physical PFN == %llx\n", (unsigned long long)(phys_sysenter_ip >> 12));
+    printf("phys_vsyscall Physical PFN == %llx\n", (unsigned long long)(phys_vsyscall >> 12));
+    printf("phys_ia32_sysenter_target Physical PFN == %llx\n", (unsigned long long)(phys_ia32_sysenter_target >> 12));
 
     /* Configure an event to track when the process is running.
      * (The CR3 register is updated on task context switch, allowing
@@ -290,7 +285,7 @@ int main (int argc, char **argv)
     /* Observe only write events to the given register. 
      *   NOTE: read events are unsupported at this time.
      */
-    cr3_event.reg_event.in_access = VMI_REG_W;
+    cr3_event.reg_event.in_access = VMI_REGACCESS_W;
 
     /* Optional (default = 0): Trigger on change 
      *  Causes events to be delivered by the hypervisor to this monitoring
@@ -322,21 +317,21 @@ int main (int argc, char **argv)
     // But don't install it; that will be done by the cr3 handler.
     memset(&msr_syscall_sysenter_event, 0, sizeof(vmi_event_t));
     msr_syscall_sysenter_event.type = VMI_EVENT_MEMORY;
-    msr_syscall_sysenter_event.mem_event.pa = phys_sysenter_ip;
+    msr_syscall_sysenter_event.mem_event.physical_address = phys_sysenter_ip;
     msr_syscall_sysenter_event.mem_event.npages = 1;
-    msr_syscall_sysenter_event.mem_event.level=VMI_MEMEVENT_PAGE;
+    msr_syscall_sysenter_event.mem_event.granularity=VMI_MEMEVENT_PAGE;
 
     memset(&kernel_sysenter_target_event, 0, sizeof(vmi_event_t));
     kernel_sysenter_target_event.type = VMI_EVENT_MEMORY;
-    kernel_sysenter_target_event.mem_event.pa = phys_ia32_sysenter_target;
+    kernel_sysenter_target_event.mem_event.physical_address = phys_ia32_sysenter_target;
     kernel_sysenter_target_event.mem_event.npages = 1;
-    kernel_sysenter_target_event.mem_event.level=VMI_MEMEVENT_PAGE;
+    kernel_sysenter_target_event.mem_event.granularity=VMI_MEMEVENT_PAGE;
 
     memset(&kernel_vsyscall_event, 0, sizeof(vmi_event_t));
     kernel_vsyscall_event.type = VMI_EVENT_MEMORY;
-    kernel_vsyscall_event.mem_event.pa = phys_vsyscall;
+    kernel_vsyscall_event.mem_event.physical_address = phys_vsyscall;
     kernel_vsyscall_event.mem_event.npages = 1;
-    kernel_vsyscall_event.mem_event.level=VMI_MEMEVENT_PAGE;
+    kernel_vsyscall_event.mem_event.granularity=VMI_MEMEVENT_PAGE;
 
     while(!interrupted){
         printf("Waiting for events...\n");

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -75,7 +75,7 @@ int main (int argc, char **argv) {
     memset(&msr_event, 0, sizeof(vmi_event_t));
     msr_event.type = VMI_EVENT_REGISTER;
     msr_event.reg_event.reg = MSR_ALL;
-    msr_event.reg_event.in_access = VMI_REG_W;
+    msr_event.reg_event.in_access = VMI_REGACCESS_W;
     msr_event.callback = msr_write_cb;
 
     vmi_register_event(vmi, &msr_event);

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -117,7 +117,8 @@ struct driver_instance {
     status_t (
     *set_mem_access_ptr)(
     vmi_instance_t,
-    mem_event_t);
+    mem_event_t,
+    vmi_mem_access_t);
     status_t (
     *start_single_step_ptr)(
     vmi_instance_t,
@@ -661,11 +662,12 @@ status_t driver_set_reg_access(
 
 status_t driver_set_mem_access(
     vmi_instance_t vmi,
-    mem_event_t event)
+    mem_event_t event,
+    vmi_mem_access_t page_access_flag)
 {
     driver_instance_t ptrs = driver_get_instance(vmi);
     if (NULL != ptrs && NULL != ptrs->set_mem_access_ptr){
-        return ptrs->set_mem_access_ptr(vmi, event);
+        return ptrs->set_mem_access_ptr(vmi, event, page_access_flag);
     }
     else{
         dbprint("WARNING: driver_set_mem_access function not implemented.\n");

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -91,7 +91,8 @@ status_t driver_events_listen(
     uint32_t timeout);
 status_t driver_set_mem_access(
     vmi_instance_t vmi,
-    mem_event_t event);
+    mem_event_t event,
+    vmi_mem_access_t page_access_flag);
 status_t driver_set_reg_access(
     vmi_instance_t vmi,
     reg_event_t event);

--- a/libvmi/driver/xen_events.c
+++ b/libvmi/driver/xen_events.c
@@ -257,8 +257,6 @@ status_t process_register(vmi_instance_t vmi,
 
 status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
 {
-    addr_t page;
-    uint64_t npages;
 
     struct hvm_hw_cpu ctx;
     xc_interface * xch;
@@ -268,19 +266,51 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
 
     /* TODO, cleanup: ctx is unused here */
     xc_domain_hvm_getcontext_partial(xch, dom,
-         HVM_SAVE_CODE(CPU), req.vcpu_id, &ctx, sizeof(ctx));
+            HVM_SAVE_CODE(CPU), req.vcpu_id, &ctx, sizeof(ctx));
 
-    vmi_event_t * event = g_hash_table_lookup(vmi->mem_events, &req.gfn);
+    memevent_page_t * page = g_hash_table_lookup(vmi->mem_events, &req.gfn);
+    vmi_mem_access_t out_access;
+    if(req.access_r) out_access = VMI_MEMACCESS_R;
+    else if(req.access_w) out_access = VMI_MEMACCESS_W;
+    else if(req.access_x) out_access = VMI_MEMACCESS_X;
 
-    if(event) {
-        event->mem_event.gla = req.gla;
-        event->mem_event.gfn = req.gfn;
-        event->mem_event.offset = req.offset;
-        event->vcpu_id = req.vcpu_id;
+    if (page)
+    {
 
-        if(req.access_r) event->mem_event.out_access = VMI_MEMACCESS_R;
-        else if(req.access_w) event->mem_event.out_access = VMI_MEMACCESS_W;
-        else if(req.access_x) event->mem_event.out_access = VMI_MEMACCESS_X;
+        vmi_event_t *event = NULL;
+
+        if (page->event && (page->event->mem_event.in_access & out_access))
+        {
+            event = page->event;
+
+            event->mem_event.gla = req.gla;
+            event->mem_event.gfn = req.gfn;
+            event->mem_event.offset = req.offset;
+            event->mem_event.out_access = out_access;
+            event->vcpu_id = req.vcpu_id;
+
+            event->callback(vmi, event);
+        }
+
+        if (page->byte_events)
+        {
+            event_iter_t i;
+            addr_t *pa;
+            for_each_event(vmi, i, page->byte_events, &pa, &event)
+            {
+                if ((event->mem_event.in_access & out_access)
+                        && *pa == req.gfn + req.offset)
+                {
+                    event->mem_event.gla = req.gla;
+                    event->mem_event.gfn = req.gfn;
+                    event->mem_event.offset = req.offset;
+                    event->mem_event.out_access = out_access;
+                    event->vcpu_id = req.vcpu_id;
+
+                    event->callback(vmi, event);
+                }
+            }
+        }
 
         /* TODO MARESCA: decide whether it's worthwhile to emulate xen-access here and call the following
          *    note: the 'access' variable is basically discarded in that spot. perhaps it's really only called
@@ -288,7 +318,6 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
          * hvmmem_access_t access;
          * rc = xc_hvm_get_mem_access(xch, domain_id, event.mem_event.gfn, &access);
          */
-        event->callback(vmi, event);
 
         return VMI_SUCCESS;
     }
@@ -296,23 +325,24 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
 }
 
 status_t process_single_step_event(vmi_instance_t vmi, mem_event_request_t req)
-{    
+{
     xc_interface * xch;
     unsigned long dom;
     xch = xen_get_xchandle(vmi);
     dom = xen_get_domainid(vmi);
-    
+
     vmi_event_t * event = g_hash_table_lookup(vmi->ss_events, &req.vcpu_id);
- 
-    if(event) {
+
+    if (event)
+    {
         event->ss_event.gla = req.gla;
         event->ss_event.gfn = req.gfn;
         event->vcpu_id = req.vcpu_id;
-        
+
         event->callback(vmi, event);
         return VMI_SUCCESS;
     }
-    
+
     return VMI_FAILURE;
 }
 
@@ -624,19 +654,23 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event)
     return VMI_SUCCESS;
 }
 
-status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event)
+status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event, vmi_mem_access_t page_access_flag)
 {
     int rc;
     hvmmem_access_t access;
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
     unsigned long dom = xen_get_domainid(vmi);
-    uint64_t npages = event.npages > xe->mem_event.max_pages
-        ? xe->mem_event.max_pages : event.npages;
+
+    addr_t page_key = event.physical_address >> 12;
+
+    uint64_t npages = page_key + event.npages > xe->mem_event.max_pages
+        ? xe->mem_event.max_pages - page_key: event.npages;
 
     // Convert betwen vmi_mem_access_t and hvmmem_access_t
     // Xen does them backwards....
-    switch(event.in_access){
+    switch(page_access_flag){
+        case VMI_MEMACCESS_INVALID: return VMI_FAILURE;
         case VMI_MEMACCESS_N: access = HVMMEM_access_rwx; break;
         case VMI_MEMACCESS_R: access = HVMMEM_access_wx; break;
         case VMI_MEMACCESS_W: access = HVMMEM_access_rx; break;
@@ -650,7 +684,7 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event)
 
     dbprint("--Setting memaccess for domain %lu on page: %"PRIu64" npages: %"PRIu64"\n",
         dom, event.page, npages);
-    if((rc = xc_hvm_set_mem_access(xch, dom, access, event.pa, npages))){
+    if((rc = xc_hvm_set_mem_access(xch, dom, access, page_key, npages))){
         errprint("xc_hvm_set_mem_access failed with code: %d\n", rc);
         return VMI_FAILURE;
     }
@@ -842,6 +876,7 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
             default:
                 errprint("UNKNOWN REASON CODE %d\n", req.reason);
                 vrc = VMI_FAILURE;
+                break;
         }
 
         rc = resume_domain(vmi, &rsp);
@@ -863,7 +898,7 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event){
 	return VMI_FAILURE;
 }
 
-status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event){
+status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event, vmi_mem_access_t page_access_flag){
 	return VMI_FAILURE;
 }
 status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t event){

--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -102,10 +102,9 @@ status_t xen_events_init(vmi_instance_t vmi);
 void xen_events_destroy(vmi_instance_t vmi);
 status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
 status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event);
-status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event);
+status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event, vmi_mem_access_t page_access_flag);
 status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t event);
 status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu);
 status_t xen_shutdown_single_step(vmi_instance_t vmi);
-
 
 #endif

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -33,55 +33,85 @@
 #define _GNU_SOURCE
 #include <glib.h>
 
-vmi_mem_access_t combine_mem_access(vmi_mem_access_t base, vmi_mem_access_t add) {
+vmi_mem_access_t combine_mem_access(vmi_mem_access_t base, vmi_mem_access_t add)
+{
 
-    if(add == base)
+    if (add == base)
         return base;
 
-    if(add  == VMI_MEMACCESS_N)
+    if (add == VMI_MEMACCESS_N)
         return base;
-    if(base == VMI_MEMACCESS_N)
+    if (base == VMI_MEMACCESS_N)
         return add;
 
     // Can't combine rights with X_ON_WRITE
-    if(add  == VMI_MEMACCESS_X_ON_WRITE)
+    if (add == VMI_MEMACCESS_X_ON_WRITE)
         return VMI_MEMACCESS_INVALID;
-    if(base == VMI_MEMACCESS_X_ON_WRITE)
+    if (base == VMI_MEMACCESS_X_ON_WRITE)
         return VMI_MEMACCESS_INVALID;
 
     return (base | add);
 
-};
+}
+;
 
 //----------------------------------------------------------------------------
 //  General event callback management.
 
-gboolean event_entry_free (gpointer key, gpointer value, gpointer data)
+gboolean event_entry_free(gpointer key, gpointer value, gpointer data)
 {
-    vmi_instance_t vmi=(vmi_instance_t)data;
-    vmi_event_t *event = (vmi_event_t*)value;
+    vmi_instance_t vmi = (vmi_instance_t) data;
+    vmi_event_t *event = (vmi_event_t*) value;
     vmi_clear_event(vmi, event);
     return TRUE;
 }
 
-void events_init (vmi_instance_t vmi)
+gboolean memevent_page_clean(gpointer key, gpointer value, gpointer data)
 {
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
-        return;
+
+    vmi_instance_t vmi = (vmi_instance_t) data;
+    memevent_page_t *page = (memevent_page_t*) value;
+    if (page->event)
+        vmi_clear_event(vmi, page->event);
+    // if the driver is page-level, this adds some overhead
+    // as we update the page-access flag as we remove each byte-level event
+    if (page->byte_events)
+    {
+        g_hash_table_foreach_steal(page->byte_events, event_entry_free, vmi);
+        g_hash_table_destroy(page->byte_events);
     }
 
-    vmi->mem_events = g_hash_table_new(g_int64_hash, g_int64_equal);
-    vmi->reg_events = g_hash_table_new(g_int_hash, g_int_equal);
-    vmi->ss_events = g_hash_table_new_full(g_int_hash, g_int_equal, g_free, NULL);
+    return TRUE;
 }
 
-void events_destroy (vmi_instance_t vmi)
+void memevent_page_free(gpointer value)
 {
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+    memevent_page_t *page = (memevent_page_t *) value;
+    free(value);
+}
+
+void events_init(vmi_instance_t vmi)
+{
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
         return;
     }
 
-    g_hash_table_foreach_steal(vmi->mem_events, event_entry_free, vmi);
+    vmi->mem_events = g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL,
+            memevent_page_free);
+    vmi->reg_events = g_hash_table_new(g_int_hash, g_int_equal);
+    vmi->ss_events = g_hash_table_new_full(g_int_hash, g_int_equal, g_free,
+            NULL);
+}
+
+void events_destroy(vmi_instance_t vmi)
+{
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
+        return;
+    }
+
+    g_hash_table_foreach_remove(vmi->mem_events, memevent_page_clean, vmi);
     g_hash_table_foreach_steal(vmi->reg_events, event_entry_free, vmi);
     g_hash_table_foreach_remove(vmi->ss_events, event_entry_free, vmi);
 
@@ -90,36 +120,131 @@ void events_destroy (vmi_instance_t vmi)
     g_hash_table_destroy(vmi->ss_events);
 }
 
-status_t register_reg_event(vmi_instance_t vmi, vmi_event_t *event) {
+status_t register_reg_event(vmi_instance_t vmi, vmi_event_t *event)
+{
 
     status_t rc = VMI_FAILURE;
 
-    if(NULL!=g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg))) {
+    if (NULL != g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg)))
+    {
         dbprint("An event is already registered on this reg: %d\n",
-            event->reg_event.reg);
-    } else
-    if(VMI_SUCCESS == driver_set_reg_access(vmi, event->reg_event)){
+                event->reg_event.reg);
+    }
+    else if (VMI_SUCCESS == driver_set_reg_access(vmi, event->reg_event))
+    {
         g_hash_table_insert(vmi->reg_events, &(event->reg_event.reg), event);
-        dbprint("Enabled register event on reg: %d\n",
-            event->reg_event.reg);
+        dbprint("Enabled register event on reg: %d\n", event->reg_event.reg);
         rc = VMI_SUCCESS;
     }
 
     return rc;
 }
 
-status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event) {
+status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event)
+{
 
     status_t rc = VMI_FAILURE;
+    memevent_page_t *page = NULL;
 
-    if(NULL!=g_hash_table_lookup(vmi->mem_events, &(event->mem_event.pa))) {
-        dbprint("An event is already registered on this page: %"PRIu64"\n",
-            event->mem_event.pa);
-    } else
-    if(VMI_SUCCESS == driver_set_mem_access(vmi, event->mem_event)){
-        g_hash_table_insert(vmi->mem_events, &(event->mem_event.pa), event);
-        dbprint("Enabling memory event on pages: %"PRIu64" + %"PRIu64"\n",
-            event->mem_event.pa, event->mem_event.npages);
+    vmi_memevent_granularity_t granularity = event->mem_event.granularity;
+    addr_t page_key = event->mem_event.physical_address >> 12;
+
+    // Page already has event(s) registered
+    page = g_hash_table_lookup(vmi->mem_events, &page_key);
+    if (NULL != page)
+    {
+
+        vmi_mem_access_t page_access_flag = combine_mem_access(
+                page->access_flag, event->mem_event.in_access);
+
+        if (granularity == VMI_MEMEVENT_PAGE)
+        {
+            if (page->event)
+            {
+                dbprint(
+                        "An event is already registered on this page: %"PRIu64"\n",
+                        page_key);
+            }
+            else
+            {
+                if (VMI_SUCCESS
+                        == driver_set_mem_access(vmi, event->mem_event,
+                                page_access_flag))
+                {
+                    page->access_flag = page_access_flag;
+                    page->event = event;
+                    rc = VMI_SUCCESS;
+                }
+            }
+        }
+        else if (granularity == VMI_MEMEVENT_BYTE)
+        {
+            if (page->byte_events)
+            {
+                if (NULL
+                        != g_hash_table_lookup(page->byte_events,
+                                &(event->mem_event.physical_address)))
+                {
+                    dbprint(
+                            "An event is already registered on this byte: 0x%"PRIx64"\n",
+                            event->mem_event.physical_address);
+                }
+                else
+                {
+                    if (VMI_SUCCESS
+                            == driver_set_mem_access(vmi, event->mem_event,
+                                    page_access_flag))
+                    {
+                        page->access_flag = page_access_flag;
+                        g_hash_table_insert(page->byte_events,
+                                &(event->mem_event.physical_address), event);
+                        rc = VMI_SUCCESS;
+                    }
+                }
+            }
+            else
+            {
+                if (VMI_SUCCESS
+                        == driver_set_mem_access(vmi, event->mem_event,
+                                page_access_flag))
+                {
+                    page->byte_events = g_hash_table_new(g_int64_hash,
+                            g_int64_equal);
+                    page->access_flag = page_access_flag;
+                    g_hash_table_insert(page->byte_events,
+                            &(event->mem_event.physical_address), event);
+                    rc = VMI_SUCCESS;
+                }
+            }
+        }
+    }
+    else
+    // Page has no event registered
+    if (VMI_SUCCESS
+            == driver_set_mem_access(vmi, event->mem_event,
+                    event->mem_event.in_access))
+    {
+
+        page = (memevent_page_t *) g_malloc0(sizeof(memevent_page_t));
+        page->access_flag = event->mem_event.in_access;
+        page->key = page_key;
+
+        if (granularity == VMI_MEMEVENT_PAGE)
+        {
+            page->event = event;
+            dbprint("Enabling memory event on page: %"PRIu64"\n", page_key);
+        }
+        else
+        {
+            page->byte_events = g_hash_table_new(g_int64_hash, g_int64_equal);
+            g_hash_table_insert(page->byte_events,
+                    &(event->mem_event.physical_address), event);
+            dbprint(
+                    "Enabling memory event on byte 0x%"PRIx64", page: %"PRIu64"\n",
+                    event->mem_event.physical_address, page_key);
+        }
+
+        g_hash_table_insert(vmi->mem_events, &(page->key), page);
         rc = VMI_SUCCESS;
     }
 
@@ -127,16 +252,52 @@ status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event) {
 
 }
 
-status_t clear_reg_event(vmi_instance_t vmi, vmi_event_t *event) {
+status_t register_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+
+    status_t rc = VMI_FAILURE;
+    uint32_t vcpu = 0;
+    uint32_t *vcpu_i = NULL;
+
+    for (; vcpu < vmi->num_vcpus; vcpu++)
+    {
+        if (CHECK_VCPU_SINGLESTEP(event->ss_event, vcpu))
+        {
+            if (NULL != g_hash_table_lookup(vmi->ss_events, &vcpu))
+            {
+                dbprint("An event is already registered on this vcpu: %u\n",
+                        vcpu);
+            }
+            else
+            {
+                if (VMI_SUCCESS
+                        == driver_start_single_step(vmi, event->ss_event))
+                {
+                    vcpu_i = malloc(sizeof(uint32_t));
+                    *vcpu_i = vcpu;
+                    g_hash_table_insert(vmi->ss_events, vcpu_i, event);
+                    dbprint("Enabling single step\n");
+                    rc = VMI_SUCCESS;
+                }
+            }
+        }
+    }
+
+    return rc;
+}
+
+status_t clear_reg_event(vmi_instance_t vmi, vmi_event_t *event)
+{
 
     status_t rc = VMI_FAILURE;
 
-    if(NULL!=g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg))) {
-        dbprint("Disabling register event on reg: %d\n",
-            event->reg_event.reg);
+    if (NULL != g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg)))
+    {
+        dbprint("Disabling register event on reg: %d\n", event->reg_event.reg);
         event->reg_event.in_access = VMI_REGACCESS_N;
         rc = driver_set_reg_access(vmi, event->reg_event);
-        if(rc==VMI_SUCCESS) {
+        if (!vmi->shutting_down && rc == VMI_SUCCESS)
+        {
             g_hash_table_remove(vmi->reg_events, &(event->reg_event.reg));
         }
     }
@@ -145,164 +306,319 @@ status_t clear_reg_event(vmi_instance_t vmi, vmi_event_t *event) {
 
 }
 
-status_t clear_mem_event(vmi_instance_t vmi, vmi_event_t *event) {
+status_t clear_mem_event(vmi_instance_t vmi, vmi_event_t *event)
+{
 
     status_t rc = VMI_FAILURE;
+    memevent_page_t *page = NULL;
+    vmi_event_t *remove_event = NULL;
 
-    if(NULL!=g_hash_table_lookup(vmi->mem_events, &(event->mem_event.pa))) {
-        dbprint("Disabling memory event on page: %"PRIu64"\n",
-            event->mem_event.pa);
-        event->mem_event.in_access = VMI_MEMACCESS_N;
-        rc = driver_set_mem_access(vmi, event->mem_event);
-        if(rc==VMI_SUCCESS) {
-            g_hash_table_remove(vmi->mem_events, &(event->mem_event.pa));
+    vmi_memevent_granularity_t granularity = event->mem_event.granularity;
+    addr_t page_key = event->mem_event.physical_address >> 12;
+
+    // Page has event(s) registered
+    page = g_hash_table_lookup(vmi->mem_events, &page_key);
+    if (NULL != page)
+    {
+
+        vmi_mem_access_t page_access_flag = VMI_MEMACCESS_N;
+
+        if (granularity == VMI_MEMEVENT_PAGE)
+        {
+            if (!page->event)
+            {
+                dbprint("Can't disable page-level memevent, non registered!\n");
+            }
+            else
+            {
+
+                remove_event = page->event;
+
+                dbprint("Disabling memory event on page: %"PRIu64"\n",
+                        remove_event->mem_event.physical_address);
+                remove_event->mem_event.in_access = VMI_MEMACCESS_N;
+
+                // We still have byte-level events registered on this page
+                if (page->byte_events)
+                {
+                    event_iter_t i;
+                    addr_t *pa;
+                    vmi_event_t *loop;
+                    for_each_event(vmi, i, page->byte_events, &pa, &loop)
+                    {
+                        page_access_flag = combine_mem_access(page_access_flag,
+                                loop->mem_event.in_access);
+                    }
+                }
+
+                rc = driver_set_mem_access(vmi, event->mem_event,
+                        page_access_flag);
+
+                if (rc == VMI_SUCCESS)
+                {
+
+                    page->event = NULL;
+                    page->access_flag = page_access_flag;
+
+                    // if libvmi is shutting down memevent_page_clean will take care of cleaning up
+                    if (!vmi->shutting_down && !page->byte_events)
+                    {
+                        g_hash_table_remove(vmi->mem_events, &page_key);
+                    }
+                }
+            }
         }
+        else if (granularity == VMI_MEMEVENT_BYTE)
+        {
+            if (!page->byte_events)
+            {
+                dbprint("Can't disable byte-level memevent, non registered!\n");
+            }
+            else
+            {
+
+                remove_event = (vmi_event_t *) g_hash_table_lookup(
+                        page->byte_events,
+                        &(event->mem_event.physical_address));
+
+                if (NULL == remove_event)
+                {
+                    dbprint(
+                            "Can't disable byte-level memevent, event not found on byte 0x%"PRIx64"!\n",
+                            event->mem_event.physical_address);
+                }
+                else
+                {
+                    g_hash_table_steal(page->byte_events,
+                            &(remove_event->mem_event.physical_address));
+
+                    if (page->event)
+                    {
+                        page_access_flag = combine_mem_access(page_access_flag,
+                                page->event->mem_event.in_access);
+                    }
+
+                    // We still have byte-level events registered on this page
+                    if (g_hash_table_size(page->byte_events) > 0)
+                    {
+                        event_iter_t i;
+                        addr_t *pa;
+                        vmi_event_t *loop;
+                        for_each_event(vmi, i, page->byte_events, &pa, &loop)
+                        {
+                            page_access_flag = combine_mem_access(
+                                    page_access_flag,
+                                    loop->mem_event.in_access);
+                        }
+                    }
+
+                    rc = driver_set_mem_access(vmi, remove_event->mem_event,
+                            page_access_flag);
+
+                    if (rc == VMI_SUCCESS)
+                    {
+
+                        page->access_flag = page_access_flag;
+
+                        if (g_hash_table_size(page->byte_events) == 0)
+                        {
+                            g_hash_table_destroy(page->byte_events);
+                            page->byte_events = NULL;
+                        }
+
+                        // if libvmi is shutting down memevent_page_clean will take care of cleaning up
+                        if (!vmi->shutting_down && !page->event
+                                && !page->byte_events)
+                        {
+                            g_hash_table_remove(vmi->mem_events, &page_key);
+                        }
+                    }
+                    else
+                    {
+                        // place back the event as removal failed
+                        g_hash_table_insert(page->byte_events,
+                                &(remove_event->mem_event.physical_address),
+                                remove_event);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        printf("Disabling event failed, no event found on page: %lu\n",
+                page_key);
     }
 
     return rc;
 
+}
+
+status_t clear_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+
+    status_t rc = VMI_FAILURE;
+    uint32_t vcpu = 0;
+
+    for (; vcpu < vmi->num_vcpus; vcpu++)
+    {
+        if (CHECK_VCPU_SINGLESTEP(event->ss_event, vcpu))
+        {
+            dbprint("Disabling single step on vcpu: %u\n", vcpu);
+            rc = driver_stop_single_step(vmi, vcpu);
+            if (!vmi->shutting_down && rc == VMI_SUCCESS)
+            {
+                g_hash_table_remove(vmi->ss_events, &(vcpu));
+            }
+        }
+    }
+
+    return rc;
 }
 
 //----------------------------------------------------------------------------
 // Public event functions.
 
-vmi_event_t *vmi_get_reg_event (vmi_instance_t vmi,
-                              registers_t reg) {
+vmi_event_t *vmi_get_reg_event(vmi_instance_t vmi, registers_t reg)
+{
     return g_hash_table_lookup(vmi->reg_events, &reg);
 }
 
-vmi_event_t *vmi_get_mem_event (vmi_instance_t vmi,
-                              addr_t page) {
-    return g_hash_table_lookup(vmi->mem_events, &page);
+vmi_event_t *vmi_get_mem_event(vmi_instance_t vmi, addr_t physical_address,
+        vmi_memevent_granularity_t granularity)
+{
+
+    addr_t page_key = physical_address >> 12;
+
+    memevent_page_t *page = g_hash_table_lookup(vmi->mem_events, &page_key);
+    if (page)
+    {
+        if (granularity == VMI_MEMEVENT_PAGE)
+            return page->event;
+        else if (granularity == VMI_MEMEVENT_BYTE && page->byte_events)
+            return (vmi_event_t *) g_hash_table_lookup(page->byte_events,
+                    &physical_address);
+    }
+
+    return NULL;
 }
 
-status_t vmi_register_event (vmi_instance_t vmi,
-                           vmi_event_t* event)
+status_t vmi_register_event(vmi_instance_t vmi, vmi_event_t* event)
 {
     status_t rc = VMI_FAILURE;
     uint32_t vcpu = 0;
     uint32_t* vcpu_i = NULL;
 
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
         dbprint("LibVMI wasn't initialized with events!\n");
         return VMI_FAILURE;
     }
-    if(!event) {
+    if (!event)
+    {
         dbprint("No event given!\n");
         return VMI_FAILURE;
     }
-    if(!event->callback) {
+    if (!event->callback)
+    {
         dbprint("No event callback function specified!\n");
         return VMI_FAILURE;
     }
 
-    switch(event->type) {
+    switch (event->type)
+    {
 
-        case VMI_EVENT_REGISTER:
-            rc = register_reg_event(vmi, event);
-            break;
-        case VMI_EVENT_MEMORY:
-            rc = register_mem_event(vmi, event);
-            break;
-        case VMI_EVENT_SINGLESTEP:
-            for(;vcpu<vmi->num_vcpus;vcpu++) {
-                if(CHECK_VCPU_SINGLESTEP(event->ss_event, vcpu)) {
-                    if(NULL!=g_hash_table_lookup(vmi->ss_events, &vcpu)) {
-                        dbprint("An event is already registered on this vcpu: %u\n", vcpu);
-                    } else {
-                        if(VMI_SUCCESS == driver_start_single_step(vmi, event->ss_event)){
-                            vcpu_i = malloc(sizeof(uint32_t));
-                            *vcpu_i = vcpu;
-                            g_hash_table_insert(vmi->ss_events, vcpu_i, event);
-                            dbprint("Enabling single step\n");
-                            rc = VMI_SUCCESS;
-                        } 
-                    }
-                }
-            }
-
-            break;
-        default:
-            errprint("Unknown event type: %d\n", event->type);
+    case VMI_EVENT_REGISTER:
+        rc = register_reg_event(vmi, event);
+        break;
+    case VMI_EVENT_MEMORY:
+        rc = register_mem_event(vmi, event);
+        break;
+    case VMI_EVENT_SINGLESTEP:
+        rc = register_singlestep_event(vmi, event);
+        break;
+    default:
+        errprint("Unknown event type: %d\n", event->type);
+        break;
     }
 
     return rc;
 }
 
-status_t vmi_clear_event (vmi_instance_t vmi,
-                          vmi_event_t* event)
+status_t vmi_clear_event(vmi_instance_t vmi, vmi_event_t* event)
 {
     status_t rc = VMI_FAILURE;
-    uint32_t vcpu = 0;
 
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
         return VMI_FAILURE;
     }
 
-    switch(event->type) {
-       case VMI_EVENT_SINGLESTEP:
-            for(;vcpu<vmi->num_vcpus;vcpu++) {
-                if(CHECK_VCPU_SINGLESTEP(event->ss_event, vcpu)) {
-                    dbprint("Disabling single step on vcpu: %u\n", vcpu);
-                    rc = driver_stop_single_step(vmi, vcpu);
-                    if(!vmi->shutting_down && rc==VMI_SUCCESS) {
-                        g_hash_table_remove(vmi->ss_events, &(vcpu));
-                    }
-                }
-            }
-            break;
-        case VMI_EVENT_REGISTER:
-            rc = clear_reg_event(vmi, event);
-            break;
-        case VMI_EVENT_MEMORY:
-            rc = clear_mem_event(vmi, event);
-            break;
-        default:
-            errprint("Cannot clear unknown event: %d\n", event->type);
-            return VMI_FAILURE;
+    switch (event->type)
+    {
+    case VMI_EVENT_SINGLESTEP:
+        rc = clear_singlestep_event(vmi, event);
+        break;
+    case VMI_EVENT_REGISTER:
+        rc = clear_reg_event(vmi, event);
+        break;
+    case VMI_EVENT_MEMORY:
+        rc = clear_mem_event(vmi, event);
+        break;
+    default:
+        errprint("Cannot clear unknown event: %d\n", event->type);
+        return VMI_FAILURE;
     }
 
     return rc;
 }
 
-status_t vmi_events_listen(vmi_instance_t vmi, uint32_t timeout){
+status_t vmi_events_listen(vmi_instance_t vmi, uint32_t timeout)
+{
 
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
         return VMI_FAILURE;
     }
 
     return driver_events_listen(vmi, timeout);
 }
 
-vmi_event_t *vmi_get_singlestep_event (vmi_instance_t vmi, 
-    uint32_t vcpu) {
+vmi_event_t *vmi_get_singlestep_event(vmi_instance_t vmi, uint32_t vcpu)
+{
     return g_hash_table_lookup(vmi->ss_events, &vcpu);
 }
 
-status_t vmi_stop_single_step_vcpu(vmi_instance_t vmi, vmi_event_t* event, 
-    uint32_t vcpu)
+status_t vmi_stop_single_step_vcpu(vmi_instance_t vmi, vmi_event_t* event,
+        uint32_t vcpu)
 {
-    
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
         return VMI_FAILURE;
     }
-    
+
     UNSET_VCPU_SINGLESTEP(event->ss_event, vcpu);
     g_hash_table_remove(vmi->ss_events, &vcpu);
-    
+
     return driver_stop_single_step(vmi, vcpu);
 }
 
-status_t vmi_shutdown_single_step(vmi_instance_t vmi){
+status_t vmi_shutdown_single_step(vmi_instance_t vmi)
+{
 
-    if(!(vmi->init_mode & VMI_INIT_EVENTS)){
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
         return VMI_FAILURE;
     }
-    
-    if(VMI_SUCCESS == driver_shutdown_single_step(vmi)){
+
+    if (VMI_SUCCESS == driver_shutdown_single_step(vmi))
+    {
         g_hash_table_foreach_remove(vmi->ss_events, event_entry_free, vmi);
         return VMI_SUCCESS;
-    } else {
+    }
+    else
+    {
         return VMI_FAILURE;
     }
 }

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -163,6 +163,7 @@ typedef struct memevent_page {
 
     vmi_mem_access_t access_flag; /**< page access flag */
     vmi_event_t *event; /**< page event registered */
+    addr_t key;
 
     GHashTable  *byte_events; /**< byte events */
 
@@ -406,5 +407,9 @@ typedef struct _windows_unicode_string32 {
         gpointer key,
         gpointer value,
         gpointer data);
+    typedef GHashTableIter event_iter_t;
+    #define for_each_event(vmi, iter, table, key, val) \
+        g_hash_table_iter_init(&iter, table); \
+        while(g_hash_table_iter_next(&iter,(void**)key,(void**)val))
 
 #endif /* PRIVATE_H */


### PR DESCRIPTION
This branch is an extension of PR #56 allowing registration of byte-level events. While Xen itself only supports page-level events, this extension abstracts that limitation from the user by keeping track internally of what access flags were set on a page. The xen events driver is updated to issue callbacks only to events whose access flags were triggered on the page.
