### PR TITLE
Fixing xen_test() for VMI_AUTO mode

### DIFF
--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -320,8 +320,8 @@ driver_init_mode(
 
     /* if we didn't see exactly one system, report error */
     if (count == 0) {
-        errprint("Could not find a VMM or file to use.\n");
-        errprint("Opening a live VMM requires root access.\n");
+        errprint("Could not find a live guest VM or file to use.\n");
+        errprint("Opening a live guest VM requires root access.\n");
         return VMI_FAILURE;
     }
     else if (count > 1) {

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -1681,10 +1681,21 @@ xen_test(
     unsigned long id,
     char *name)
 {
-    // Only way this could fail on Xen is when LibVMI is running in a domU
-    // and the XSM policy doesn't allow the getdomaininfo hypercall.
-    // Default Xen allows this without XSM for _all_ domains.
-    return xen_check_domainid(NULL, 0);
+    if (id == VMI_INVALID_DOMID && name == NULL) {
+        errprint("VMI_ERROR: xen_test: domid or name must be specified\n");
+        return VMI_FAILURE;
+    }
+
+    if (id == VMI_INVALID_DOMID) { /* name != NULL */
+        unsigned long domid = xen_get_domainid_from_name(NULL, name);
+        if (domid != VMI_INVALID_DOMID) {
+            return VMI_SUCCESS;
+        } else {
+            return VMI_FAILURE;
+        }
+    }
+
+    return xen_check_domainid(NULL, id);
 }
 
 status_t
@@ -1767,7 +1778,7 @@ unsigned long
 xen_get_domainid(
     vmi_instance_t vmi)
 {
-    return 0;
+    return VMI_INVALID_DOMID;
 }
 
 void


### PR DESCRIPTION
VMI_AUTO was not working when trying to use a file because xen_test() was ignoring `name` and calling checkid with 0 instead of the passed in id.
