### PR TITLE
remove linux_addr from offset finder tool

### DIFF
--- a/tools/linux-offset-finder/findoffsets.c
+++ b/tools/linux-offset-finder/findoffsets.c
@@ -76,8 +76,6 @@ my_init_module(
                (unsigned int) pidOffset);
         printk(KERN_ALERT "    linux_pgd = 0x%x;\n",
                (unsigned int) pgdOffset);
-        printk(KERN_ALERT "    linux_addr = 0x%x;\n",
-               (unsigned int) addrOffset);
         printk(KERN_ALERT "}\n");
     }
     else {


### PR DESCRIPTION
- this value is no longer used by libvmi
