### PR TITLE
Rectify inconsistency between documentation of vmi_instance_t->init_task...

### DIFF
--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -62,16 +62,10 @@ linux_init(
     vmi->kpgd = vmi->cr3;
     dbprint("**set vmi->kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
-    addr_t address = vmi_translate_ksym2v(vmi, "init_task");
-
-    address += vmi->os.linux_instance.tasks_offset;
-    if (VMI_FAILURE ==
-        vmi_read_addr_va(vmi, address, 0, &(vmi->init_task))) {
-        errprint("Failed to get task list head 'init_task'.\n");
-        goto _exit;
-    }
+    vmi->init_task = vmi_translate_ksym2v(vmi, "init_task");
 
     ret = VMI_SUCCESS;
+
 _exit:
     return ret;
 }

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -134,12 +134,18 @@ get_kpgd_method2(
     }
     dbprint("**set kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
-    vmi_read_addr_pa(vmi,
+    if (VMI_FAILURE == 
+        vmi_read_addr_pa(vmi,
                      sysproc + vmi->os.windows_instance.tasks_offset,
-                     &vmi->init_task);
+                     &vmi->init_task)) {
+        dbprint("--failed to resolve address of Idle process\n");
+        goto error_exit;
+    }
+    vmi->init_task -= vmi->os.windows_instance.tasks_offset;
     dbprint("**set init_task (0x%.16"PRIx64").\n", vmi->init_task);
 
     return VMI_SUCCESS;
+
 error_exit:
     return VMI_FAILURE;
 }
@@ -187,12 +193,18 @@ get_kpgd_method1(
     }
     dbprint("**set kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
-    vmi_read_addr_pa(vmi,
+    if (VMI_FAILURE == 
+        vmi_read_addr_pa(vmi,
                      sysproc + vmi->os.windows_instance.tasks_offset,
-                     &vmi->init_task);
+                     &vmi->init_task)) {
+        dbprint("--failed to resolve address of Idle process\n");
+        goto error_exit;
+    }
+    vmi->init_task -= vmi->os.windows_instance.tasks_offset;
     dbprint("**set init_task (0x%.16"PRIx64").\n", vmi->init_task);
 
     return VMI_SUCCESS;
+
 error_exit:
     return VMI_FAILURE;
 }
@@ -234,11 +246,18 @@ get_kpgd_method0(
     }
     dbprint("**set kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
-    vmi_read_addr_pa(vmi,
+    if (VMI_FAILURE == 
+        vmi_read_addr_pa(vmi,
                      sysproc + vmi->os.windows_instance.tasks_offset,
-                     &vmi->init_task);
+                     &vmi->init_task)){
+        dbprint("--failed to resolve address of Idle process\n");
+        goto error_exit;
+    }
+    vmi->init_task -= vmi->os.windows_instance.tasks_offset;
     dbprint("**set init_task (0x%.16"PRIx64").\n", vmi->init_task);
+
     return VMI_SUCCESS;
+
 error_exit:
     return VMI_FAILURE;
 }

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -191,8 +191,7 @@ find_pname_offset(
                 }
                 else {
                     vmi->init_task =
-                        block_pa + offset +
-                        vmi->os.windows_instance.tasks_offset;
+                        block_pa + offset;
                     dbprint
                         ("--%s: found Idle process at 0x%.8"PRIx64" + 0x%x\n",
                          __FUNCTION__, block_pa + offset, i);
@@ -275,7 +274,7 @@ windows_find_eprocess(
 
     if (vmi->init_task) {
         start_address =
-            vmi->init_task - vmi->os.windows_instance.tasks_offset;
+            vmi->init_task;
     }
 
     return find_process_by_name(vmi, check, start_address, name);


### PR DESCRIPTION
... in private.h and actual use in code. (Documented to be the address of the first task, but previous to this patch initialized to the head of the task list).

(as discussed; no changes)
