### PR TITLE
Fix mixup in the order of PID and base vaddr in vmi_translate_sym2v

### DIFF
--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -564,7 +564,7 @@ addr_t vmi_translate_sym2v (vmi_instance_t vmi, addr_t base_vaddr, vmi_pid_t pid
 
     if (VMI_FAILURE == sym_cache_get(vmi, base_vaddr, pid, symbol, &address)) {
 
-        if (vmi->os_interface && vmi->os_interface->os_ksym2v) {
+        if (vmi->os_interface && vmi->os_interface->os_usym2rva) {
             status  = vmi->os_interface->os_usym2rva(vmi, base_vaddr, pid, symbol, &rva);
             if (status == VMI_SUCCESS) {
                 address = base_vaddr + rva;

--- a/libvmi/os/windows/memory.c
+++ b/libvmi/os/windows/memory.c
@@ -66,7 +66,7 @@ windows_kernel_symbol_to_address(
 
     /* check exports */
     if (VMI_SUCCESS
-            == windows_export_to_rva(vmi, 0, windows->ntoskrnl_va, symbol,
+            == windows_export_to_rva(vmi, windows->ntoskrnl_va, 0, symbol,
                     address)) {
         addr_t rva = *address;
 

--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -529,8 +529,8 @@ peparse_get_export_table(
 status_t
 windows_export_to_rva(
     vmi_instance_t vmi,
-    vmi_pid_t pid,
     addr_t base_vaddr,
+    vmi_pid_t pid,
     const char *symbol,
     addr_t *rva)
 {

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -53,7 +53,7 @@ status_t
 windows_kernel_symbol_to_address(vmi_instance_t vmi, const char *symbol,
         addr_t *kernel_base_address, addr_t *address);
 status_t
-windows_export_to_rva(vmi_instance_t vmi, vmi_pid_t pid, addr_t base_vaddr,
+windows_export_to_rva(vmi_instance_t vmi, addr_t base_vaddr, vmi_pid_t pid,
         const char *symbol, addr_t *rva);
 char*
 windows_rva_to_export(vmi_instance_t vmi, addr_t rva, addr_t base_vaddr,


### PR DESCRIPTION
There was a bug caused by discrepancy in the order of the PID and base_vaddr input between what was in libvmi.h and how the internal function took the inputs. Changed them internally to avoid future issues.
