### PR TITLE
Minimal Shm-snapshot API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,41 @@ If you would like LibVMI to work on physical memory snapshots saved to
 a file, then you don't need any special setup.
 
 
+Shm-snapshot Support
+------------------------------
+(Don't mix up with VM snapshot file) This technique will provide a very 
+fast and coherent memory access, except the creation of shm-snapshot can take
+0.2 ~ 1.4 seconds when the memory size of guest VM expands from 512MB to 
+3GB. This technique is currently for KVM only, we are going to support Xen
+later. If you would like LibVMI to work on a shm-snapshot, then 
+you need to do the following:
+
+- Ensure that your libvirt installation supports QMP commands.
+
+- Patch QEMU-KVM with the provided shm-snapshot patch.  
+  cd qemu-1.6
+  patch -p1 < [libvmi_dir]/tools/qemu-kvm-patch/kvm-physmem-access-physmem-snapshot_1.6.0.patch
+  make
+  make install
+  
+- ./configure --enable-shm-snapshot
+
+- Choose a setup method :
+  1) Add VMI_INIT_SHM_SNAPSHOT flag to vmi_int(), then vmi_init() will create 
+     a shm-snapshot and enter shm-snapshot mode automatically. Once LibVMI enters 
+     the shm-snapshot mode, memory access will be redirect to the shared memory 
+     shm-snapshot, rather than your live guest VM.
+  
+  2) After the vmi_init() has been called, invoke vmi_snapshot_create(vmi)
+     to snaphsot your guest VM and enter shm-snapshot mode.
+  
+  No matter which method you choose, you can turn LibVMI back to live mode 
+  by calling vmi_shm_snapshot_destroy(vmi).
+  
+  Even if you didn't call vmi_shm_snapshot_destroy(vmi), vmi_destroy(vmi) will 
+  teardown the shm-snapshot if existed.
+
+
 Building
 --------
 LibVMI uses the standard GNU build system.  To compile this library, simply

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,13 @@ AC_ARG_ENABLE([kvm],
       [enable_kvm=yes])
 AM_CONDITIONAL([KVM], [test x$enable_kvm = xyes])
 
