### PR TITLE
Fix unicode string read function for Windows x64 and update module-list example.

### DIFF
--- a/examples/module-list.c
+++ b/examples/module-list.c
@@ -94,10 +94,21 @@ main(
             free(modname);
         }
         else if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)) {
-            /*TODO don't use a hard-coded offsets here */
-            /* this offset works with WinXP SP2 */
-            unicode_string_t *us =
-                vmi_read_unicode_str_va(vmi, next_module + 0x2c, 0);
+
+            unicode_string_t *us = NULL;
+
+            /*
+             * The offset 0x58 and 0x2c is the offset in the _LDR_DATA_TABLE_ENTRY structure
+             * to the BaseDllName member.
+             * These offset values are stable (at least) between XP and Windows 7.
+             */
+
+            if (VMI_PM_IA32E == vmi_get_page_mode(vmi)) {
+                us = vmi_read_unicode_str_va(vmi, next_module + 0x58, 0);
+            } else {
+                us = vmi_read_unicode_str_va(vmi, next_module + 0x2c, 0);
+            }
+
             unicode_string_t out = { 0 };
             //         both of these work
             if (us &&

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -450,7 +450,7 @@ vmi_read_win_unicode_struct_va(
                  __FUNCTION__, vaddr, pid);
             goto out_error;
         }   // if
-        buffer_va = us64.pBuffer;
+        buffer_va = (vaddr & 0xFFFFFFFF00000000) + (us64.pBuffer >> 32);
         buffer_len = us64.length;
     }
     else {


### PR DESCRIPTION
Under Windows7 x64 the unicode string reading function wasn't returning anything. After some debugging and comparing the values to Volatility I noticed the following pattern:

LibVMI was trying to read the unicode buffer from, for example, the VA 0x234221800000000 for a module with base VA 0xfffffa8000000000, which failed. At the same time Volatility succeeded, but the offset Volatility used was 0xfffffa8002342218.

Changing the buffer VA address to be (vaddr & 0xFFFFFFFF00000000) + (us64.pBuffer >> 32) solved the issue. Maybe someone with a better understanding of the x64 Windows unicode management can verify this, but it works for me for both the kernel module list and for walking the PEB lists.

I'm also updating the module-list example to work with 64-bit Windows.
