### PR TITLE
Interrupt events

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(GLIB_CFLAGS)
 AM_LDFLAGS = -L$(top_srcdir)/libvmi/.libs/
 LDADD = -lvmi -lm $(LIBS) $(GLIB_LIBS)
 
-bin_PROGRAMS = module-list process-list shm-snapshot-process-list map-symbol map-addr dump-memory win-guid event-example msr-event-example singlestep-event-example
+bin_PROGRAMS = module-list process-list shm-snapshot-process-list map-symbol map-addr dump-memory win-guid event-example msr-event-example singlestep-event-example interrupt-event-example
 module_list_SOURCES = module-list.c
 process_list_SOURCES = process-list.c
 shm_snapshot_process_list_SOURCES = shm-snapshot-process-list.c
@@ -16,5 +16,6 @@ dump_memory_SOURCES = dump-memory.c
 event_example_SOURCES = event-example.c
 msr_event_example_SOURCES = msr-event-example.c
 singlestep_event_example_SOURCES = singlestep-event-example.c
+interrupt_event_example_SOURCES = interrupt-event-example.c
 win_guid_SOURCES = win-guid.c
 

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -1,0 +1,93 @@
+/* The LibVMI Library is an introspection library that simplifies access to 
+ * memory in a target virtual machine or in a file containing a dump of 
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Steven Maresca (steven.maresca@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libvmi/libvmi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+
+vmi_event_t interrupt_event;
+
+void int3_cb(vmi_instance_t vmi, vmi_event_t *event){
+    printf("Int 3 happened: GFN=%lx RIP=%lx\n", event->interrupt_event.gfn, event->interrupt_event.gla);
+}
+
+static int interrupted = 0;
+static void close_handler(int sig){
+    interrupted = sig;
+}
+
+int main (int argc, char **argv) {
+    vmi_instance_t vmi;
+    struct sigaction act;
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    char *name = NULL;
+
+    if(argc < 2){
+        fprintf(stderr, "Usage: interrupt_events_example <name of VM>\n");
+        exit(1);
+    }
+
+    // Arg 1 is the VM name.
+    name = argv[1];
+
+    // Initialize the libvmi library.
+    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_PARTIAL | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+        printf("Failed to init LibVMI library.\n");
+        return 1;
+    }
+    else{
+        printf("LibVMI init succeeded!\n");
+    }
+
+    /* Register event to track INT3 interrupts */
+    memset(&interrupt_event, 0, sizeof(vmi_event_t));
+    interrupt_event.type = VMI_EVENT_INTERRUPT;
+    interrupt_event.interrupt_event.enabled = 1;
+    interrupt_event.interrupt_event.reinject = 1;
+    interrupt_event.callback = int3_cb;
+
+    vmi_register_event(vmi, &interrupt_event);
+
+    printf("Waiting for events...\n");
+    while(!interrupted){
+        vmi_events_listen(vmi,500);
+    }
+    printf("Finished with test.\n");
+
+leave:
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -121,6 +121,10 @@ struct driver_instance {
     vmi_instance_t,
     reg_event_t);
     status_t (
+    *set_intr_access_ptr)(
+    vmi_instance_t,
+    interrupt_event_t);
+    status_t (
     *set_mem_access_ptr)(
     vmi_instance_t,
     mem_event_t,
@@ -175,6 +179,7 @@ driver_xen_setup(
 #if ENABLE_XEN_EVENTS==1
     instance->events_listen_ptr = &xen_events_listen;
     instance->set_reg_access_ptr = &xen_set_reg_access;
+    instance->set_intr_access_ptr = &xen_set_intr_access;
     instance->set_mem_access_ptr = &xen_set_mem_access;
     instance->start_single_step_ptr = &xen_start_single_step;
     instance->stop_single_step_ptr = &xen_stop_single_step;
@@ -215,6 +220,7 @@ driver_kvm_setup(
 #endif
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
+    instance->set_intr_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
     instance->start_single_step_ptr = NULL;
     instance->stop_single_step_ptr = NULL;
@@ -247,6 +253,7 @@ driver_file_setup(
     instance->resume_vm_ptr = &file_resume_vm;
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
+    instance->set_intr_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
     instance->start_single_step_ptr = NULL;
     instance->stop_single_step_ptr = NULL;
@@ -277,6 +284,7 @@ driver_null_setup(
     instance->resume_vm_ptr = NULL;
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
+    instance->set_intr_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
     instance->start_single_step_ptr = NULL;
     instance->stop_single_step_ptr = NULL;
@@ -706,6 +714,20 @@ status_t driver_set_reg_access(
     }
     else{
         dbprint("WARNING: driver_set_reg_w_access function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+status_t driver_set_intr_access(
+    vmi_instance_t vmi,
+    interrupt_event_t event)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->set_intr_access_ptr){
+        return ptrs->set_intr_access_ptr(vmi, event);
+    }
+    else{
+        dbprint("WARNING: driver_set_intr_access function not implemented.\n");
         return VMI_FAILURE;
     }
 }

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -102,6 +102,9 @@ status_t driver_set_mem_access(
     vmi_instance_t vmi,
     mem_event_t event,
     vmi_mem_access_t page_access_flag);
+status_t driver_set_intr_access(
+    vmi_instance_t vmi,
+    interrupt_event_t event);
 status_t driver_set_reg_access(
     vmi_instance_t vmi,
     reg_event_t event);

--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -102,6 +102,8 @@ status_t xen_events_init(vmi_instance_t vmi);
 void xen_events_destroy(vmi_instance_t vmi);
 status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
 status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event);
+status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t event);
+status_t xen_set_int3_access(vmi_instance_t vmi, interrupt_event_t event);
 status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event, vmi_mem_access_t page_access_flag);
 status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t event);
 status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu);

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1435,7 +1435,8 @@ typedef enum {
     VMI_EVENT_INVALID,
     VMI_EVENT_MEMORY,    /* Read/write/execute on a region of memory */
     VMI_EVENT_REGISTER,  /* Read/write of a specific register */
-    VMI_EVENT_SINGLESTEP /* Instructions being executed on a set of VCPUs */
+    VMI_EVENT_SINGLESTEP,/* Instructions being executed on a set of VCPUs */
+    VMI_EVENT_INTERRUPT  /* Interrupts being delivered */
 } vmi_event_type_t;
 
 /* max number of vcpus we can set single step on at one time for a domain */
