### PR TITLE
TEVAT & DGVMA : speedup guest virtual memory access with shm-snapshot

### DIFF
--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -114,8 +114,12 @@ struct driver_instance {
 	vmi_instance_t);
 	const void * (
 	*get_dgpma_ptr) (
-	vmi_instance_t);
-	status_t (
+    vmi_instance_t);
+    const void* (
+    *get_dgvma_ptr) (
+    vmi_instance_t,
+    pid_t);
+    status_t (
     *events_listen_ptr)(
     vmi_instance_t,
     uint32_t);
@@ -227,10 +231,12 @@ driver_kvm_setup(
 	instance->create_shm_snapshot_ptr = &kvm_create_shm_snapshot;
 	instance->destroy_shm_snapshot_ptr = &kvm_destroy_shm_snapshot;
 	instance->get_dgpma_ptr = &kvm_get_dgpma;
+	instance->get_dgvma_ptr = &kvm_get_dgvma;
 #else
 	instance->create_shm_snapshot_ptr = NULL;
 	instance->destroy_shm_snapshot_ptr = NULL;
 	instance->get_dgpma_ptr = NULL;
+	instance->get_dgvma_ptr = NULL;
 #endif
     instance->events_listen_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
@@ -704,7 +710,8 @@ status_t driver_destroy_shm_snapshot_vm(
 }
 
 const void * driver_get_dgpma(
-    vmi_instance_t vmi) {
+    vmi_instance_t vmi)
+{
     driver_instance_t ptrs = driver_get_instance(vmi);
 
     if (NULL != ptrs && NULL != ptrs->get_dgpma_ptr) {
@@ -712,9 +719,24 @@ const void * driver_get_dgpma(
     }
     else {
         dbprint("WARNING: get_dgpma_ptr function not implemented.\n");
-        return VMI_FAILURE;
+        return NULL;
     }
+}
 
+const void* driver_get_dgvma(
+	vmi_instance_t vmi,
+    pid_t pid)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+
+    if (NULL != ptrs && NULL != ptrs->get_dgvma_ptr) {
+        return ptrs->get_dgvma_ptr(vmi, pid);
+    }
+    else {
+        dbprint("WARNING: driver_get_dgvma function not implemented.\n");
+        return NULL;
+    }
+    return NULL;
 }
 #endif
 

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -88,7 +88,7 @@ status_t driver_resume_vm(
     vmi_instance_t vmi);
 #if ENABLE_SHM_SNAPSHOT == 1
 /* "shm-snapshot" feature is applicable to
- * hypervisor drivers (e.g. KVM, Xen), and not to the
+ * hypervisor drivers (e.g. KVM, Xen), but not to the
  * other drivers (e.g. File). */
 status_t driver_shm_snapshot_vm(
     vmi_instance_t vmi);
@@ -96,6 +96,9 @@ status_t driver_destroy_shm_snapshot_vm(
     vmi_instance_t vmi);
 const void * driver_get_dgpma(
     vmi_instance_t vmi);
+const void* driver_get_dgvma(
+    vmi_instance_t vmi,
+    pid_t pid);
 #endif
 status_t driver_events_listen(
     vmi_instance_t vmi,

--- a/libvmi/driver/kvm.h
+++ b/libvmi/driver/kvm.h
@@ -28,6 +28,28 @@
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 
+#if ENABLE_SHM_SNAPSHOT == 1
+struct tevat_mapping_chunk_entry_struct{
+	addr_t vaddr_begin;
+	addr_t vaddr_end;
+	addr_t paddr_begin;
+	addr_t paddr_end;
+	struct tevat_mapping_chunk_entry_struct* next;
+};
+typedef struct tevat_mapping_chunk_entry_struct tevat_mapping_chunk_entry;
+typedef struct tevat_mapping_chunk_entry_struct *tevat_mapping_chunk_entry_t;
+
+struct tevat_mapping_table_entry_struct {
+	pid_t pid;
+	tevat_mapping_chunk_entry_t chunks;
+	uint64_t vaddr_space_size;
+	void* vaddr_base;
+	struct tevat_mapping_table_entry_struct* next;
+};
+typedef struct tevat_mapping_table_entry_struct tevat_mapping_table_entry;
+typedef struct tevat_mapping_table_entry_struct *tevat_mapping_table_entry_t;
+#endif
+
 typedef struct kvm_instance {
     virConnectPtr conn;
     virDomainPtr dom;
@@ -41,6 +63,7 @@ typedef struct kvm_instance {
     int   shm_snapshot_fd;    /** file description of the shared memory snapshot device */
     void *shm_snapshot_map;   /** mapped shared memory region */
     char *shm_snapshot_cpu_regs;  /** string of dumped CPU registers */
+    tevat_mapping_table_entry_t shm_snapshot_tevat_mapping_table; /** TEVAT mappping table link list of all pids */
 #endif
 } kvm_instance_t;
 
@@ -111,4 +134,7 @@ status_t kvm_destroy_shm_snapshot(
     vmi_instance_t vmi);
 const void * kvm_get_dgpma(
     vmi_instance_t vmi);
+const void* kvm_get_dgvma(
+    vmi_instance_t vmi,
+    pid_t pid);
 #endif

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1320,7 +1320,6 @@ status_t vmi_shm_snapshot_create(
  */
 status_t vmi_shm_snapshot_destroy(
 		vmi_instance_t vmi);
-#endif
 
 /**
  * Direct Guest Physical Memory Access: Get a read-only pointer of shm-snapshot.
@@ -1332,6 +1331,24 @@ const void * vmi_get_dgpma(
     vmi_instance_t vmi);
 
 /**
+ * Direct Guest Virtual Memory Access: get a read-only pointer of the guest
+ * virtual memory related to a pid.  It provides a much faster (non-copy)
+ * option to read guest virtual memory bypassing vmi_read_va().
+ * Note:
+ * 1. It is dependent on shm-snapshot, if LibVMI isn't in shm-snapshot mode,
+ *    just return NULL;
+ * 2. It costs several hundred milliseconds to create a shadow addr mapping
+ *    (i.e. TEVAT mapping) for first use;
+ * 3. The TEVAT mappings will stay until vmi_shm_snapshot_destroy().
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] pid Pid of the virtual address space (0 for kernel)
+ * @return The base address of DGVMA
+ */
+const void * vmi_get_dgvma(
+    vmi_instance_t vmi,
+    pid_t pid);
+#endif
 
 /**
  * Removes all entries from LibVMI's internal virtual to physical address

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -474,6 +474,13 @@ addr_t vmi_pagetable_lookup (vmi_instance_t vmi, addr_t dtb, addr_t vaddr)
     return paddr;
 }
 
+#if ENABLE_SHM_SNAPSHOT == 1
+const void* vmi_get_dgvma(vmi_instance_t vmi, pid_t pid)
+{
+    return driver_get_dgvma(vmi, pid);
+}
+#endif
+
 /* expose virtual to physical mapping for kernel space via api call */
 addr_t vmi_translate_kv2p (vmi_instance_t vmi, addr_t virt_address)
 {


### PR DESCRIPTION
Transparent Efficient Virtual Address Translation (TEVAT):
Create a shadow mapping table of shm-snapshot in LibVMI address space, so MMU can help us translate the guest virtual address to physical one, bypassing vmi_translate_kv2p() and vmi_translate_uv2p().

Direct Guest Virtual Memory Access (DGVMA):
Based on TEVAT, users can acquire a read only pointer to the virtual memory base of shm-snapshot. It provides a much faster (non-copy) manner to read guest virtual memory bypassing vmi_read_va().

I add an API in this PR:

const void \* vmi_get_dgvma(vmi_instance_t vmi, pid_t pid);

Performance benchmark:
Achieve native memory read bandwidth with TEVAT and DGVMA. (3X ~ 4X speedup over legacy vmi_read_va())

![1](https://f.cloud.github.com/assets/667845/1134651/d5c0789a-1bf6-11e3-8def-c54aa611771f.png)

Advantages:
1. MMU assist address translation, so lower CPU consumption;
2. Direct virtual memory access, more efficiency.

Overhead:
The creation of a TEVAT mapping table can cost 0.1 second on my desktop.

Limitation:
just targeting KVM
