### PR TITLE
Update Zentific crew in authors list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,8 +11,9 @@ Other Contributors:
   Daniel English
   Hajime Inoue (ATC-NY)
   Tomas Kouba
-  Tamas Lengyel
-  John Maccini
+  Tamas K Lengyel (Zentific)
+  Matthew Fusaro (Zentific)
   Steve Maresca (Zentific)
+  John Maccini
   Tony Saba (Mandiant)
   Chad Spensky (MIT Lincoln Labs)


### PR DESCRIPTION
Adding Matt for his work on Xen singlestep events.
