### PR TITLE
Direct Guest Physical Memory Access (DGPMA) of shm-snapshot

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -203,6 +203,11 @@ vmi_shm_snapshot_destroy(
 {
 	return driver_destroy_shm_snapshot_vm(vmi);
 }
+
+const void * vmi_get_dgpma(
+    vmi_instance_t vmi) {
+    return driver_get_dgpma(vmi);
+}
 #endif
 
 char *

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -112,6 +112,9 @@ struct driver_instance {
 	status_t (
 	*destroy_shm_snapshot_ptr) (
 	vmi_instance_t);
+	const void * (
+	*get_dgpma_ptr) (
+	vmi_instance_t);
 	status_t (
     *events_listen_ptr)(
     vmi_instance_t,
@@ -168,9 +171,11 @@ driver_xen_setup(
 #if ENABLE_SHM_SNAPSHOT == 1
 	instance->create_shm_snapshot_ptr = &xen_create_shm_snapshot;
 	instance->destroy_shm_snapshot_ptr = &xen_destroy_shm_snapshot;
+	instance->get_dgpma_ptr = &xen_get_dgpma;
 #else
 	instance->create_shm_snapshot_ptr = NULL;
 	instance->destroy_shm_snapshot_ptr = NULL;
+	instance->get_dgpma_ptr = NULL;
 #endif
 #if ENABLE_XEN_EVENTS==1
     instance->events_listen_ptr = &xen_events_listen;
@@ -209,9 +214,11 @@ driver_kvm_setup(
 #if ENABLE_SHM_SNAPSHOT == 1
 	instance->create_shm_snapshot_ptr = &kvm_create_shm_snapshot;
 	instance->destroy_shm_snapshot_ptr = &kvm_destroy_shm_snapshot;
+	instance->get_dgpma_ptr = &kvm_get_dgpma;
 #else
 	instance->create_shm_snapshot_ptr = NULL;
 	instance->destroy_shm_snapshot_ptr = NULL;
+	instance->get_dgpma_ptr = NULL;
 #endif
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
@@ -679,6 +686,20 @@ status_t driver_destroy_shm_snapshot_vm(
         dbprint("WARNING: driver_destroy_shm_snapshot_vm function not implemented.\n");
         return VMI_FAILURE;
     }
+}
+
+const void * driver_get_dgpma(
+    vmi_instance_t vmi) {
+    driver_instance_t ptrs = driver_get_instance(vmi);
+
+    if (NULL != ptrs && NULL != ptrs->get_dgpma_ptr) {
+        return ptrs->get_dgpma_ptr(vmi);
+    }
+    else {
+        dbprint("WARNING: get_dgpma_ptr function not implemented.\n");
+        return VMI_FAILURE;
+    }
+
 }
 #endif
 

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -94,6 +94,8 @@ status_t driver_shm_snapshot_vm(
     vmi_instance_t vmi);
 status_t driver_destroy_shm_snapshot_vm(
     vmi_instance_t vmi);
+const void * driver_get_dgpma(
+    vmi_instance_t vmi);
 #endif
 status_t driver_events_listen(
     vmi_instance_t vmi,

--- a/libvmi/driver/kvm.c
+++ b/libvmi/driver/kvm.c
@@ -1161,6 +1161,11 @@ kvm_destroy_shm_snapshot(
 
 	return kvm_setup_live_mode(vmi);
 }
+
+const void * kvm_get_dgpma(
+    vmi_instance_t vmi) {
+    return kvm_get_instance(vmi)->shm_snapshot_map;
+}
 #endif
 
 //////////////////////////////////////////////////////////////////////
@@ -1314,6 +1319,11 @@ kvm_destroy_shm_snapshot(
     vmi_instance_t vmi)
 {
     return VMI_FAILURE;
+}
+
+const void * kvm_get_dgpma(
+    vmi_instance_t vmi) {
+    return NULL;
 }
 #endif
 

--- a/libvmi/driver/kvm.h
+++ b/libvmi/driver/kvm.h
@@ -109,4 +109,6 @@ status_t kvm_create_shm_snapshot(
     vmi_instance_t vmi);
 status_t kvm_destroy_shm_snapshot(
     vmi_instance_t vmi);
+const void * kvm_get_dgpma(
+    vmi_instance_t vmi);
 #endif

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -2175,6 +2175,11 @@ xen_destroy_shm_snapshot(
 
 	return xen_setup_live_mode(vmi);
 }
+
+const void * xen_get_dgpma(
+    vmi_instance_t vmi) {
+    return xen_get_instance(vmi)->shm_snapshot_map;
+}
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2355,6 +2360,11 @@ xen_destroy_shm_snapshot(
     vmi_instance_t vmi)
 {
     return VMI_FAILURE;
+}
+
+const void * xen_get_dgpma(
+    vmi_instance_t vmi) {
+    return NULL;
 }
 #endif
 

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -170,4 +170,6 @@ status_t xen_create_shm_snapshot(
     vmi_instance_t vmi);
 status_t xen_destroy_shm_snapshot(
     vmi_instance_t vmi);
+const void * xen_get_dgpma(
+    vmi_instance_t vmi);
 #endif

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1323,6 +1323,17 @@ status_t vmi_shm_snapshot_destroy(
 #endif
 
 /**
+ * Direct Guest Physical Memory Access: Get a read-only pointer of shm-snapshot.
+ * This function provides a much faster (non-copy) option to read guest physical
+ * memory bypassing vmi_read_pa().
+ * If the shm-snapshot hasn't been created yet, it returns NULL.
+ */
+const void * vmi_get_dgpma(
+    vmi_instance_t vmi);
+
+/**
+
+/**
  * Removes all entries from LibVMI's internal virtual to physical address
  * cache.  This is generally only useful if you believe that an entry in
  * the cache is incorrect, or out of date.


### PR DESCRIPTION
Users now can get a read only pointer to the shm-snapshot by the vmi_get_dgpma(vmi) function, and then read the shm-snapshot content in a non-copy manner (ideally  at a native speed like reading the local memory) , bypassing the vmi_read_pa(vmi) function.

Example:
1. without DGPMA:
   vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, vm);
   void\* pmem = malloc(ANY_SIZE);
   vmi_read_pa(vmi,  A_PHY_ADDR, pmem, ANY_SIZE); // with memcpy() inside
   any_vmi_processing(pmem, ANY_SIZE);
   free(pmem);
   vmi_shm_snapshot_destroy(vmi);
   vmi_destroy(vmi);
2. with DGPMA:
   vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, vm);
   vmi_shm_snapshot_create(vmi);
   const void\* pmem = vmi_get_dgpma(vmi);
   if (NULL == pmem) {
       printf("fail to get dpgma\n");
       return 1;
   }
   any_vmi_processing(pmem + A_PHY_ADDR, ANY_SIZE);
   vmi_shm_snapshot_destroy(vmi);
   vmi_destroy(vmi);

My benchmark shows crazy memory read bandwidth with DGPMA:
![1](https://f.cloud.github.com/assets/667845/1126639/46723b80-1b27-11e3-8949-5e75341e4d8a.png)
