### PR TITLE
Make vmi_step_mem_event universal so it can be called with any type of e...

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -17,7 +17,7 @@ bin_PROGRAMS =  module-list \
                 msr-event-example \
                 singlestep-event-example \
                 interrupt-event-example \
-                step-memevent-example
+                step-event-example
 
 module_list_SOURCES = module-list.c
 process_list_SOURCES = process-list.c
@@ -30,4 +30,4 @@ msr_event_example_SOURCES = msr-event-example.c
 singlestep_event_example_SOURCES = singlestep-event-example.c
 interrupt_event_example_SOURCES = interrupt-event-example.c
 win_guid_SOURCES = win-guid.c
-step_memevent_example_SOURCES = step-memevent-example.c
+step_event_example_SOURCES = step-event-example.c

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1797,19 +1797,25 @@ vmi_event_t *vmi_get_mem_event(
     vmi_memevent_granularity_t granularity);
 
 /**
- * Setup single-stepping to re-register the given memory event
- *
- * This function is intended to be called in the callback routine of a memory event.
+ * Setup single-stepping to register the given event
+ * after the specified number of steps.
  *
  * @param[in] vmi LibVMI instance
- * @param[in] event The memory event to re-register
- * @param[in] steps The number of steps to take before re-registering
+ * @param[in] event The event to register
+ * @param[in] vcpu_id The vCPU ID to step the event on.
+ * @param[in] steps The number of steps to take before registering the event
+ * @param[in] cb Optional: A callback function to call after the specified number of steps.
+ *                         If no callback is provided, the event will be re-registered
+                           automatically. If a callback is provided, event re-registration
+                           is not automatic, but can be done in the callback.
  * @return VMI_SUCCESS or VMI_FAILURE
  */
-status_t vmi_step_mem_event(
+status_t vmi_step_event(
     vmi_instance_t vmi,
     vmi_event_t *event,
-    uint64_t steps);
+    uint32_t vcpu_id,
+    uint64_t steps,
+    event_callback_t cb);
 
 /**
  * Listen for events until one occurs or a timeout.

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -127,7 +127,9 @@ struct vmi_instance {
 
     GHashTable *ss_events; /**< single step event to functions mapping (key: vcpu_id) */
 
-    GSList *step_memevents; /**< memory events to be re-registered after single-stepping them */
+    GSList *step_events; /**< events to be re-registered after single-stepping them */
+
+    uint32_t step_vcpus[MAX_SINGLESTEP_VCPUS]; /**< counter of events on vcpus for which we have internal singlestep enabled */
 
     gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
 };
@@ -143,11 +145,13 @@ typedef struct memevent_page {
 
 } memevent_page_t;
 
-/** Memevent singlestep reregister wrapper */
-typedef struct rereg_memevent_wrapper {
+/** Event singlestep reregister wrapper */
+typedef struct step_and_reg_event_wrapper {
     vmi_event_t *event;
+    uint32_t vcpu_id;
     uint64_t steps;
-} rereg_memevent_wrapper_t;
+    event_callback_t cb;
+} step_and_reg_event_wrapper_t;
 
 /** structure to hold virtual address and page size during get_va_pages */
 struct va_page {


### PR DESCRIPTION
...vent and not just from callbacks. This is especially useful for handling INT3 events where INT3 was injected from the hypervisor and needs to be re-written into the target location after processing the trap.

This PR also expands the use of this function to multiple vCPUs for which we need to keep track how many internal singel-step events are registered as to not having to loop through the list of events to check if the MFT flag can be removed or not.
