### PR TITLE
Fix xen domain id comparison types

### DIFF
--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -308,7 +308,7 @@ xen_check_domainid(
     int rc = xc_domain_getinfo(xchandle, domainid, 1,
                            &info);
 
-    if(rc==1 && info.domid==domainid) {
+    if(rc==1 && info.domid==(uint32_t)domainid) {
         ret = VMI_SUCCESS;
     }
 


### PR DESCRIPTION
Apparently with some compilers (clang) a comparison between a unsigned long and a uint32_t can produce a negative result even if their contents match.. casting it fixes the issue.