+AC_ARG_ENABLE([shm_snapshot],
+      [AS_HELP_STRING([--disable-shm-snapshot],
+         [Support shm-snapshot with KVM VMs (Xen is pending) (default is no)])],
+      [enable_shm_snapshot=$enableval],
+      [enable_shm_snapshot=no])
+AM_CONDITIONAL([KVM], [test x$enable_shm_snapshot = xyes])
+
 AC_ARG_ENABLE([file],
       [AS_HELP_STRING([--disable-file],
          [Support memory introspection with physical memory dumps in a file (default is yes)])],
@@ -208,6 +215,15 @@ kvm_space='      '
     [fi]
 [fi]
 
+have_shm_snapshot='no'
+shm_snapshot_space=' '
+[if test "$enable_shm_snapshot" = "yes"]
+[then]
+    AC_DEFINE([ENABLE_SHM_SNAPSHOT], [1], [Define to 1 to enable shm-snapshot support.])
+    shm_snapshot_space=''
+    have_shm_snapshot='yes'
+[fi]
+
 have_file='no'
 file_space='      '
 [if test "$enable_file" = "yes"]
@@ -296,17 +312,18 @@ Host system type: $host
 Build system type: $build
 Installation prefix: $prefix
 
-Feature      | Option                  | Reason
--------------|-------------------------|----------------------------
-Xen Support  | --enable-xen=$enable_xen$xen_space   | $have_xen
-Xen Events   | --enable-xen-events=$enable_xen_events$xen_event_space | $have_xen_events
-KVM Support  | --enable-kvm=$enable_kvm$kvm_space   | $have_kvm
-File Support | --enable-file=$enable_file$file_space  | $have_file
--------------|-------------------------|----------------------------
+Feature      | Option                    | Reason
+-------------|---------------------------|----------------------------
+Xen Support  | --enable-xen=$enable_xen$xen_space     | $have_xen
+Xen Events   | --enable-xen-events=$enable_xen_events$xen_event_space   | $have_xen_events
+KVM Support  | --enable-kvm=$enable_kvm$kvm_space     | $have_kvm
+File Support | --enable-file=$enable_file$file_space    | $have_file
+Shm-snapshot | --enable-shm-snapshot=$enable_shm_snapshot$shm_snapshot_space | $have_shm_snapshot
+-------------|---------------------------|----------------------------
 
-Tools        | Option                  | Reason
--------------|-------------------------|----------------------------
-VMIFS        | --enable-vmifs=$enable_vmifs$vmifs_space | $have_vmifs
+Tools        | Option                    | Reason
+-------------|---------------------------|----------------------------
+VMIFS        | --enable-vmifs=$enable_vmifs$vmifs_space         | $have_vmifs
  
 If everything is correct, you can now run 'make' and (optionally)
 'make install'.  Otherwise, you can run './configure' again.

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -6,9 +6,10 @@ AM_CPPFLAGS = -I$(top_srcdir) $(GLIB_CFLAGS)
 AM_LDFLAGS = -L$(top_srcdir)/libvmi/.libs/
 LDADD = -lvmi -lm $(LIBS) $(GLIB_LIBS)
 
-bin_PROGRAMS = module-list process-list map-symbol map-addr dump-memory win-guid event-example msr-event-example singlestep-event-example
+bin_PROGRAMS = module-list process-list shm-snapshot-process-list map-symbol map-addr dump-memory win-guid event-example msr-event-example singlestep-event-example
 module_list_SOURCES = module-list.c
 process_list_SOURCES = process-list.c
+shm_snapshot_process_list_SOURCES = shm-snapshot-process-list.c
 map_symbol_SOURCES = map-symbol.c
 map_addr_SOURCES = map-addr.c
 dump_memory_SOURCES = dump-memory.c

--- a/examples/shm-snapshot-process-list.c
+++ b/examples/shm-snapshot-process-list.c
@@ -1,0 +1,199 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Bryan D. Payne (bdpayne@acm.org)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libvmi/libvmi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+
+void list_processes(vmi_instance_t* vmi, addr_t current_process,
+    addr_t list_head, unsigned long tasks_offset, addr_t current_list_entry,
+    status_t status, addr_t next_list_entry, unsigned long pid_offset,
+    vmi_pid_t pid, char* procname, unsigned long name_offset) {
+
+    /* demonstrate name and id accessors */
+    char* name2 = vmi_get_name(vmi);
+    if (VMI_FILE != vmi_get_access_mode(vmi)) {
+        unsigned long id = vmi_get_vmid(vmi);
+
+        printf("Process listing for VM %s (id=%lu)\n", name2, id);
+    } else {
+        printf("Process listing for file %s\n", name2);
+    }
+    free(name2);
+    /* get the head of the list */
+    if (VMI_OS_LINUX == vmi_get_ostype(vmi)) {
+        /* Begin at PID 0, the 'swapper' task. It's not typically shown by OS
+         *  utilities, but it is indeed part of the task list and useful to
+         *  display as such.
+         */
+        current_process = vmi_translate_ksym2v(vmi, "init_task");
+    } else if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)) {
+        // find PEPROCESS PsInitialSystemProcess
+        vmi_read_addr_ksym(vmi, "PsInitialSystemProcess", &current_process);
+    }
+
+    /* walk the task list */
+    list_head = current_process + tasks_offset;
+    current_list_entry = list_head;
+    status = vmi_read_addr_va(vmi, current_list_entry, 0, &next_list_entry);
+    if (status == VMI_FAILURE) {
+        printf("Failed to read next pointer at 0x%lx before entering loop\n",
+            current_list_entry);
+        goto error_exit;
+    }
+    printf("Next list entry is at: %lx\n", next_list_entry);
+    do {
+        /* Note: the task_struct that we are looking at has a lot of
+         * information.  However, the process name and id are burried
+         * nice and deep.  Instead of doing something sane like mapping
+         * this data to a task_struct, I'm just jumping to the location
+         * with the info that I want.  This helps to make the example
+         * code cleaner, if not more fragile.  In a real app, you'd
+         * want to do this a little more robust :-)  See
+         * include/linux/sched.h for mode details */
+
+        /* NOTE: _EPROCESS.UniqueProcessId is a really VOID*, but is never > 32 bits,
+         * so this is safe enough for x64 Windows for example purposes */
+        vmi_read_32_va(vmi, current_process + pid_offset, 0, &pid);
+
+        procname = vmi_read_str_va(vmi, current_process + name_offset, 0);
+
+        if (!procname) {
+            printf("Failed to find procname\n");
+            goto error_exit;
+        }
+
+        /* print out the process name */
+        printf("[%5d] %s (struct addr:%lx)\n", pid, procname, current_process);
+        if (procname) {
+            free(procname);
+            procname = NULL;
+        }
+
+        current_list_entry = next_list_entry;
+        current_process = current_list_entry - tasks_offset;
+
+        /* follow the next pointer */
+
+        status = vmi_read_addr_va(vmi, current_list_entry, 0, &next_list_entry);
+        if (status == VMI_FAILURE) {
+            printf("Failed to read next pointer in loop at %lx\n",
+                current_list_entry);
+            goto error_exit;
+        }
+
+    } while (next_list_entry != list_head);
+    error_exit: if (procname)
+        free(procname);
+}
+
+int main (int argc, char **argv)
+{
+#if ENABLE_SHM_SNAPSHOT == 1
+    vmi_instance_t vmi;
+    unsigned char *memory = NULL;
+    uint32_t offset;
+    addr_t list_head = 0, current_list_entry = 0, next_list_entry = 0;
+    addr_t current_process = 0;
+    addr_t tmp_next = 0;
+    char *procname = NULL;
+    vmi_pid_t pid = 0;
+    unsigned long tasks_offset, pid_offset, name_offset;
+    status_t status;
+
+    /* this is the VM or file that we are looking at */
+    if (argc != 2) {
+        printf("Usage: %s <vmname>\n", argv[0]);
+        return 1;
+    } // if
+
+    char *name = argv[1];
+
+    /* initialize the libvmi library */
+    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name) == VMI_FAILURE) {
+        printf("Failed to init LibVMI library.\n");
+        return 1;
+    }
+
+    /* init the offset values */
+    if (VMI_OS_LINUX == vmi_get_ostype(vmi)) {
+        tasks_offset = vmi_get_offset(vmi, "linux_tasks");
+        name_offset = vmi_get_offset(vmi, "linux_name");
+        pid_offset = vmi_get_offset(vmi, "linux_pid");
+
+        /* NOTE: 
+         *  name_offset is no longer hard-coded. Rather, it is now set 
+         *  via libvmi.conf.
+         */
+    }
+    else if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)) {
+        tasks_offset = vmi_get_offset(vmi, "win_tasks");
+        if (0 == tasks_offset) {
+            printf("Failed to find win_tasks\n");
+            goto error_exit;
+        }
+        name_offset = vmi_get_offset(vmi, "win_pname");
+        if (0 == name_offset) {
+            printf("Failed to find win_pname\n");
+            goto error_exit;
+        }
+        pid_offset = vmi_get_offset(vmi, "win_pid");
+        if (0 == pid_offset) {
+            printf("Failed to find win_pid\n");
+            goto error_exit;
+        }
+    }
+
+    /* create a shm-snapshot */
+    if (vmi_shm_snapshot_create(vmi) != VMI_SUCCESS) {
+        printf("Failed to shm-snapshot VM\n");
+        goto error_exit;
+    }
+
+    /* demonstrate name and id accessors */
+	list_processes(vmi, current_process, list_head, tasks_offset,
+        current_list_entry, status, next_list_entry, pid_offset, pid,
+        procname, name_offset);
+
+    error_exit: if (procname)
+        free(procname);
+
+    /* destroy the shm-snapshot, and return live mode */
+    vmi_shm_snapshot_destroy(vmi);
+
+    /* cleanup any memory associated with the LibVMI instance */
+    vmi_destroy(vmi);
+
+    return 0;
+#else
+    printf("Error : this example should only run after ./configure --enable-shm-snapshot.\n");
+    return 1; // error
+#endif
+
+}

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -189,6 +189,22 @@ vmi_resume_vm(
     return driver_resume_vm(vmi);
 }
 