@@ -1566,6 +1567,19 @@ typedef struct {
                                              */
 } mem_event_t;
 
+typedef enum {
+    INT_INVALID,
+    INT3                /* The only one supported today by the only capable-driver */
+} interrupts_t;
+
+typedef struct {
+    addr_t gla;         /* (Global Linear Address) == RIP of the trapped instruction */
+    addr_t gfn;         /* (Guest Frame Number) == 'physical' page where trap occurred */
+    interrupts_t intr;  /* Specific interrupt intended to trigger the event */
+    int reinject:1;     /* Toggle, controls whether interrupt is re-injected after callback */ 
+    int enabled:1;      /* Toggle */ 
+} interrupt_event_t;
+
 typedef struct {
     addr_t gla;      /* The IP of the current instruction */
     addr_t gfn;      /* The physical page of the current instruction */
@@ -1601,6 +1615,7 @@ struct vmi_event {
         reg_event_t reg_event;
         mem_event_t mem_event;
         single_step_event_t ss_event;
+        interrupt_event_t interrupt_event;
     };
 
     uint32_t vcpu_id; /* The VCPU relative to which the event occurred. */

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -113,6 +113,8 @@ struct vmi_instance {
     uint32_t memory_cache_size_max;/**< max size of memory cache */
 
     unsigned int num_vcpus; /**< number of VCPUs used by this instance */
+    
+    GHashTable *interrupt_events; /**< interrupt event to function mapping (key: interrupt) */
 
     GHashTable *mem_events; /**< mem event to functions mapping (key: physical address) */
 

--- a/notes/embedded-int3.c
+++ b/notes/embedded-int3.c
@@ -1,0 +1,30 @@
+/* used to help test the int3 events 
+ *  Provides ability to test both 0xCC and 0xCD03
+ *  variants of the INT3 breakpoint.
+ *
+ * Author: Steve Maresca <steve@zentific.com>
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main() {
+	printf("pid %d\n", getpid());
+	
+	sleep(10);
+
+#ifndef int3imm8
+	/* default int3 with a 1 byte opcode */
+	asm("int $3");
+#else
+	/* non-standard int3 with a 2-byte instruction of INTNN imm8 style 
+	 *	As far as I know gcc won't emit that, so need to do this
+	 * 	manually
+	 */
+	asm __volatile__ (".byte 0xcd; .byte 0x03;");
+#endif
+	printf("Hello World\n");
+	return 0;
+}

--- a/notes/events.txt
+++ b/notes/events.txt
@@ -1,7 +1,7 @@
 LibVMI Events
 Author: Steven Maresca <steve@zentific.com>
-Document: version 1.0, 2013-05-18
-Relevant LibVMI release: 0.10
+Document: version 1.1, 2013-09-10
+Relevant LibVMI release: 0.11
 
 Overview:
 --------------------------------------------------------------------------------
@@ -18,6 +18,7 @@ provide the requisite features:
     Register events to observe read and write access to specific VCPU
      registers, including CR0, CR3, CR4, and MSR registers.
     Single-step events for each instruction executed upon a VCPU/set of VCPUs.
+    Interrupt events (e.g., INT3)
 
 This new set of features is made possible by the flexibility of modern
 hypervisors, which provide rich access to their internal facilities. In
@@ -164,7 +165,7 @@ Limitations:
 
 1) General support of hypervisors
 
