### PR TITLE
Bugfixes pr82

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -536,7 +536,6 @@ vmi_init_private(
         /* read and parse the ghashtable */
         if ((VMI_CONFIG_GHASHTABLE & (*vmi)->config_mode)) {
             (*vmi)->config = (GHashTable*)config;
-            goto error_exit;
         }
 
         if(VMI_FAILURE == set_os_type_from_config(*vmi)) {


### PR DESCRIPTION
1. Fixes VMI_CONFIG_GHASHTABLE
2. Fixes compile bug with VMI_DEBUG enabled

I'd like to add a unit test for VMI_CONFIG_GHASHTABLE, but it kind of doesn't fit with giving the VM name when when running make check.
