### PR TITLE
minimal-shm-snapshot-api-xen

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,22 +153,29 @@ Shm-snapshot Support
 ------------------------------
 (Don't mix up with VM snapshot file) This technique will provide a very 
 fast and coherent memory access, except the creation of shm-snapshot can take
-0.2 ~ 1.4 seconds when the memory size of guest VM expands from 512MB to 
-3GB. This technique is currently for KVM only, we are going to support Xen
-later. If you would like LibVMI to work on a shm-snapshot, then 
-you need to do the following:
+0.2 ~ 1.4 seconds (KVM) when the memory size of guest VM expands from 512MB to 
+3GB. 
+Shm-snapshot supports both KVM and Xen. However,shm-snapshot for Xen is 
+currently created by LibVMI, hence unreal. Moreover,it takes more time (about 3 
+seconds in 1GB guest memory settings) to create Xen "shm-snapshot" because we 
+have to probe unmmapable memory page holes one by one.
 
-- Ensure that your libvirt installation supports QMP commands.
+If you would like LibVMI to work on a shm-snapshot, then you need to do the 
+following:
 
-- Patch QEMU-KVM with the provided shm-snapshot patch.  
-  cd qemu-1.6
-  patch -p1 < [libvmi_dir]/tools/qemu-kvm-patch/kvm-physmem-access-physmem-snapshot_1.6.0.patch
-  make
-  make install
+(P.S: If you use Xen, just to start on step 3)
+
+1. ensure that your libvirt installation supports QMP commands.
+
+2. patch QEMU-KVM with the provided shm-snapshot patch.  
+    cd qemu-1.6
+    patch -p1 < [libvmi_dir]/tools/qemu-kvm-patch/kvm-physmem-access-physmem-snapshot_1.6.0.patch
+    make
+    make install
   
-- ./configure --enable-shm-snapshot
+3. ./configure --enable-shm-snapshot
 
-- Choose a setup method :
+4. Choose a setup method :
   1) Add VMI_INIT_SHM_SNAPSHOT flag to vmi_int(), then vmi_init() will create 
      a shm-snapshot and enter shm-snapshot mode automatically. Once LibVMI enters 
      the shm-snapshot mode, memory access will be redirect to the shared memory 

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -165,6 +165,13 @@ driver_xen_setup(
     instance->is_pv_ptr = &xen_is_pv;
     instance->pause_vm_ptr = &xen_pause_vm;
     instance->resume_vm_ptr = &xen_resume_vm;
+#if ENABLE_SHM_SNAPSHOT == 1
+	instance->create_shm_snapshot_ptr = &xen_create_shm_snapshot;
+	instance->destroy_shm_snapshot_ptr = &xen_destroy_shm_snapshot;
+#else
+	instance->create_shm_snapshot_ptr = NULL;
+	instance->destroy_shm_snapshot_ptr = NULL;
+#endif
 #if ENABLE_XEN_EVENTS==1
     instance->events_listen_ptr = &xen_events_listen;
     instance->set_reg_access_ptr = &xen_set_reg_access;

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -86,6 +86,13 @@ typedef struct xen_instance {
 #if ENABLE_XEN_EVENTS==1
     xen_events_t *events; /**< handle to events data */
 #endif
+
+#if ENABLE_SHM_SNAPSHOT == 1
+    char *shm_snapshot_path;  /** reserved for shared memory snapshot device path in /dev/shm directory */
+    int   shm_snapshot_fd;    /** reserved for file description of the shared memory snapshot device */
+    void *shm_snapshot_map;   /** reserved mapped shared memory region. It's currently malloc() regions */
+    void *shm_snapshot_cpu_regs;  /** structure of dumped CPU registers */
+#endif
 } xen_instance_t;
 
 #else
@@ -158,3 +165,9 @@ status_t xen_set_domain_debug_control(
     vmi_instance_t vmi,
     unsigned long vcpu,
     int enable);
+#if ENABLE_SHM_SNAPSHOT == 1
+status_t xen_create_shm_snapshot(
+    vmi_instance_t vmi);
+status_t xen_destroy_shm_snapshot(
+    vmi_instance_t vmi);
+#endif


### PR DESCRIPTION
Now we can use shm-snapshot feature even in Xen!
However, note that this is actually not a real shm-snapshot, because we create the snapshot in LibVMI, which should be created by Xen hypervisor.
