### PR TITLE
Clear memory events when no callback is issued

### DIFF
--- a/examples/step-memevent-example.c
+++ b/examples/step-memevent-example.c
@@ -74,6 +74,7 @@ void mm_callback(vmi_instance_t vmi, vmi_event_t *event) {
         interrupted = 1;
     } else {
         printf("\tEvent on same page, but not the same RIP");
+        vmi_clear_event(vmi, event);
         vmi_step_mem_event(vmi, event, 1);
     }
 

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -185,7 +185,9 @@ void rereg_mem_events(vmi_instance_t vmi, vmi_event_t *singlestep_event)
 
         rereg_memevent_wrapper_t *wrap = (rereg_memevent_wrapper_t *)rereg_list->data;
 
-        wrap->steps--;
+        if(wrap->event->vcpu_id == singlestep_event->vcpu_id) {
+            wrap->steps--;
+        }
 
         if(0 == wrap->steps) {
             vmi_register_event(vmi, wrap->event);
@@ -697,12 +699,7 @@ status_t vmi_step_mem_event(vmi_instance_t vmi, vmi_event_t *event, uint64_t ste
         goto done;
     }
 
-    if(VMI_SUCCESS != vmi_clear_event(vmi, event))
-    {
-        goto done;
-    }
-
-    //setup single step event to re-register the memevent
+    // setup single step event to re-register the memevent
     vmi_event_t *single_event = g_malloc0(sizeof(vmi_event_t));
     single_event->type = VMI_EVENT_SINGLESTEP;
     single_event->callback = rereg_mem_events;


### PR DESCRIPTION
When using byte events it can be the case that no callback is issued when a page fault is trapped. In those cases, the events registered for that paged have to be cleared and added to the reregistration list used by vmi_step_mem_event.
