### PR TITLE
Fix init complete when upgrading from partial

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -664,18 +664,9 @@ vmi_init_private(
     }
     dbprint("--completed driver init.\n");
 
-    if (init_mode & VMI_INIT_PARTIAL) {
-        init_page_offset(*vmi);
-        driver_get_memsize(*vmi, &(*vmi)->size);
-
-        /* Enable event handlers */
-        if(init_mode & VMI_INIT_EVENTS){
-            events_init(*vmi);
-        }
-
-        return VMI_SUCCESS;
-    }
-    else if (init_mode & VMI_INIT_COMPLETE) {
+    /* we check VMI_INIT_COMPLETE first as
+       VMI_INIT_PARTIAL is not exclusive */
+    if (init_mode & VMI_INIT_COMPLETE) {
 
         /* init_complete requires configuration */
         if(VMI_CONFIG_NONE & (*vmi)->config_mode) {
@@ -748,6 +739,16 @@ vmi_init_private(
         }
 
         return status;
+    } else if (init_mode & VMI_INIT_PARTIAL) {
+        init_page_offset(*vmi);
+        driver_get_memsize(*vmi, &(*vmi)->size);
+
+        /* Enable event handlers */
+        if(init_mode & VMI_INIT_EVENTS){
+            events_init(*vmi);
+        }
+
+        return VMI_SUCCESS;
     }
 
 error_exit:


### PR DESCRIPTION
When upgrading from partial init to full init using vmi_init_complete\* the old flags are taken from the vmi instance which has VMI_INIT_PARTIAL already set, therefore both VMI_INIT_PARTIAL and VMI_INIT_COMPLETE will be set on the new instance. Partial init should only happen if that's the only flag set. Otherwise I think we can keep having both flags set, that would just indicate that the instance was upgraded from a partial init to complete.
