### PR TITLE
Direct Guest Memory Access for Shm-snapshot

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -203,11 +203,6 @@ vmi_shm_snapshot_destroy(
 {
     return driver_destroy_shm_snapshot_vm(vmi);
 }
-
-const void * vmi_get_dgpma(
-    vmi_instance_t vmi) {
-    return driver_get_dgpma(vmi);
-}
 #endif
 
 char *

--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -24,10 +24,11 @@
  * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Three kinds of cache:
+// Four kinds of cache:
 //  1) PID --> DTB
 //  2) Symbol --> Virtual address
 //  3) Virtual address --> physical address
+//  4) Virtual address --> Medial address (for dgvma of shm-snapshot)
 
 #include "libvmi.h"
 #include "private.h"
@@ -579,6 +580,117 @@ v2p_cache_flush(
     dbprint("--V2P cache flushed\n");
 }
 
+#if ENABLE_SHM_SNAPSHOT == 1
+//
+// Virtual address --> Medial address cache implementation
+struct v2m_cache_entry {
+    addr_t ma;
+    uint64_t length;
+    addr_t last_used;
+};
+typedef struct v2m_cache_entry *v2m_cache_entry_t;
+
+static v2m_cache_entry_t v2m_cache_entry_create (vmi_instance_t vmi, addr_t ma, uint64_t length)
+{
+    v2m_cache_entry_t entry = (v2m_cache_entry_t) safe_malloc(sizeof(struct v2m_cache_entry));
+    ma &= ~((addr_t)vmi->page_size - 1);
+    entry->ma = ma;
+    entry->length = length;
+    entry->last_used = time(NULL);
+    return entry;
+}
+
+void
+v2m_cache_init(
+    vmi_instance_t vmi)
+{
+    vmi->v2m_cache = g_hash_table_new_full((GHashFunc) key_128_hash, key_128_equals, g_free, g_free);
+}
+
+void
+v2m_cache_destroy(
+    vmi_instance_t vmi)
+{
+    g_hash_table_destroy(vmi->v2m_cache);
+}
+
+status_t
+v2m_cache_get(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid,
+    addr_t *ma,
+    uint64_t *length)
+{
+    v2m_cache_entry_t entry = NULL;
+    struct key_128 local_key;
+    key_128_t key = &local_key;
+
+    key_128_init(vmi, key, (uint64_t)va, (uint64_t)pid);
+
+    if ((entry = g_hash_table_lookup(vmi->v2m_cache, key)) != NULL) {
+
+        entry->last_used = time(NULL);
+        *ma = entry->ma | ((vmi->page_size - 1) & va);
+        *length = entry->length;
+        dbprint("--v2m cache hit 0x%.16"PRIx64" -- 0x%.16"PRIx64" len 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n",
+                va, *ma, *length, key->high, key->low);
+        return VMI_SUCCESS;
+    }
+
+    return VMI_FAILURE;
+}
+
+void
+v2m_cache_set(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid,
+    addr_t ma,
+    uint64_t length)
+{
+    if (!va || !ma) {
+        return;
+    }
+    key_128_t key = key_128_build(vmi, (uint64_t)va, (uint64_t)pid);
+    v2m_cache_entry_t entry = v2m_cache_entry_create(vmi, ma, length);
+    g_hash_table_insert(vmi->v2m_cache, key, entry);
+    dbprint("--v2m cache set 0x%.16"PRIx64" -- 0x%.16"PRIx64" len 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
+            ma, length, key->high, key->low);
+}
+
+status_t
+v2m_cache_del(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid)
+{
+    struct key_128 local_key;
+    key_128_t key = &local_key;
+    key_128_init(vmi, key, (uint64_t)va, (uint64_t)pid);
+    dbprint("--v2m cache del 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
+            key->high, key->low);
+
+    // key collision doesn't really matter here because worst case
+    // scenario we incur an small performance hit
+
+    if (TRUE == g_hash_table_remove(vmi->v2m_cache, key)){
+        return VMI_SUCCESS;
+    }
+    else{
+        return VMI_FAILURE;
+    }
+}
+
+void
+v2m_cache_flush(
+    vmi_instance_t vmi)
+{
+    g_hash_table_remove_all(vmi->v2m_cache);
+    dbprint("--v2m cache flushed\n");
+}
+#endif
+
 #else
 void
 pid_cache_init(
@@ -782,6 +894,60 @@ v2p_cache_flush(
 {
     return;
 }
+
+#if ENABLE_SHM_SNAPSHOT == 1
+void
+v2m_cache_init(
+    vmi_instance_t vmi)
+{
+    return;
+}
+
+void
+v2m_cache_destroy(
+    vmi_instance_t vmi)
+{
+    return;
+}
+
+status_t
+v2m_cache_get(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid,
+    addr_t *ma,
+    uint64_t *length)
+{
+    return VMI_FAILURE;
+}
+
+void
+v2m_cache_set(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid,
+    addr_t ma,
+    uint64_t length)
+{
+    return;
+}
+
+status_t
+v2m_cache_del(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid)
+{
+    return VMI_FAILURE;
+}
+
+void
+v2m_cache_flush(
+    vmi_instance_t vmi)
+{
+    return;
+}
+#endif
 #endif
 
 // Below are wrapper functions for external API access to the cache

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -494,6 +494,9 @@ vmi_init_private(
     sym_cache_init(*vmi);
     rva_cache_init(*vmi);
     v2p_cache_init(*vmi);
+#if ENABLE_SHM_SNAPSHOT == 1
+    v2m_cache_init(*vmi);
+#endif
 
     /* connecting to xen, kvm, file, etc */
     if (VMI_FAILURE == set_driver_type(*vmi, access_mode, id, name)) {
@@ -746,7 +749,9 @@ vmi_destroy(
     pid_cache_destroy(vmi);
     sym_cache_destroy(vmi);
     rva_cache_destroy(vmi);
-    v2p_cache_destroy(vmi);
+#if ENABLE_SHM_SNAPSHOT == 1
+    v2m_cache_destroy(vmi);
+#endif
     memory_cache_destroy(vmi);
     if (vmi->image_type)
         free(vmi->image_type);

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -88,14 +88,23 @@ status_t driver_resume_vm(
     vmi_instance_t vmi);
 #if ENABLE_SHM_SNAPSHOT == 1
 /* "shm-snapshot" feature is applicable to
- * hypervisor drivers (e.g. KVM, Xen), and not to the
+ * hypervisor drivers (e.g. KVM, Xen), but not to the
  * other drivers (e.g. File). */
 status_t driver_shm_snapshot_vm(
     vmi_instance_t vmi);
 status_t driver_destroy_shm_snapshot_vm(
     vmi_instance_t vmi);
-const void * driver_get_dgpma(
-    vmi_instance_t vmi);
+size_t driver_get_dgpma(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    void** guest_mapping_paddr,
+    size_t count);
+size_t driver_get_dgvma(
+    vmi_instance_t vmi,
+    addr_t vaddr,
+    pid_t pid,
+    void** guest_mapping_vaddr,
+    size_t count);
 #endif
 status_t driver_events_listen(
     vmi_instance_t vmi,

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -2176,9 +2176,16 @@ xen_destroy_shm_snapshot(
     return xen_setup_live_mode(vmi);
 }
 
-const void * xen_get_dgpma(
-    vmi_instance_t vmi) {
-    return xen_get_instance(vmi)->shm_snapshot_map;
+size_t
+xen_get_dgpma(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    void** medial_addr_ptr,
+    size_t count) {
+
+    *medial_addr_ptr = xen_get_instance(vmi)->shm_snapshot_map + paddr;
+    size_t max_size = vmi->size - (paddr - 0);
+    return max_size>count?count:max_size;
 }
 #endif
 
@@ -2362,9 +2369,14 @@ xen_destroy_shm_snapshot(
     return VMI_FAILURE;
 }
 
-const void * xen_get_dgpma(
-    vmi_instance_t vmi) {
-    return NULL;
+size_t
+xen_get_dgpma(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    void** medial_addr_ptr,
+    size_t count)
+{
+    return 0;
 }
 #endif
 

--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -170,6 +170,9 @@ status_t xen_create_shm_snapshot(
     vmi_instance_t vmi);
 status_t xen_destroy_shm_snapshot(
     vmi_instance_t vmi);
-const void * xen_get_dgpma(
-    vmi_instance_t vmi);
+size_t xen_get_dgpma(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    void** medial_addr_ptr,
+    size_t count);
 #endif

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1320,16 +1320,41 @@ status_t vmi_shm_snapshot_create(
  */
 status_t vmi_shm_snapshot_destroy(
     vmi_instance_t vmi);
-#endif
 
 /**
- * Direct Guest Physical Memory Access: Get a read-only pointer of shm-snapshot.
- * This function provides a much faster (non-copy) option to read guest physical
- * memory bypassing vmi_read_pa().
- * If the shm-snapshot hasn't been created yet, it returns NULL.
+ * Direct Guest Physical Memory Access:  A similar memory read semantic to
+ *  vmi_read_pa() but a non-copy direct access.
+ * Note that it is only capable for shm-snapshot.
+ * @param[in] vmi LibVMI instance
+ * @param[in] paddr
+ * @param[out] medial_addr_ptr
+ * @param[in] count the expected count of bytes
+ * @return the actual count that less or equal than count[in]
  */
-const void * vmi_get_dgpma(
-    vmi_instance_t vmi);
+size_t vmi_get_dgpma(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    void **buf_ptr,
+    size_t count);
+
+/**
+ * Direct Guest Virtual Memory Access:  A similar memory read semantic to
+ *  vmi_read_pa() but a non-copy direct access.
+ * Note that it is only capable for shm-snapshot.
+ * @param[in] vmi LibVMI instance
+ * @param[in] vaddr
+ * @param[in] pid
+ * @param[out] medial_addr_ptr
+ * @param[in] count the expected count of bytes
+ * @return the actual count that less or equal than count[in]
+ */
+size_t vmi_get_dgvma(
+    vmi_instance_t vmi,
+    addr_t vaddr,
+    pid_t pid,
+    void **buf_ptr,
+    size_t count);
+#endif
 
 /**
  * Removes all entries from LibVMI's internal virtual to physical address

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -100,6 +100,10 @@ struct vmi_instance {
 
     GHashTable *v2p_cache;  /**< hash table to hold the v2p cache data */
 
+#if ENABLE_SHM_SNAPSHOT == 1
+    GHashTable *v2m_cache;  /**< hash table to hold the v2m cache data */
+#endif
+
     void *driver;           /**< driver-specific information */
 
     GHashTable *memory_cache;  /**< hash table for memory cache */
@@ -251,6 +255,30 @@ typedef struct _windows_unicode_string32 {
     addr_t dtb);
     void v2p_cache_flush(
     vmi_instance_t vmi);
+#if ENABLE_SHM_SNAPSHOT == 1
+    void v2m_cache_init(
+    vmi_instance_t vmi);
+    void v2m_cache_destroy(
+    vmi_instance_t vmi);
+    status_t v2m_cache_get(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid,
+    addr_t *ma,
+    uint64_t *length);
+    void v2m_cache_set(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid,
+    addr_t ma,
+    uint64_t length);
+    status_t v2m_cache_del(
+    vmi_instance_t vmi,
+    addr_t va,
+    pid_t pid);
+    void v2m_cache_flush(
+    vmi_instance_t vmi);
+#endif
 
 /*-----------------------------------------
  * core.c

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -148,6 +148,29 @@ vmi_read_va(
     return buf_offset;
 }
 
+#if ENABLE_SHM_SNAPSHOT == 1
+size_t
+vmi_get_dgpma(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    void **buf_ptr,
+    size_t count)
+{
+    return driver_get_dgpma(vmi, paddr, buf_ptr, count);
+}
+
+size_t
+vmi_get_dgvma(
+    vmi_instance_t vmi,
+    addr_t vaddr,
+    pid_t pid,
+    void **buf_ptr,
+    size_t count)
+{
+    return driver_get_dgvma(vmi, vaddr, pid, buf_ptr, count);
+}
+#endif
+
 size_t
 vmi_read_ksym(
     vmi_instance_t vmi,


### PR DESCRIPTION
##### Introduce non-copy guest memory read for shm-snapshot, which has drastically reduced memory read latency.
##### I add two APIs in this PR:

```
size_t vmi_get_dgpma(vmi_instance_t vmi, addr_t paddr, void **buf_ptr, size_t count);
size_t vmi_get_dgvma(vmi_instance_t vmi, addr_t vaddr, pid_t pid, void **buf_ptr, size_t count);
```

Both of which are similar to vmi_read_pa() / vmi_read_va(), except the non-copy manners.
##### Principle:

Medial address mapping strategy to ensure continous address mappings so that direct access can be possible.
##### Performance benchmark:

at least 5.6x speedup with minimal one page block in terms of the reduction of guest memory access latency.

![dgma](https://f.cloud.github.com/assets/667845/1337038/22e6ec56-35d0-11e3-9106-222963151d14.png)