+#if ENABLE_SHM_SNAPSHOT == 1
+status_t
+vmi_shm_snapshot_create(
+		vmi_instance_t vmi)
+{
+	return driver_shm_snapshot_vm(vmi);
+}
+
+status_t
+vmi_shm_snapshot_destroy(
+		vmi_instance_t vmi)
+{
+	return driver_destroy_shm_snapshot_vm(vmi);
+}
+#endif
+
 char *
 vmi_get_name(
     vmi_instance_t vmi)

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -107,6 +107,12 @@ struct driver_instance {
     *resume_vm_ptr) (
     vmi_instance_t);
     status_t (
+	*create_shm_snapshot_ptr) (
+	vmi_instance_t);
+	status_t (
+	*destroy_shm_snapshot_ptr) (
+	vmi_instance_t);
+	status_t (
     *events_listen_ptr)(
     vmi_instance_t,
     uint32_t);
@@ -193,6 +199,13 @@ driver_kvm_setup(
     instance->is_pv_ptr = &kvm_is_pv;
     instance->pause_vm_ptr = &kvm_pause_vm;
     instance->resume_vm_ptr = &kvm_resume_vm;
+#if ENABLE_SHM_SNAPSHOT == 1
+	instance->create_shm_snapshot_ptr = &kvm_create_shm_snapshot;
+	instance->destroy_shm_snapshot_ptr = &kvm_destroy_shm_snapshot;
+#else
+	instance->create_shm_snapshot_ptr = NULL;
+	instance->destroy_shm_snapshot_ptr = NULL;
+#endif
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
@@ -631,6 +644,36 @@ driver_resume_vm(
         return VMI_FAILURE;
     }
 }
