### PR TITLE
Fixed compilation errors when caches are disabled

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -641,6 +641,8 @@ sym_cache_destroy(
 status_t
 sym_cache_get(
     vmi_instance_t vmi,
+    addr_t base_addr,
+    uint32_t pid,
     char *sym,
     addr_t *va)
 {
@@ -650,6 +652,8 @@ sym_cache_get(
 void
 sym_cache_set(
     vmi_instance_t vmi,
+    addr_t base_addr,
+    uint32_t pid,
     char *sym,
     addr_t va)
 {
@@ -659,6 +663,8 @@ sym_cache_set(
 status_t
 sym_cache_del(
     vmi_instance_t vmi,
+    addr_t bade_addr,
+    uint32_t pid,
     char *sym)
 {
     return VMI_FAILURE;
@@ -697,8 +703,10 @@ rva_cache_get(
 void
 rva_cache_set(
     vmi_instance_t vmi,
-    char *sym,
-    addr_t va)
+    addr_t base_addr,
+    uint32_t pid,
+    addr_t rva,
+    char *sym)
 {
     return;
 }


### PR DESCRIPTION
When address cache and page cache are turned off in libvmi.h compilation breaks. 
