### PR TITLE
Additional safety check

### DIFF
--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -184,6 +184,9 @@ find_aon_idx_bin(
 
     // get the curr string & compare to symbol
     name = rva_to_string(vmi, (addr_t) str_rva, base_addr, pid);
+    if(!name)
+        goto not_found;
+
     cmp = strcmp(symbol, name);
     free(name);
 


### PR DESCRIPTION
Add extra safety check in get_aon_idx_bin. I seem to have encountered an image where this returns NULL and segfaults libvmi at the strcmp line.