+
+#if ENABLE_SHM_SNAPSHOT == 1
+status_t driver_shm_snapshot_vm(
+    vmi_instance_t vmi)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+
+    if (NULL != ptrs && NULL != ptrs->create_shm_snapshot_ptr) {
+        return ptrs->create_shm_snapshot_ptr(vmi);
+    }
+    else {
+        dbprint("WARNING: driver_shm_snapshot_vm function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_destroy_shm_snapshot_vm(
+    vmi_instance_t vmi)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+
+    if (NULL != ptrs && NULL != ptrs->destroy_shm_snapshot_ptr) {
+        return ptrs->destroy_shm_snapshot_ptr(vmi);
+    }
+    else {
+        dbprint("WARNING: driver_destroy_shm_snapshot_vm function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+#endif
 
 status_t driver_events_listen(
     vmi_instance_t vmi,

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -86,6 +86,15 @@ status_t driver_pause_vm(
     vmi_instance_t vmi);
 status_t driver_resume_vm(
     vmi_instance_t vmi);
+#if ENABLE_SHM_SNAPSHOT == 1
+/* "shm-snapshot" feature is applicable to
+ * hypervisor drivers (e.g. KVM, Xen), and not to the
+ * other drivers (e.g. File). */
+status_t driver_shm_snapshot_vm(
+    vmi_instance_t vmi);
+status_t driver_destroy_shm_snapshot_vm(
+    vmi_instance_t vmi);
+#endif
 status_t driver_events_listen(
     vmi_instance_t vmi,
     uint32_t timeout);

--- a/libvmi/driver/kvm.h
+++ b/libvmi/driver/kvm.h
@@ -35,6 +35,13 @@ typedef struct kvm_instance {
     char *name;
     char *ds_path;
     int socket_fd;
+
+#if ENABLE_SHM_SNAPSHOT == 1
+    char *shm_snapshot_path;  /** shared memory snapshot device path in /dev/shm directory */
+    int   shm_snapshot_fd;    /** file description of the shared memory snapshot device */
+    void *shm_snapshot_map;   /** mapped shared memory region */
+    char *shm_snapshot_cpu_regs;  /** string of dumped CPU registers */
+#endif
 } kvm_instance_t;
 
 #else
@@ -97,3 +104,9 @@ status_t kvm_pause_vm(
     vmi_instance_t vmi);
 status_t kvm_resume_vm(
     vmi_instance_t vmi);
+#if ENABLE_SHM_SNAPSHOT == 1
+status_t kvm_create_shm_snapshot(
+    vmi_instance_t vmi);
+status_t kvm_destroy_shm_snapshot(
+    vmi_instance_t vmi);
+#endif

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -82,6 +82,8 @@ typedef uint32_t vmi_mode_t;
 
 #define VMI_INIT_EVENTS (1 << 18) /**< init support for memory events */
 
+#define VMI_INIT_SHM_SNAPSHOT (1 << 19) /**< setup shm-snapshot in vmi_init() if the feature is activated */
+
 #define VMI_CONFIG_NONE (1 << 24) /**< no config provided */
 
 #define VMI_CONFIG_GLOBAL_FILE_ENTRY (1 << 25) /**< config in file provided */
@@ -1289,6 +1291,36 @@ status_t vmi_pause_vm(
  */
 status_t vmi_resume_vm(
     vmi_instance_t vmi);
+
+#if ENABLE_SHM_SNAPSHOT == 1
+/**
+ * Create a shm-snapshot and enter "shm-snapshot" mode.
+ *  (KVM only, Xen support is pending.)
+ *  (This API requires a patch to KVM.)
+ * If LibVMI is in "live" mode (i.e. KVM patch or KVM native), this will
+ * switch it to "shm-snapshot" mode; If LibVMI is already in "shm-snapshot" mode,
+ * this will destroy the old shm-snapshot and create a new one.
+ *
+ * @param[in] vmi LibVMI instance
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_shm_snapshot_create(
+		vmi_instance_t vmi);
+
+/**
+ * Destroy existed shm-snapshot and exit "shm-snapshot" mode.
+ *  (KVM only, Xen support is pending.)
+ *  (This API requires a patch to KVM.)
+ * If LibVMI is in "shm-snapshot", this API will switch it to "live" mode
+ * (i.e. KVM patch or KVM native); if LibVMI is already in "live" mode,
+ * this API does nothing.
+ *
+ * @param[in] vmi LibVMI instance
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_shm_snapshot_destroy(
+		vmi_instance_t vmi);
+#endif
 
 /**
  * Removes all entries from LibVMI's internal virtual to physical address

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ check_libvmi_SOURCES = \
     test_util.c \
     test_write.c \
     test_peparse.c \
+    test_shm_snapshot.c \
     $(top_builddir)/libvmi/libvmi.h
 
 check_libvmi_CFLAGS = @CHECK_CFLAGS@

--- a/tests/check_runner.c
+++ b/tests/check_runner.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "check_tests.h"
+#include "../libvmi/libvmi.h"
 
 char *testvm = NULL;
 
@@ -59,6 +60,9 @@ main (void)
     suite_add_tcase(s, accessor_tcase());
     suite_add_tcase(s, util_tcase());
     suite_add_tcase(s, peparse_tcase());
+#if ENABLE_SHM_SNAPSHOT == 1
+    suite_add_tcase(s, shm_snapshot_tcase());
+#endif
 
     /* run the tests */
     SRunner *sr = srunner_create(s);

--- a/tests/test_shm_snapshot.c
+++ b/tests/test_shm_snapshot.c
@@ -1,0 +1,58 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2012 VMITools Project
+ *
+ * Author: Bryan D. Payne (bdpayne@acm.org), Guanglin Xu (mzguanglin@gmail.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <check.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include "../libvmi/libvmi.h"
+#include "check_tests.h"
+
+
+/* test vmi_snapshot_create */
+START_TEST (test_libvmi_shm_snapshot_create)
+{
+    vmi_instance_t vmi = NULL;
+    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+
+#if ENABLE_SNAPSHOT == 1
+    ret = vmi_snapshot_create(vmi);
+#endif
+
+    fail_unless(ret == VMI_SUCCESS,
+                "vmi_init failed with AUTO | COMPLETE");
+    fail_unless(vmi != NULL,
+                "vmi_init failed to initialize vmi instance struct");
+    vmi_destroy(vmi);
+}
+END_TEST
+
+/* snapshot test cases */
+TCase *shm_snapshot_tcase (void)
+{
+    TCase *tc_init = tcase_create("LibVMI shm-snapshot");
+    tcase_add_test(tc_init, test_libvmi_shm_snapshot_create);
+    return tc_init;
+}

--- a/tools/qemu-kvm-patch/kvm-physmem-access-physmem-snapshot_1.6.0.patch
+++ b/tools/qemu-kvm-patch/kvm-physmem-access-physmem-snapshot_1.6.0.patch
@@ -1,0 +1,531 @@
+diff --git a/Makefile.target b/Makefile.target
+index 9a49852..46db6e7 100644
+--- a/Makefile.target
++++ b/Makefile.target
+@@ -113,7 +113,7 @@ endif #CONFIG_BSD_USER
+ #########################################################
+ # System emulator target
+ ifdef CONFIG_SOFTMMU
+-obj-y += arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o
++obj-y += arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o memory-snapshot.o memory-access.o
+ obj-y += qtest.o
+ obj-y += hw/
+ obj-$(CONFIG_FDT) += device_tree.o
+diff --git a/memory-access.c b/memory-access.c
+new file mode 100644
+index 0000000..801299e
+--- /dev/null
++++ b/memory-access.c
+@@ -0,0 +1,199 @@
++/*
++ * Access guest physical memory via a domain socket.
++ *
++ * Copyright (C) 2011 Sandia National Laboratories
++ * Author: Bryan D. Payne (bdpayne@acm.org)
++ */
++
++#include "memory-access.h"
++//#include "cpu-all.h"
++#include "qemu-common.h"
++#include "exec/cpu-common.h"
++#include "config.h"
++
++#include <stdlib.h>
++#include <stdio.h>
++#include <string.h>
++#include <pthread.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <sys/un.h>
++#include <unistd.h>
++#include <signal.h>
++#include <stdint.h>
++
++struct request{
++    uint8_t type;      // 0 quit, 1 read, 2 write, ... rest reserved
++    uint64_t address;  // address to read from OR write to
++    uint64_t length;   // number of bytes to read OR write
++};
++
++static uint64_t
++connection_read_memory (uint64_t user_paddr, void *buf, uint64_t user_len)
++{
++    hwaddr paddr = (hwaddr) user_paddr;
++    hwaddr len = (hwaddr) user_len;
++    void *guestmem = cpu_physical_memory_map(paddr, &len, 0);
++    if (!guestmem){
++        return 0;
++    }
++    memcpy(buf, guestmem, len);
++    cpu_physical_memory_unmap(guestmem, len, 0, len);
++
++    return len;
++}
++
++static uint64_t
++connection_write_memory (uint64_t user_paddr, void *buf, uint64_t user_len)
++{
++    hwaddr paddr = (hwaddr) user_paddr;
++    hwaddr len = (hwaddr) user_len;
++    void *guestmem = cpu_physical_memory_map(paddr, &len, 1);
++    if (!guestmem){
++        return 0;
++    }
++    memcpy(guestmem, buf, len);
++    cpu_physical_memory_unmap(guestmem, len, 0, len);
++
++    return len;
++}
++
++static void
++send_success_ack (int connection_fd)
++{
++    uint8_t success = 1;
++    int nbytes = write(connection_fd, &success, 1);
++    if (1 != nbytes){
++        printf("QemuMemoryAccess: failed to send success ack\n");
++    }
++}
++
++static void
++send_fail_ack (int connection_fd)
++{
++    uint8_t fail = 0;
++    int nbytes = write(connection_fd, &fail, 1);
++    if (1 != nbytes){
++        printf("QemuMemoryAccess: failed to send fail ack\n");
++    }
++}
++
++static void
++connection_handler (int connection_fd)
++{
++    int nbytes;
++    struct request req;
++
++    while (1){
++        // client request should match the struct request format
++        nbytes = read(connection_fd, &req, sizeof(struct request));
++        if (nbytes != sizeof(struct request)){
++            // error
++            continue;
++        }
++        else if (req.type == 0){
++            // request to quit, goodbye
++            break;
++        }
++        else if (req.type == 1){
++            // request to read
++            char *buf = malloc(req.length + 1);
++            nbytes = connection_read_memory(req.address, buf, req.length);
++            if (nbytes != req.length){
++                // read failure, return failure message
++                buf[req.length] = 0; // set last byte to 0 for failure
++                nbytes = write(connection_fd, buf, 1);
++            }
++            else{
++                // read success, return bytes
++                buf[req.length] = 1; // set last byte to 1 for success
++                nbytes = write(connection_fd, buf, nbytes + 1);
++            }
++            free(buf);
++        }
++        else if (req.type == 2){
++            // request to write
++            void *write_buf = malloc(req.length);
++            nbytes = read(connection_fd, &write_buf, req.length);
++            if (nbytes != req.length){
++                // failed reading the message to write
++                send_fail_ack(connection_fd);
++            }
++            else{
++                // do the write
++                nbytes = connection_write_memory(req.address, write_buf, req.length);
++                if (nbytes == req.length){
++                    send_success_ack(connection_fd);
++                }
++                else{
++                    send_fail_ack(connection_fd);
++                }
++            }
++            free(write_buf);
++        }
++        else{
++            // unknown command
++            printf("QemuMemoryAccess: ignoring unknown command (%d)\n", req.type);
++            char *buf = malloc(1);
++            buf[0] = 0;
++            nbytes = write(connection_fd, buf, 1);
++            free(buf);
++        }
++    }
++
++    close(connection_fd);
++}
++
++static void *
++memory_access_thread (void *path)
++{
++    struct sockaddr_un address;
++    int socket_fd, connection_fd;
++    socklen_t address_length;
++
++    socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
++    if (socket_fd < 0){
++        printf("QemuMemoryAccess: socket failed\n");
++        goto error_exit;
++    }
++    unlink(path);
++    address.sun_family = AF_UNIX;
++    address_length = sizeof(address.sun_family) + sprintf(address.sun_path, "%s", (char *) path);
++
++    if (bind(socket_fd, (struct sockaddr *) &address, address_length) != 0){
++        printf("QemuMemoryAccess: bind failed\n");
++        goto error_exit;
++    }
++    if (listen(socket_fd, 0) != 0){
++        printf("QemuMemoryAccess: listen failed\n");
++        goto error_exit;
++    }
++
++    connection_fd = accept(socket_fd, (struct sockaddr *) &address, &address_length);
++    connection_handler(connection_fd);
++
++    close(socket_fd);
++    unlink(path);
++error_exit:
++    return NULL;
++}
++
++int
++memory_access_start (const char *path)
++{
++    pthread_t thread;
++    sigset_t set, oldset;
++    int ret;
++
++    // create a copy of path that we can safely use
++    char *pathcopy = malloc(strlen(path) + 1);
++    memcpy(pathcopy, path, strlen(path) + 1);
++
++    // start the thread
++    sigfillset(&set);
++    pthread_sigmask(SIG_SETMASK, &set, &oldset);
++    ret = pthread_create(&thread, NULL, memory_access_thread, pathcopy);
++    pthread_sigmask(SIG_SETMASK, &oldset, NULL);
++
++    return ret;
++}
+diff --git a/memory-access.h b/memory-access.h
+new file mode 100644
+index 0000000..e538134
+--- /dev/null
++++ b/memory-access.h
+@@ -0,0 +1,8 @@
++/*
++ * Mount guest physical memory using FUSE.
++ *
++ * Copyright (C) 2011 Sandia National Laboratories
++ * Author: Bryan D. Payne (bdpayne@acm.org)
++ */
++
++int memory_access_start (const char *path);
+diff --git a/memory-snapshot.c b/memory-snapshot.c
+new file mode 100644
+index 0000000..7c686ff
+--- /dev/null
++++ b/memory-snapshot.c
+@@ -0,0 +1,123 @@
++/* 
++ * Shared Memory Snapshot via POSIX shared memory
++ *
++ * Copyright (C) 2013
++ * Author: Peter F. Klemperer (klemperer@cmu.edu)
++ */
++
++
++#include "config-host.h"
++
++#include "monitor/monitor.h"
++#include "sysemu/sysemu.h"
++#include "exec/gdbstub.h"
++#include "sysemu/dma.h"
++#include "sysemu/kvm.h"
++#include "qmp-commands.h"
++
++#include "qemu/thread.h"
++#include "sysemu/cpus.h"
++#include "sysemu/qtest.h"
++#include "qemu/main-loop.h"
++#include "qemu/bitmap.h"
++
++#ifndef _WIN32
++#include "qemu/compatfd.h"
++#endif
++
++#ifdef CONFIG_LINUX
++
++#include <sys/mman.h>
++#include <sys/stat.h>        /* For mode constants */
++#include <fcntl.h>           /* For O_* constants */
++                     
++#include <sys/prctl.h>
++
++#endif /* CONFIG_LINUX */
++
++#include "memory-snapshot.h"
++
++
++// shm_pmemsave - same functionality as pmemsave
++// except that the "file" is actually shm shared memory space.
++int64_t shm_pmemsave(int64_t psize, const char *filename,
++                  Error **errp)
++{
++    fprintf(stderr, "qemu: shm_pmemsave %s : start\n", filename);
++    int64_t addr = 0;
++    int64_t size = psize;
++    uint32_t l;
++    uint8_t buf[1024];
++    
++    int shm_fd;
++    int shm_flags = O_CREAT | O_RDWR;
++    int perms = 0777;
++    shm_fd = shm_open( filename, shm_flags, (mode_t) perms);
++    if ( shm_fd == -1 ) {
++        error_setg_file_open(errp, errno, filename);
++        psize = 0;
++        return psize;
++    }
++
++    if( ftruncate( shm_fd, size ) == -1 ) {
++        error_set(errp, QERR_IO_ERROR); 
++        psize = 0;
++        goto exit;
++    }
++
++    // mmap open file
++    uint8_t *shm_buffer;
++    int mprot  = PROT_READ | PROT_WRITE;
++    int mflags = MAP_SHARED;
++    shm_buffer = (void *) mmap( NULL, size, mprot, mflags, shm_fd, (off_t)0 );
++    if (shm_buffer == MAP_FAILED ) {
++        error_set(errp, QERR_IO_ERROR);
++        psize = 0;
++        goto exit;
++    }
++
++    while (size != 0) {
++        l = sizeof(buf);
++        if (l > size)
++            l = size;
++
++        // read out memory
++        cpu_physical_memory_rw(addr, buf, l, 0);
++
++        // memcopy from buffer into file instead of file
++        memcpy( (shm_buffer + addr), buf, l );
++
++        addr += l;
++        size -= l;
++    }
++
++    // munmap the shm_buffer
++    if( munmap( shm_buffer, psize ) == -1 ) {
++        error_set(errp, QERR_IO_ERROR); 
++        psize = 0;
++        goto exit;
++    }
++
++exit:
++    close(shm_fd);
++    return psize;
++}
++
++
++int64_t qmp_snapshot_create(const char *filename, Error **errp)
++{
++    RAMBlock *block;
++    block = QTAILQ_FIRST( &ram_list.blocks );
++
++    int64_t size = memory_region_size(block->mr);
++
++    return shm_pmemsave( size, filename, errp );
++}
++
++
++void qmp_snapshot_destroy(const char *filename, Error **errp)
++{
++    shm_unlink( filename );
++    return;
++}
++
+diff --git a/memory-snapshot.h b/memory-snapshot.h
+new file mode 100644
+index 0000000..36e2a0a
+--- /dev/null
++++ b/memory-snapshot.h
+@@ -0,0 +1,13 @@
++/* 
++ * Shared Memory Snapshot via POSIX shared memory
++ *
++ * Copyright (C) 2013
++ * Author: Peter F. Klemperer (klemperer@cmu.edu)
++ */
++#ifndef MEMORY_SNAPSHOT_H
++#define MEMORY_SNAPSHOT_H 1
++
++/* memory-snapshot.c */
++int64_t shm_pmemsave(int64_t size, const char *filename, Error **errp);
++
++#endif /* MEMORY_SNAPSHOT_H */
+diff --git a/monitor.c b/monitor.c
+index 5dc0aa9..4120d5f 100644
+--- a/monitor.c
++++ b/monitor.c
+@@ -67,6 +67,7 @@
+ #include "qmp-commands.h"
+ #include "hmp.h"
+ #include "qemu/thread.h"
++#include "memory-access.h"
+ 
+ /* for pic/irq_info */
+ #if defined(TARGET_SPARC)
+@@ -1258,6 +1259,13 @@ static void do_print(Monitor *mon, const QDict *qdict)
+     monitor_printf(mon, "\n");
+ }
+ 
++static int do_physical_memory_access(Monitor *mon, const QDict *qdict, QObject **ret_data)
++{
++    const char *path = qdict_get_str(qdict, "path");
++    memory_access_start(path);
++    return 0;
++}
++
+ static void do_sum(Monitor *mon, const QDict *qdict)
+ {
+     uint32_t addr;
+diff --git a/qapi-schema.json b/qapi-schema.json
+index a51f7d2..166874d 100644
+--- a/qapi-schema.json
++++ b/qapi-schema.json
+@@ -3773,3 +3773,31 @@
+ ##
+ { 'command': 'query-rx-filter', 'data': { '*name': 'str' },
+   'returns': ['RxFilterInfo'] }
++
++##
++# @snapshot-create
++#
++# Create a memory snapshot with POSIX shared memory.
++#
++# @filename: store at /dev/shm/filename
++#
++# Returns: json-int the size of the memory snapshot in bytes.
++#
++# Since: 1.6
++##
++{'command': 'snapshot-create', 'data': { 'filename': 'str' },
++  'returns': 'int' }
++
++##
++# @snapshot-destroy
++#
++# Destroy the memory snapshot with POSIX shared memory.
++#
++# @filename: Destroy snapshot stored at /dev/shm/filename
++#
++# Returns: none.
++#
++# Since: 1.6
++##
++{'command': 'snapshot-destroy', 'data': { 'filename': 'str' } }
++
+diff --git a/qmp-commands.hx b/qmp-commands.hx
+index cf47e3f..bc157de 100644
+--- a/qmp-commands.hx
++++ b/qmp-commands.hx
+@@ -610,6 +610,84 @@ Example:
+ EQMP
+ 
+     {
++        .name       = "snapshot-create",
++        .args_type  = "filename:s",
++        .help       = "share guest physical memory image at '/dev/shm/filename'",
++        .mhandler.cmd_new = qmp_marshal_input_snapshot_create,
++    },
++
++SQMP
++snapshot-create
++----------
++
++Mount guest physical memory image at 'path'. 
++Returns json-int indicating the size of the snapshot.
++
++Arguments:
++
++- "path": mount point path (json-string)
++
++Example:
++
++-> { "execute": "snapshot-create",
++             "arguments": { "path": "/snapshot" } }
++<- { "return": {1074859} }
++
++EQMP
++
++    {
++        .name       = "snapshot-destroy",
++        .args_type  = "filename:s",
++        .help       = "destroy guest physical memory image at '/dev/shm/filename'",
++        .mhandler.cmd_new = qmp_marshal_input_snapshot_destroy,
++    },
++
++SQMP
++snapshot-destroy
++----------
++
++Mount guest physical memory image at 'path'. 
++
++Arguments:
++
++- "path": mount point path (json-string)
++
++Example:
++
++-> { "execute": "snapshot-destroy",
++             "arguments": { "path": "/snapshot" } }
++<- { "return": {} }
++
++EQMP
++
++    {
++        .name       = "pmemaccess",
++        .args_type  = "path:s",
++        .params     = "path",
++        .help       = "mount guest physical memory image at 'path'",
++        .user_print = monitor_user_noop,
++        .mhandler.cmd_new = do_physical_memory_access,
++    },
++
++SQMP
++pmemaccess
++----------
++
++Mount guest physical memory image at 'path'.
++
++Arguments:
++
++- "path": mount point path (json-string)
++
++Example:
++
++-> { "execute": "pmemaccess",
++             "arguments": { "path": "/tmp/guestname" } }
++<- { "return": {} }
++
++EQMP
++
++    {
+         .name       = "migrate",
+         .args_type  = "detach:-d,blk:-b,inc:-i,uri:s",
+         .mhandler.cmd_new = qmp_marshal_input_migrate,


### PR DESCRIPTION
Minimal API for KVM shm-snapshot

This PR contains a new feature for LibVMI, named "shm-snapshot" (Don't mix up with VM snapshot file). The technique provides a very fast and coherent memory access for KVM guest (Xen is pending), except the creation of shm-snapshot can take 0.2 ~ 1.4 seconds when the memory size of guest VM expands from 512MB to 3GB.

shm-snapshots offer the capability to quickly examine guest physical memory state at a single moment in time. This capability will enable or improve memory heavy introspection tasks like memory-based antivirus scanning.

This is the first in a series of pull requests designed around the concept of bringing fast, coherent memory access to LibVMI. In future PRs we plan to accelerate physical memory access speed, increase Xen memory access performance, and decrease KVM snapshot latency. In the future we would be interested in looking at how snapshotting could be combined with events to precisely trigger the snapshotting process.

The major contributions in this PR:
1. shm-snapshot and pmemaccess patch for QEMU 1.6
2. two new API vmi_shm_snapshot_create(vmi) and vmi_shm_snapshot_destroy(vmi)
3. new flag of VMI_INIT_SHM_SNAPSHOT for vmi_init() to make shm-snapshot during initialization.
4. modified KVM driver with shm-snapshot support
5. an example program "shm-snapshot-process-list"
6. unit test for shm-snapshot
7. configure option --enable-shm-snapshot.

If you would like LibVMI to work on a "shm-snapshot", then you need to do the following:

Ensure that your libvirt installation supports QMP commands.

Patch QEMU-KVM with the provided shm-snapshot patch.

cd qemu-1.6
patch -p1 < [libvmi_dir]/tools/qemu-kvm-patch/kvm-physmem-access-physmem-snapshot_1.6.0.patch
make
make install

./configure --enable-shm-snapshot

make clean && make && make install

make check and run shm-snapshot-process-list to verify the validity of shm-snapshot.

write your VMI programs to take advantage of snapshot by choosing a setup method :

1) Add VMI_INIT_SHM_SNAPSHOT flag to vmi_int(), then vmi_init() will create a shm-snapshot and enter shm-snapshot mode automatically.
Once LibVMI enters the shm-snapshot mode, memory access will be redirect to the shm-snapshot, rather than your live guest VM.

2) After the vmi_init() without shm-snapshot flag has been called, invoke vmi_shm_snapshot_create(vmi) to snaphsot your guest VM and enter shm-snapshot mode. If LibVMI is already in shm-snapshot mode (no matter by vmi_init() flag or vmi_shm_snapshot_create(vmi), a subsequent call to vmi_shm_snapshot_create(vmi) will create a new shm-snapshot to replace the old one.

You can turn LibVMI back to live mode by invoking vmi_shm_snapshot_destroy(vmi).

Even if you didn't call vmi_shm_snapshot_destroy(vmi), vmi_destroy(vmi) will teardown the shm-snapshot if existed.
