### PR TITLE
Xen events: prevent initialization for PV domains and perform more sanity checks

### DIFF
--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -440,8 +440,10 @@ xen_init(
 #endif /* VMI_DEBUG */
 
 #if ENABLE_XEN_EVENTS==1
-    /* Only enable events for hvm and IFF(mode & VMI_INIT_EVENTS) */
-    if(xen_get_instance(vmi)->hvm && (vmi->init_mode & VMI_INIT_EVENTS)){
+    /* Only enable events IFF(mode & VMI_INIT_EVENTS) 
+     * Additional checks performed within xen_events_init
+     */
+    if(vmi->init_mode & VMI_INIT_EVENTS){
         if(xen_events_init(vmi)==VMI_FAILURE){
             errprint("Failed to initialize xen events.\n");
             goto _bail;


### PR DESCRIPTION
Provides better error messaging when attempting to initialize events for PV domains, addressing http://code.google.com/p/vmitools/issues/detail?id=48 

and addresses NULL dereferences in http://code.google.com/p/vmitools/issues/detail?id=48 (this current PR provides some insurance with more careful validity checks, though the root problem of issue 48 was solved by PR#5 ) 
