### PR TITLE
"name" is a valid entry, but not processed here.

### DIFF
--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -137,7 +137,15 @@ void linux_read_config_ghashtable_entries(char* key, gpointer value,
         goto _done;
     }
 
-    errprint("VMI_WARNING: Invalid offset %s given for Linux target\n", key);
+    if (strncmp(key, "name", CONFIG_STR_LENGTH) == 0) {
+        goto _done;
+    }
+
+    if (strncmp(key, "domid", CONFIG_STR_LENGTH) == 0) {
+        goto _done;
+    }
+
+    warnprint("Invalid offset %s given for Linux target\n", key);
 
     _done: return;
 }

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -367,7 +367,15 @@ void windows_read_config_ghashtable_entries(char* key, gpointer value,
         goto _done;
     }
 
-    errprint("VMI_WARNING: Invalid offset %s given for Windows target\n", key);
+    if (strncmp(key, "name", CONFIG_STR_LENGTH) == 0) {
+        goto _done;
+    }
+
+    if (strncmp(key, "domid", CONFIG_STR_LENGTH) == 0) {
+        goto _done;
+    }
+
+    warnprint("Invalid offset \"%s\" given for Windows target\n", key);
 
     _done: return;
 }


### PR DESCRIPTION
Small fix to get rid of unnecessary warnings.
