### PR TITLE
Cleaning up a few minor nits with Xen 4.1.2 support and some typos.

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -870,6 +870,10 @@ vmi_init_complete(
         flags |= VMI_CONFIG_NONE;
     }
 
+    if (((*vmi)->flags) & VMI_INIT_EVENTS) {
+        flags |= VMI_INIT_EVENTS;
+    }
+
     vmi_destroy(*vmi);
     return vmi_init_private(vmi,
                             flags,

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -290,12 +290,16 @@ status_t clear_reg_event(vmi_instance_t vmi, vmi_event_t *event)
 {
 
     status_t rc = VMI_FAILURE;
+    vmi_reg_access_t original_in_access = VMI_REGACCESS_N;
 
     if (NULL != g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg)))
     {
         dbprint("Disabling register event on reg: %d\n", event->reg_event.reg);
+        original_in_access = event->reg_event.in_access;
         event->reg_event.in_access = VMI_REGACCESS_N;
         rc = driver_set_reg_access(vmi, event->reg_event);
+        event->reg_event.in_access = original_in_access;
+
         if (!vmi->shutting_down && rc == VMI_SUCCESS)
         {
             g_hash_table_remove(vmi->reg_events, &(event->reg_event.reg));


### PR DESCRIPTION
Xen 4.1.2 specific:
- Suppress error on call to xc_set_access_required because apparently
  Xen 4.1.2 always fails.

Non 4.1 specific:
- Fixing a compiler warning.
- Fixing a dbprint.
- Return VMI_SUCCESS for timeouts with no events.  This is consistent
  with the examples from xenaccess example itself and the underlying
  poll().
- event_example: Need to destroy() if driver completed it's init
  otherwise, events are still bound on the domain and can't be reattached.
- Keep VMI_INIT_EVENTS from PARTIAL->COMPLETE.
- Restoring original access flags after clearing reg_event.  Fields
  declared as "in_" should not be modified by the library.
