### PR TITLE
fix function signitures

### DIFF
--- a/examples/shm-snapshot-process-list.c
+++ b/examples/shm-snapshot-process-list.c
@@ -31,7 +31,7 @@
 #include <sys/mman.h>
 #include <stdio.h>
 
-void list_processes(vmi_instance_t* vmi, addr_t current_process,
+void list_processes(vmi_instance_t vmi, addr_t current_process,
     addr_t list_head, unsigned long tasks_offset, addr_t current_list_entry,
     status_t status, addr_t next_list_entry, unsigned long pid_offset,
     vmi_pid_t pid, char* procname, unsigned long name_offset) {

--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -646,7 +646,7 @@ sym_cache_get(
     vmi_instance_t vmi,
     addr_t base_addr,
     vmi_pid_t pid,
-    char *sym,
+    const char *sym,
     addr_t *va)
 {
     return VMI_FAILURE;
@@ -657,7 +657,7 @@ sym_cache_set(
     vmi_instance_t vmi,
     addr_t base_addr,
     vmi_pid_t pid,
-    char *sym,
+    const char *sym,
     addr_t va)
 {
     return;


### PR DESCRIPTION
1. cache.c : prevent compilation error when #define ENABLE_ADDRESS_CACHE 0
2. shm-snapshot-process-list.c : remove compiler warnings
