### PR TITLE
LibVMI cache : bug fix and unit test

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -83,7 +83,7 @@ static gboolean key_128_equals(gconstpointer key1, gconstpointer key2){
  */
 static void key_128_init(vmi_instance_t vmi, key_128_t key, uint64_t low, uint64_t high)
 {
-    low = (low & ~(vmi->page_size - 1));
+    low = (low & ~((uint64_t)vmi->page_size - 1));
     key->low = low;
     key->high = high;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,10 @@ check_libvmi_SOURCES = \
     test_write.c \
     test_peparse.c \
     test_shm_snapshot.c \
+    test_cache.c \
+    ../libvmi/cache.c \
+    ../libvmi/convenience.c \
     $(top_builddir)/libvmi/libvmi.h
 
-check_libvmi_CFLAGS = @CHECK_CFLAGS@
+check_libvmi_CFLAGS = @CHECK_CFLAGS@ @GLIB_CFLAGS@ -I../libvmi/
 check_libvmi_LDADD = $(top_builddir)/libvmi/libvmi.la @CHECK_LIBS@

--- a/tests/check_runner.c
+++ b/tests/check_runner.c
@@ -63,6 +63,7 @@ main (void)
 #if ENABLE_SHM_SNAPSHOT == 1
     suite_add_tcase(s, shm_snapshot_tcase());
 #endif
+    suite_add_tcase(s, cache_tcase());
 
     /* run the tests */
     SRunner *sr = srunner_create(s);

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -1,0 +1,62 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2012 VMITools Project
+ *
+ * Author: Bryan D. Payne (bdpayne@acm.org), Guanglin Xu (mzguanglin@gmail.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <check.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include "../libvmi/libvmi.h"
+#include "check_tests.h"
+#include "../libvmi/private.h"
+
+/* test cache */
+START_TEST (test_libvmi_cache)
+{
+    vmi_instance_t vmi = NULL;
+    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+
+    v2p_cache_flush(vmi);
+    v2p_cache_set(vmi, 0x400000, 0xabcde, 0x3b40a000);
+
+    addr_t pa = 0;
+    ret = v2p_cache_get(vmi, 0x880000400000ull, 0xabcde, &pa);
+    fail_if(ret == VMI_SUCCESS, "hit a wrong cache");
+
+    /* @awsaba 's complementary */
+    ret = v2p_cache_get(vmi, 0x00000400000ull, 0xabcde, &pa);
+    fail_if(ret == VMI_FAILURE, "cache entry not found");
+
+    v2p_cache_flush(vmi);
+    vmi_destroy(vmi);
+}
+END_TEST
+
+/* cache test cases */
+TCase *cache_tcase (void)
+{
+    TCase *tc_init = tcase_create("LibVMI cache");
+    tcase_add_test(tc_init, test_libvmi_cache);
+    return tc_init;
+}


### PR DESCRIPTION
1. fix the bug : key_128_int() misses the high 32bits of the uint64_t low.
   As vmi->page_size is a uint32_t type, we can't assume it the same as uint64_t when using the bitwise NOT of it.
2. unit test for LibVMI cache

Thanks to awsaba's help in fixing and unit testing.