-As of 0.10, only the Xen driver provides event capabilities; regrettably, such
+For 0.10+, only the Xen driver provides event capabilities; regrettably, such
 events are not available in a useable fashion for KVM. However, if upstream KVM
 and QEMU developers provide the ability to do so, LibVMI developers will add
 support as soon as possible. (NOTE: KVM by design does make this type of event
@@ -178,11 +179,27 @@ implement this feature for KVM.)
 
 MSR register events are only available for Xen version 4.3 and newer.
 
+3) Interrupt event support
+
+INT3 events for Xen version 4.1.x and newer. Best supported by 4.2.3 and newer.
+
+INT3 events are reported via the event facilities of Xen for only the
+1-byte 0xCC variant of the operation.  The 2-byte 0xCD imm8 variant which takes
+the interrupt vector as an operand (i.e., 0xCD03) is NOT reported in the
+same fashion (Note: This observation is valid at time of writing for Xen 4.3
+and earlier.) Because only 0xCC is in play for this class of event, the
+instruction length involved is always one byte.
+
+Warning: For INT3 to be handled correctly by the VM kernel and subsequently
+passed on to the debugger within a VM (via OS-specified signalling mechanism),
+the trap must be re-injected. Failure to do so may constitute a serious error.
+
 3) Xen version capabilities
 
 Xen memory events in general are only supported for Xen 4.1.2 and newer.
 
 4) Documentation bias
+
 At the time this document was first written, Xen was the only hypervisor
 with an events framework supported by LibVMI. As such, some of the behavior
 described may be Xen-specific; however, it is expected that similar or identical

--- a/notes/int3-variants-disassembly.txt
+++ b/notes/int3-variants-disassembly.txt
@@ -1,0 +1,48 @@
+Disassembly of embedded-int3.c for both:
+  # One byte variant
+     gcc -o embedded-int3 -Dint3imm8=1 embedded-int3.c -O0
+  # Two byte variant
+     gcc -o embedded-int3 embedded-int3.c -O0
+
+1 byte variant, 0xCC:
+
+0000000000400594 <main>:
+  400594:	55                   	push   %rbp
+  400595:	48 89 e5             	mov    %rsp,%rbp
+  400598:	e8 f3 fe ff ff       	callq  400490 <getpid@plt>
+  40059d:	89 c2                	mov    %eax,%edx
+  40059f:	b8 c8 06 40 00       	mov    $0x4006c8,%eax
+  4005a4:	89 d6                	mov    %edx,%esi
+  4005a6:	48 89 c7             	mov    %rax,%rdi
+  4005a9:	b8 00 00 00 00       	mov    $0x0,%eax
+  4005ae:	e8 ad fe ff ff       	callq  400460 <printf@plt>
+  4005b3:	bf 0a 00 00 00       	mov    $0xa,%edi
+  4005b8:	e8 e3 fe ff ff       	callq  4004a0 <sleep@plt>
+  4005bd:	cc                   	int3   
+  4005be:	bf d0 06 40 00       	mov    $0x4006d0,%edi
+  4005c3:	e8 a8 fe ff ff       	callq  400470 <puts@plt>
+  4005c8:	b8 00 00 00 00       	mov    $0x0,%eax
+  4005cd:	c9                   	leaveq 
+  4005ce:	c3                   	retq   
+  4005cf:	90                   	nop
+
+2 byte variant, 0xCD03:
+
+0000000000400594 <main>:
+  400594:	55                   	push   %rbp
+  400595:	48 89 e5             	mov    %rsp,%rbp
+  400598:	e8 f3 fe ff ff       	callq  400490 <getpid@plt>
+  40059d:	89 c2                	mov    %eax,%edx
+  40059f:	b8 c8 06 40 00       	mov    $0x4006c8,%eax
+  4005a4:	89 d6                	mov    %edx,%esi
+  4005a6:	48 89 c7             	mov    %rax,%rdi
+  4005a9:	b8 00 00 00 00       	mov    $0x0,%eax
+  4005ae:	e8 ad fe ff ff       	callq  400460 <printf@plt>
+  4005b3:	bf 0a 00 00 00       	mov    $0xa,%edi
+  4005b8:	e8 e3 fe ff ff       	callq  4004a0 <sleep@plt>
+  4005bd:	cd 03                	int    $0x3
+  4005bf:	bf d0 06 40 00       	mov    $0x4006d0,%edi
+  4005c4:	e8 a7 fe ff ff       	callq  400470 <puts@plt>
+  4005c9:	b8 00 00 00 00       	mov    $0x0,%eax
+  4005ce:	c9                   	leaveq 
+  4005cf:	c3                   	retq   


### PR DESCRIPTION
Generalized boilerplate supporting drivers that offer interrupt event capabilities. Provides an extension to the Xen driver supporting Xen's only interrupt event, INT3.

Includes an example program handling INT3 events, and a small tool that can be used to generate events within a VM.

Follow-up PRs will include code to aid in binary instrumentation and, as an example, a very basic debugger.
