### PR TITLE
Refactor dbprint to enable selective debug output

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -164,7 +164,7 @@ pid_cache_get(
     if ((entry = g_hash_table_lookup(vmi->pid_cache, &key)) != NULL) {
         entry->last_used = time(NULL);
         *dtb = entry->dtb;
-        dbprint("--PID cache hit %d -- 0x%.16"PRIx64"\n", pid, *dtb);
+        dbprint(VMI_DEBUG_PIDCACHE, "--PID cache hit %d -- 0x%.16"PRIx64"\n", pid, *dtb);
         return VMI_SUCCESS;
     }
 
@@ -183,7 +183,7 @@ pid_cache_set(
     pid_cache_entry_t entry = pid_cache_entry_create(pid, dtb);
 
     g_hash_table_insert(vmi->pid_cache, key, entry);
-    dbprint("--PID cache set %d -- 0x%.16"PRIx64"\n", pid, dtb);
+    dbprint(VMI_DEBUG_PIDCACHE, "--PID cache set %d -- 0x%.16"PRIx64"\n", pid, dtb);
 }
 
 status_t
@@ -193,7 +193,7 @@ pid_cache_del(
 {
     gint key = (gint) pid;
 
-    dbprint("--PID cache del %d\n", pid);
+    dbprint(VMI_DEBUG_PIDCACHE, "--PID cache del %d\n", pid);
     if (TRUE == g_hash_table_remove(vmi->pid_cache, &key)) {
         return VMI_SUCCESS;
     }
@@ -207,7 +207,7 @@ pid_cache_flush(
     vmi_instance_t vmi)
 {
     g_hash_table_remove_all(vmi->pid_cache);
-    dbprint("--PID cache flushed\n");
+    dbprint(VMI_DEBUG_PIDCACHE, "--PID cache flushed\n");
 }
 
 //
@@ -292,7 +292,7 @@ sym_cache_get(
     if ((entry = g_hash_table_lookup(symbol_table, sym)) != NULL) {
         entry->last_used = time(NULL);
         *va = entry->va;
-        dbprint("--SYM cache hit %u:0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n", pid, base_addr, sym, *va);
+        dbprint(VMI_DEBUG_SYMCACHE, "--SYM cache hit %u:0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n", pid, base_addr, sym, *va);
         ret=VMI_SUCCESS;
     }
 
@@ -324,7 +324,7 @@ sym_cache_set(
 
     sym_dup = strndup(sym, 100);
     g_hash_table_insert(symbol_table, sym_dup, entry);
-    dbprint("--SYM cache set %s -- 0x%.16"PRIx64"\n", sym, va);
+    dbprint(VMI_DEBUG_SYMCACHE, "--SYM cache set %s -- 0x%.16"PRIx64"\n", sym, va);
 }
 
 status_t
@@ -344,7 +344,7 @@ sym_cache_del(
         return ret;
     }
 
-    dbprint("--SYM cache del %u:0x%.16"PRIx64":%s\n", pid, base_addr, sym);
+    dbprint(VMI_DEBUG_SYMCACHE, "--SYM cache del %u:0x%.16"PRIx64":%s\n", pid, base_addr, sym);
 
     if (TRUE == g_hash_table_remove(symbol_table, sym)) {
         ret=VMI_SUCCESS;
@@ -362,7 +362,7 @@ sym_cache_flush(
     vmi_instance_t vmi)
 {
     g_hash_table_remove_all(vmi->sym_cache);
-    dbprint("--SYM cache flushed\n");
+    dbprint(VMI_DEBUG_SYMCACHE, "--SYM cache flushed\n");
 }
 
 void
@@ -405,7 +405,7 @@ rva_cache_get(
     if ((entry = g_hash_table_lookup(rva_table, GUINT_TO_POINTER(rva))) != NULL) {
         entry->last_used = time(NULL);
         *sym = entry->sym;
-        dbprint("--RVA cache hit %u:0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n", pid, base_addr, *sym, rva);
+        dbprint(VMI_DEBUG_RVACACHE, "--RVA cache hit %u:0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n", pid, base_addr, *sym, rva);
         ret=VMI_SUCCESS;
     }
 
@@ -434,7 +434,7 @@ rva_cache_set(
     }
 
     g_hash_table_insert(rva_table, GUINT_TO_POINTER(rva), entry);
-    dbprint("--RVA cache set %s -- 0x%.16"PRIx64"\n", sym, rva);
+    dbprint(VMI_DEBUG_RVACACHE, "--RVA cache set %s -- 0x%.16"PRIx64"\n", sym, rva);
 }
 
 status_t
@@ -454,7 +454,7 @@ rva_cache_del(
         return ret;
     }
 
-    dbprint("--RVA cache del %u:0x%.16"PRIx64":0x%.16"PRIx64"\n",
+    dbprint(VMI_DEBUG_RVACACHE, "--RVA cache del %u:0x%.16"PRIx64":0x%.16"PRIx64"\n",
             pid, base_addr, rva);
 
     if (TRUE == g_hash_table_remove(rva_table, GUINT_TO_POINTER(rva))) {
@@ -473,7 +473,7 @@ rva_cache_flush(
     vmi_instance_t vmi)
 {
     g_hash_table_remove_all(vmi->rva_cache);
-    dbprint("--RVA cache flushed\n");
+    dbprint(VMI_DEBUG_RVACACHE, "--RVA cache flushed\n");
 }
 
 //
@@ -524,7 +524,7 @@ v2p_cache_get(
 
         entry->last_used = time(NULL);
         *pa = entry->pa | ((vmi->page_size - 1) & va);
-        dbprint("--V2P cache hit 0x%.16"PRIx64" -- 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n",
+        dbprint(VMI_DEBUG_V2PCACHE, "--V2P cache hit 0x%.16"PRIx64" -- 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n",
                 va, *pa, key->high, key->low);
         return VMI_SUCCESS;
     }
@@ -545,7 +545,7 @@ v2p_cache_set(
     key_128_t key = key_128_build(vmi, (uint64_t)va, (uint64_t)dtb);
     v2p_cache_entry_t entry = v2p_cache_entry_create(vmi, pa);
     g_hash_table_insert(vmi->v2p_cache, key, entry);
-    dbprint("--V2P cache set 0x%.16"PRIx64" -- 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
+    dbprint(VMI_DEBUG_V2PCACHE, "--V2P cache set 0x%.16"PRIx64" -- 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
             pa, key->high, key->low);
 }
 
@@ -558,7 +558,7 @@ v2p_cache_del(
     struct key_128 local_key;
     key_128_t key = &local_key;
     key_128_init(vmi, key, (uint64_t)va, (uint64_t)dtb);
-    dbprint("--V2P cache del 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
+    dbprint(VMI_DEBUG_V2PCACHE, "--V2P cache del 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
             key->high, key->low);
 
     // key collision doesn't really matter here because worst case
@@ -577,7 +577,7 @@ v2p_cache_flush(
     vmi_instance_t vmi)
 {
     g_hash_table_remove_all(vmi->v2p_cache);
-    dbprint("--V2P cache flushed\n");
+    dbprint(VMI_DEBUG_V2PCACHE, "--V2P cache flushed\n");
 }
 
 #if ENABLE_SHM_SNAPSHOT == 1
@@ -633,7 +633,7 @@ v2m_cache_get(
         entry->last_used = time(NULL);
         *ma = entry->ma | ((vmi->page_size - 1) & va);
         *length = entry->length;
-        dbprint("--v2m cache hit 0x%.16"PRIx64" -- 0x%.16"PRIx64" len 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n",
+        dbprint(VMI_DEBUG_V2MCACHE, "--v2m cache hit 0x%.16"PRIx64" -- 0x%.16"PRIx64" len 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n",
                 va, *ma, *length, key->high, key->low);
         return VMI_SUCCESS;
     }
@@ -655,7 +655,7 @@ v2m_cache_set(
     key_128_t key = key_128_build(vmi, (uint64_t)va, (uint64_t)pid);
     v2m_cache_entry_t entry = v2m_cache_entry_create(vmi, ma, length);
     g_hash_table_insert(vmi->v2m_cache, key, entry);
-    dbprint("--v2m cache set 0x%.16"PRIx64" -- 0x%.16"PRIx64" len 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
+    dbprint(VMI_DEBUG_V2MCACHE, "--v2m cache set 0x%.16"PRIx64" -- 0x%.16"PRIx64" len 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
             ma, length, key->high, key->low);
 }
 
@@ -668,7 +668,7 @@ v2m_cache_del(
     struct key_128 local_key;
     key_128_t key = &local_key;
     key_128_init(vmi, key, (uint64_t)va, (uint64_t)pid);
-    dbprint("--v2m cache del 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
+    dbprint(VMI_DEBUG_V2MCACHE, "--v2m cache del 0x%.16"PRIx64" (0x%.16"PRIx64"/0x%.16"PRIx64")\n", va,
             key->high, key->low);
 
     // key collision doesn't really matter here because worst case
@@ -687,7 +687,7 @@ v2m_cache_flush(
     vmi_instance_t vmi)
 {
     g_hash_table_remove_all(vmi->v2m_cache);
-    dbprint("--v2m cache flushed\n");
+    dbprint(VMI_DEBUG_V2MCACHE, "--v2m cache flushed\n");
 }
 #endif
 

--- a/libvmi/convenience.c
+++ b/libvmi/convenience.c
@@ -35,14 +35,17 @@
 #else
 void
 dbprint(
+    vmi_debug_flag_t category,
     char *format,
     ...)
 {
-    va_list args;
+    if(category & VMI_DEBUG) {
+        va_list args;
 
-    va_start(args, format);
-    vfprintf(stdout, format, args);
-    va_end(args);
+        va_start(args, format);
+        vfprintf(stdout, format, args);
+        va_end(args);
+    }
 }
 #endif
 

--- a/libvmi/debug.h
+++ b/libvmi/debug.h
@@ -1,0 +1,57 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBVMI_DEBUG_H
+#define LIBVMI_DEBUG_H
+
+/*
+ * This enum holds the various debug print-outs that can be generated
+ */
+typedef enum {
+    VMI_DEBUG_MISC     = (1 << 0),
+    VMI_DEBUG_MEMCACHE = (1 << 1),
+    VMI_DEBUG_PIDCACHE = (1 << 2),
+    VMI_DEBUG_SYMCACHE = (1 << 3),
+    VMI_DEBUG_RVACACHE = (1 << 4),
+    VMI_DEBUG_V2PCACHE = (1 << 5),
+    VMI_DEBUG_V2MCACHE = (1 << 6),
+    VMI_DEBUG_PTLOOKUP = (1 << 7),
+    VMI_DEBUG_EVENTS   = (1 << 8),
+    VMI_DEBUG_XEN      = (1 << 9),
+    VMI_DEBUG_KVM      = (1 << 10),
+    VMI_DEBUG_FILE     = (1 << 11),
+    VMI_DEBUG_CORE     = (1 << 12),
+    VMI_DEBUG_READ     = (1 << 13),
+    VMI_DEBUG_WRITE    = (1 << 14),
+    VMI_DEBUG_DRIVER   = (1 << 15),
+
+    __VMI_DEBUG_ALL    = ~(0ULL)
+} vmi_debug_flag_t;
+
+/* uncomment this and recompile to enable debug output */
+//#define VMI_DEBUG __VMI_DEBUG_ALL
+
+#endif

--- a/libvmi/driver/file.c
+++ b/libvmi/driver/file.c
@@ -69,7 +69,7 @@ file_get_memory(
 
     if (paddr + length > vmi->size) {
         dbprint
-            ("--%s: request for PA range [0x%.16"PRIx64"-0x%.16"PRIx64"] reads past end of file\n",
+            (VMI_DEBUG_FILE, "--%s: request for PA range [0x%.16"PRIx64"-0x%.16"PRIx64"] reads past end of file\n",
              __FUNCTION__, paddr, paddr + length);
         goto error_noprint;
     }   // if
@@ -92,7 +92,7 @@ file_get_memory(
     return memory;
 
 error_print:
-    dbprint("%s: failed to read %d bytes at "
+    dbprint(VMI_DEBUG_WRITE, "%s: failed to read %d bytes at "
             "PA (offset) 0x%.16"PRIx64" [VM size 0x%.16"PRIx64"]\n", __FUNCTION__,
             length, paddr, vmi->size);
 error_noprint:

--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -359,17 +359,17 @@ driver_init_mode(
 
     /* see what systems are accessable */
     if (VMI_SUCCESS == xen_test(id, name)) {
-        dbprint("--found Xen\n");
+        dbprint(VMI_DEBUG_DRIVER, "--found Xen\n");
         vmi->mode = VMI_XEN;
         count++;
     }
     if (VMI_SUCCESS == kvm_test(id, name)) {
-        dbprint("--found KVM\n");
+        dbprint(VMI_DEBUG_DRIVER, "--found KVM\n");
         vmi->mode = VMI_KVM;
         count++;
     }
     if (VMI_SUCCESS == file_test(id, name)) {
-        dbprint("--found file\n");
+        dbprint(VMI_DEBUG_DRIVER, "--found file\n");
         vmi->mode = VMI_FILE;
         count++;
     }
@@ -400,7 +400,7 @@ driver_init(
         return ptrs->init_ptr(vmi);
     }
     else {
-        dbprint("WARNING: driver_init function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_init function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -417,7 +417,7 @@ driver_destroy(
         return;
     }
     else {
-        dbprint("WARNING: driver_destroy function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_destroy function not implemented.\n");
         return;
     }
 }
@@ -434,7 +434,7 @@ driver_get_id_from_name(
     }
     else {
         dbprint
-            ("WARNING: driver_get_id_from_name function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_get_id_from_name function not implemented.\n");
         return 0;
     }
 }
@@ -452,7 +452,7 @@ driver_get_name_from_id(
     }
     else {
         dbprint
-            ("WARNING: driver_get_name_from_id function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_get_name_from_id function not implemented.\n");
         return 0;
     }
 }
@@ -467,7 +467,7 @@ driver_get_id(
         return ptrs->get_id_ptr(vmi);
     }
     else {
-        dbprint("WARNING: driver_get_id function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_id function not implemented.\n");
         return 0;
     }
 }
@@ -483,7 +483,7 @@ driver_set_id(
         return ptrs->set_id_ptr(vmi, id);
     }
     else {
-        dbprint("WARNING: driver_set_id function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_id function not implemented.\n");
         return;
     }
 }
@@ -500,7 +500,7 @@ driver_check_id(
         return;
     }
     else {
-        dbprint("WARNING: driver_check_id function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_check_id function not implemented.\n");
         return;
     }
 }
@@ -516,7 +516,7 @@ driver_get_name(
         return ptrs->get_name_ptr(vmi, name);
     }
     else {
-        dbprint("WARNING: driver_get_name function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_name function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -532,7 +532,7 @@ driver_set_name(
         return ptrs->set_name_ptr(vmi, name);
     }
     else {
-        dbprint("WARNING: driver_set_name function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_name function not implemented.\n");
         return;
     }
 }
@@ -549,7 +549,7 @@ driver_get_memsize(
     }
     else {
         dbprint
-            ("WARNING: driver_get_memsize function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_get_memsize function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -568,7 +568,7 @@ driver_get_vcpureg(
     }
     else {
         dbprint
-            ("WARNING: driver_get_vcpureg function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_get_vcpureg function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -585,7 +585,7 @@ driver_set_vcpureg(
         return ptrs->set_vcpureg_ptr(vmi, value, reg, vcpu);
     }
     else{
-        dbprint("WARNING: driver_set_vcpureg function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_vcpureg function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -602,7 +602,7 @@ driver_get_address_width(
     }
     else {
         dbprint
-            ("WARNING: driver_get_address_width function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_get_address_width function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -619,7 +619,7 @@ driver_read_page(
     }
     else {
         dbprint
-            ("WARNING: driver_read_page function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_read_page function not implemented.\n");
         return NULL;
     }
 }
@@ -637,7 +637,7 @@ driver_write(
         return ptrs->write_ptr(vmi, paddr, buf, length);
     }
     else {
-        dbprint("WARNING: driver_write function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_write function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -652,7 +652,7 @@ driver_is_pv(
         return ptrs->is_pv_ptr(vmi);
     }
     else {
-        dbprint("WARNING: driver_is_pv function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_is_pv function not implemented.\n");
         return 0;
     }
 }
@@ -667,7 +667,7 @@ driver_pause_vm(
         return ptrs->pause_vm_ptr(vmi);
     }
     else {
-        dbprint("WARNING: driver_pause_vm function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_pause_vm function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -683,7 +683,7 @@ driver_resume_vm(
     }
     else {
         dbprint
-            ("WARNING: driver_resume_vm function not implemented.\n");
+            (VMI_DEBUG_DRIVER, "WARNING: driver_resume_vm function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -698,7 +698,7 @@ status_t driver_shm_snapshot_vm(
         return ptrs->create_shm_snapshot_ptr(vmi);
     }
     else {
-        dbprint("WARNING: driver_shm_snapshot_vm function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_shm_snapshot_vm function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -712,7 +712,7 @@ status_t driver_destroy_shm_snapshot_vm(
         return ptrs->destroy_shm_snapshot_ptr(vmi);
     }
     else {
-        dbprint("WARNING: driver_destroy_shm_snapshot_vm function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_destroy_shm_snapshot_vm function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -729,7 +729,7 @@ size_t driver_get_dgpma(
         return ptrs->get_dgpma_ptr(vmi, paddr, medial_addr_ptr, count);
     }
     else {
-        dbprint("WARNING: get_dgpma_ptr function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: get_dgpma_ptr function not implemented.\n");
         return 0;
     }
     return 0;
@@ -749,7 +749,7 @@ driver_get_dgvma(
         return ptrs->get_dgvma_ptr(vmi, vaddr, pid, medial_addr_ptr, count);
     }
     else {
-        dbprint("WARNING: get_dgvma_ptr function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: get_dgvma_ptr function not implemented.\n");
         return 0;
     }
     return 0;
@@ -765,7 +765,7 @@ status_t driver_events_listen(
         return ptrs->events_listen_ptr(vmi, timeout);
     }
     else{
-        dbprint("WARNING: driver_events_listen function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_events_listen function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -779,7 +779,7 @@ status_t driver_set_reg_access(
         return ptrs->set_reg_access_ptr(vmi, event);
     }
     else{
-        dbprint("WARNING: driver_set_reg_w_access function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_reg_w_access function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -793,7 +793,7 @@ status_t driver_set_intr_access(
         return ptrs->set_intr_access_ptr(vmi, event);
     }
     else{
-        dbprint("WARNING: driver_set_intr_access function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_intr_access function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -808,7 +808,7 @@ status_t driver_set_mem_access(
         return ptrs->set_mem_access_ptr(vmi, event, page_access_flag);
     }
     else{
-        dbprint("WARNING: driver_set_mem_access function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_mem_access function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -822,7 +822,7 @@ status_t driver_start_single_step(
         return ptrs->start_single_step_ptr(vmi, event);
     }
     else{
-        dbprint("WARNING: driver_start_single_step function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_start_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -836,7 +836,7 @@ status_t driver_stop_single_step(
         return ptrs->stop_single_step_ptr(vmi, vcpu);
     }
     else{
-        dbprint("WARNING: driver_stop_single_step function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_stop_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
 }
@@ -849,7 +849,7 @@ status_t driver_shutdown_single_step(
         return ptrs->shutdown_single_step_ptr(vmi);
     }
     else{
-        dbprint("WARNING: driver_shutdown_single_step function not implemented.\n");
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_shutdown_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
 }

--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -104,7 +104,7 @@ clean_cache(
     g_list_foreach(list, remove_entry, vmi->memory_cache);
     g_list_free(list);
 
-    dbprint("--MEMORY cache cleanup round complete (cache size = %u)\n",
+    dbprint(VMI_DEBUG_MEMCACHE, "--MEMORY cache cleanup round complete (cache size = %u)\n",
             g_hash_table_size(vmi->memory_cache));
 }
 
@@ -117,7 +117,7 @@ validate_and_return_data(
 
     if (vmi->memory_cache_age &&
         (now - entry->last_updated > vmi->memory_cache_age)) {
-        dbprint("--MEMORY cache refresh 0x%"PRIx64"\n", entry->paddr);
+        dbprint(VMI_DEBUG_MEMCACHE, "--MEMORY cache refresh 0x%"PRIx64"\n", entry->paddr);
         release_data_callback(entry->data, entry->length);
         entry->data = get_memory_data(vmi, entry->paddr, entry->length);
         entry->last_updated = now;
@@ -211,11 +211,11 @@ memory_cache_insert(
 
     gint64 *key = &paddr;
     if ((entry = g_hash_table_lookup(vmi->memory_cache, key)) != NULL) {
-        dbprint("--MEMORY cache hit 0x%"PRIx64"\n", paddr);
+        dbprint(VMI_DEBUG_MEMCACHE, "--MEMORY cache hit 0x%"PRIx64"\n", paddr);
         return validate_and_return_data(vmi, entry);
     }
     else {
-        dbprint("--MEMORY cache set 0x%"PRIx64"\n", paddr);
+        dbprint(VMI_DEBUG_MEMCACHE, "--MEMORY cache set 0x%"PRIx64"\n", paddr);
 
         entry = create_new_entry(vmi, paddr, vmi->page_size);
         if (!entry) {

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -143,13 +143,13 @@ status_t register_interrupt_event(vmi_instance_t vmi, vmi_event_t *event)
 
     if (NULL != g_hash_table_lookup(vmi->interrupt_events, &(event->interrupt_event.intr)))
     {
-        dbprint("An event is already registered on this interrupt: %d\n",
+        dbprint(VMI_DEBUG_EVENTS, "An event is already registered on this interrupt: %d\n",
                 event->interrupt_event.intr);
     }
     else if (VMI_SUCCESS == driver_set_intr_access(vmi, event->interrupt_event))
     {
         g_hash_table_insert(vmi->interrupt_events, &(event->interrupt_event.intr), event);
-        dbprint("Enabled event on interrupt: %d\n", event->interrupt_event.intr);
+        dbprint(VMI_DEBUG_EVENTS, "Enabled event on interrupt: %d\n", event->interrupt_event.intr);
         rc = VMI_SUCCESS;
     }
 
@@ -163,13 +163,13 @@ status_t register_reg_event(vmi_instance_t vmi, vmi_event_t *event)
 
     if (NULL != g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg)))
     {
-        dbprint("An event is already registered on this reg: %d\n",
+        dbprint(VMI_DEBUG_EVENTS, "An event is already registered on this reg: %d\n",
                 event->reg_event.reg);
     }
     else if (VMI_SUCCESS == driver_set_reg_access(vmi, event->reg_event))
     {
         g_hash_table_insert(vmi->reg_events, &(event->reg_event.reg), event);
-        dbprint("Enabled register event on reg: %d\n", event->reg_event.reg);
+        dbprint(VMI_DEBUG_EVENTS, "Enabled register event on reg: %d\n", event->reg_event.reg);
         rc = VMI_SUCCESS;
     }
 
@@ -229,7 +229,7 @@ status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event)
         {
             if (page->event)
             {
-                dbprint(
+                dbprint(VMI_DEBUG_EVENTS,
                         "An event is already registered on this page: %"PRIu64"\n",
                         page_key);
             }
@@ -253,7 +253,7 @@ status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event)
                         != g_hash_table_lookup(page->byte_events,
                                 &(event->mem_event.physical_address)))
                 {
-                    dbprint(
+                    dbprint(VMI_DEBUG_EVENTS,
                             "An event is already registered on this byte: 0x%"PRIx64"\n",
                             event->mem_event.physical_address);
                 }
@@ -300,14 +300,14 @@ status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event)
         if (granularity == VMI_MEMEVENT_PAGE)
         {
             page->event = event;
-            dbprint("Enabling memory event on page: %"PRIu64"\n", page_key);
+            dbprint(VMI_DEBUG_EVENTS, "Enabling memory event on page: %"PRIu64"\n", page_key);
         }
         else
         {
             page->byte_events = g_hash_table_new(g_int64_hash, g_int64_equal);
             g_hash_table_insert(page->byte_events,
                     &(event->mem_event.physical_address), event);
-            dbprint(
+            dbprint(VMI_DEBUG_EVENTS,
                     "Enabling memory event on byte 0x%"PRIx64", page: %"PRIu64"\n",
                     event->mem_event.physical_address, page_key);
         }
@@ -333,7 +333,7 @@ status_t register_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
         {
             if (NULL != g_hash_table_lookup(vmi->ss_events, &vcpu))
             {
-                dbprint("An event is already registered on this vcpu: %u\n",
+                dbprint(VMI_DEBUG_EVENTS, "An event is already registered on this vcpu: %u\n",
                         vcpu);
             }
             else
@@ -344,7 +344,7 @@ status_t register_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
                     vcpu_i = malloc(sizeof(uint32_t));
                     *vcpu_i = vcpu;
                     g_hash_table_insert(vmi->ss_events, vcpu_i, event);
-                    dbprint("Enabling single step\n");
+                    dbprint(VMI_DEBUG_EVENTS, "Enabling single step\n");
                     rc = VMI_SUCCESS;
                 }
             }
@@ -361,7 +361,7 @@ status_t clear_interrupt_event(vmi_instance_t vmi, vmi_event_t *event)
 
     if (NULL != g_hash_table_lookup(vmi->interrupt_events, &(event->interrupt_event.intr)))
     {
-        dbprint("Disabling event on interrupt: %d\n", event->interrupt_event.intr);
+        dbprint(VMI_DEBUG_EVENTS, "Disabling event on interrupt: %d\n", event->interrupt_event.intr);
         event->interrupt_event.enabled = 0;
         rc = driver_set_intr_access(vmi, event->interrupt_event);
         if (!vmi->shutting_down && rc == VMI_SUCCESS)
@@ -382,7 +382,7 @@ status_t clear_reg_event(vmi_instance_t vmi, vmi_event_t *event)
 
     if (NULL != g_hash_table_lookup(vmi->reg_events, &(event->reg_event.reg)))
     {
-        dbprint("Disabling register event on reg: %d\n", event->reg_event.reg);
+        dbprint(VMI_DEBUG_EVENTS, "Disabling register event on reg: %d\n", event->reg_event.reg);
         original_in_access = event->reg_event.in_access;
         event->reg_event.in_access = VMI_REGACCESS_N;
         rc = driver_set_reg_access(vmi, event->reg_event);
@@ -423,14 +423,14 @@ status_t clear_mem_event(vmi_instance_t vmi, vmi_event_t *event)
         {
             if (!page->event)
             {
-                dbprint("Can't disable page-level memevent, non registered!\n");
+                dbprint(VMI_DEBUG_EVENTS, "Can't disable page-level memevent, non registered!\n");
             }
             else
             {
 
                 remove_event = page->event;
 
-                dbprint("Disabling memory event on page: %"PRIu64"\n",
+                dbprint(VMI_DEBUG_EVENTS, "Disabling memory event on page: %"PRIu64"\n",
                         remove_event->mem_event.physical_address);
 
                 // We still have byte-level events registered on this page
@@ -466,7 +466,7 @@ status_t clear_mem_event(vmi_instance_t vmi, vmi_event_t *event)
         {
             if (!page->byte_events)
             {
-                dbprint("Can't disable byte-level memevent, non registered!\n");
+                dbprint(VMI_DEBUG_EVENTS, "Can't disable byte-level memevent, non registered!\n");
             }
             else
             {
@@ -477,7 +477,7 @@ status_t clear_mem_event(vmi_instance_t vmi, vmi_event_t *event)
 
                 if (NULL == remove_event)
                 {
-                    dbprint(
+                    dbprint(VMI_DEBUG_EVENTS,
                             "Can't disable byte-level memevent, event not found on byte 0x%"PRIx64"!\n",
                             event->mem_event.physical_address);
                 }
@@ -538,7 +538,7 @@ status_t clear_mem_event(vmi_instance_t vmi, vmi_event_t *event)
     }
     else
     {
-        dbprint("Disabling event failed, no event found on page: %"PRIu64"\n",
+        dbprint(VMI_DEBUG_EVENTS, "Disabling event failed, no event found on page: %"PRIu64"\n",
                 page_key);
     }
 
@@ -557,7 +557,7 @@ status_t clear_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
     {
         if (CHECK_VCPU_SINGLESTEP(event->ss_event, vcpu))
         {
-            dbprint("Disabling single step on vcpu: %u\n", vcpu);
+            dbprint(VMI_DEBUG_EVENTS, "Disabling single step on vcpu: %u\n", vcpu);
             rc = driver_stop_single_step(vmi, vcpu);
             if (!vmi->shutting_down && rc == VMI_SUCCESS)
             {
@@ -609,17 +609,17 @@ status_t vmi_register_event(vmi_instance_t vmi, vmi_event_t* event)
 
     if (!(vmi->init_mode & VMI_INIT_EVENTS))
     {
-        dbprint("LibVMI wasn't initialized with events!\n");
+        dbprint(VMI_DEBUG_EVENTS, "LibVMI wasn't initialized with events!\n");
         return VMI_FAILURE;
     }
     if (!event)
     {
-        dbprint("No event given!\n");
+        dbprint(VMI_DEBUG_EVENTS, "No event given!\n");
         return VMI_FAILURE;
     }
     if (!event->callback)
     {
-        dbprint("No event callback function specified!\n");
+        dbprint(VMI_DEBUG_EVENTS, "No event callback function specified!\n");
         return VMI_FAILURE;
     }
 
@@ -684,18 +684,18 @@ status_t vmi_step_mem_event(vmi_instance_t vmi, vmi_event_t *event, uint64_t ste
 
     if(VMI_EVENT_MEMORY != event->type)
     {
-        dbprint("This function is only for memory events!\n");
+        dbprint(VMI_DEBUG_EVENTS, "This function is only for memory events!\n");
         goto done;
     }
 
     if(NULL != vmi_get_singlestep_event(vmi, event->vcpu_id))
     {
-        dbprint("Can't step memory event, single-step is already enabled on vCPU %u\n", event->vcpu_id);
+        dbprint(VMI_DEBUG_EVENTS, "Can't step memory event, single-step is already enabled on vCPU %u\n", event->vcpu_id);
         goto done;
     }
 
     if(0 == steps) {
-        dbprint("Minimum number of steps is 1!\n");
+        dbprint(VMI_DEBUG_EVENTS, "Minimum number of steps is 1!\n");
         goto done;
     }
 

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -52,9 +52,6 @@ extern "C" {
 #include <errno.h>
 #include <string.h>
 
-/* uncomment this and recompile to enable debug output */
-//#define VMI_DEBUG
-
 /* enable or disable the address cache (v2p, pid, etc) */
 #define ENABLE_ADDRESS_CACHE 1
 

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -67,7 +67,7 @@ uint64_t get_pml4e (vmi_instance_t vmi, addr_t vaddr, reg_t cr3)
     uint64_t value = 0;
     addr_t pml4e_address = get_bits_51to12(cr3) | get_pml4_index(vaddr);
 
-    dbprint("--PTLookup pml4e_address = 0x%.16"PRIx64"\n", pml4e_address);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup pml4e_address = 0x%.16"PRIx64"\n", pml4e_address);
     vmi_read_64_pa(vmi, pml4e_address, &value);
     return value;
 }
@@ -88,7 +88,7 @@ uint64_t get_pdpi (vmi_instance_t instance, uint32_t vaddr, uint32_t cr3)
     uint64_t value;
     uint32_t pdpi_entry = get_pdptb(cr3) + pdpi_index(vaddr);
 
-    dbprint("--PTLookup: pdpi_entry = 0x%.8x\n", pdpi_entry);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pdpi_entry = 0x%.8x\n", pdpi_entry);
     vmi_read_64_pa(instance, pdpi_entry, &value);
     return value;
 }
@@ -102,7 +102,7 @@ uint64_t get_pdpte_ia32e (vmi_instance_t vmi, addr_t vaddr, uint64_t pml4e)
 {
     uint64_t value = 0;
     addr_t pdpte_address = get_bits_51to12(pml4e) | get_pdpt_index_ia32e(vaddr);
-    dbprint("--PTLookup: pdpte_address = 0x%.16"PRIx64"\n", pdpte_address);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pdpte_address = 0x%.16"PRIx64"\n", pdpte_address);
     vmi_read_64_pa(vmi, pdpte_address, &value);
     return value;
 }
@@ -137,7 +137,7 @@ uint32_t get_pgd_nopae (vmi_instance_t instance, uint32_t vaddr, uint32_t pdpe)
 {
     uint32_t value;
     uint32_t pgd_entry = pdba_base_nopae(pdpe) + pgd_index(instance, vaddr);
-    dbprint("--PTLookup: pgd_entry = 0x%.8x\n", pgd_entry);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pgd_entry = 0x%.8x\n", pgd_entry);
     vmi_read_32_pa(instance, pgd_entry, &value);
     return value;
 }
@@ -146,7 +146,7 @@ uint64_t get_pgd_pae (vmi_instance_t instance, uint32_t vaddr, uint64_t pdpe)
 {
     uint64_t value;
     uint32_t pgd_entry = pdba_base_pae(pdpe) + pgd_index(instance, vaddr);
-    dbprint("--PTLookup: pgd_entry = 0x%.8x\n", pgd_entry);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pgd_entry = 0x%.8x\n", pgd_entry);
     vmi_read_64_pa(instance, pgd_entry, &value);
     return value;
 }
@@ -160,7 +160,7 @@ uint64_t get_pde_ia32e (vmi_instance_t vmi, addr_t vaddr, uint64_t pdpte)
 {
     uint64_t value = 0;
     addr_t pde_address = get_bits_51to12(pdpte) | get_pd_index_ia32e(vaddr);
-    dbprint("--PTLookup: pde_address = 0x%.16"PRIx64"\n", pde_address);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pde_address = 0x%.16"PRIx64"\n", pde_address);
     vmi_read_64_pa(vmi, pde_address, &value);
     return value;
 }
@@ -190,7 +190,7 @@ uint32_t get_pte_nopae (vmi_instance_t instance, uint32_t vaddr, uint32_t pgd)
 {
     uint32_t value;
     uint32_t pte_entry = ptba_base_nopae(pgd) + pte_index(instance, vaddr);
-    dbprint("--PTLookup: pte_entry = 0x%.8x\n", pte_entry);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte_entry = 0x%.8x\n", pte_entry);
     vmi_read_32_pa(instance, pte_entry, &value);
     return value;
 }
@@ -199,7 +199,7 @@ uint64_t get_pte_pae (vmi_instance_t instance, uint32_t vaddr, uint64_t pgd)
 {
     uint64_t value;
     uint32_t pte_entry = ptba_base_pae(pgd) + pte_index(instance, vaddr);
-    dbprint("--PTLookup: pte_entry = 0x%.8x\n", pte_entry);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte_entry = 0x%.8x\n", pte_entry);
     vmi_read_64_pa(instance, pte_entry, &value);
     return value;
 }
@@ -213,7 +213,7 @@ uint64_t get_pte_ia32e (vmi_instance_t vmi, addr_t vaddr, uint64_t pde)
 {
     uint64_t value = 0;
     addr_t pte_address = get_bits_51to12(pde) | get_pt_index_ia32e(vaddr);
-    dbprint("--PTLookup: pte_address = 0x%.16"PRIx64"\n", pte_address);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte_address = 0x%.16"PRIx64"\n", pte_address);
     vmi_read_64_pa(vmi, pte_address, &value);
     return value;
 }
@@ -298,33 +298,33 @@ void buffalo_nopae (vmi_instance_t instance, uint32_t entry, int pde)
 
         /* pagefile */
         if (pfnum != 0 && pfframe != 0) {
-            dbprint("--Buffalo: page file = %d, frame = 0x%.8x\n",
+            dbprint(VMI_DEBUG_PTLOOKUP, "--Buffalo: page file = %d, frame = 0x%.8x\n",
                     pfnum, pfframe);
         }
         /* demand zero */
         else if (pfnum == 0 && pfframe == 0) {
-            dbprint("--Buffalo: demand zero page\n");
+            dbprint(VMI_DEBUG_PTLOOKUP, "--Buffalo: demand zero page\n");
         }
     }
 
     else if (get_transition_bit(entry) && !get_prototype_bit(entry)) {
         /* transition */
-        dbprint("--Buffalo: page in transition\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--Buffalo: page in transition\n");
     }
 
     else if (!pde && get_prototype_bit(entry)) {
         /* prototype */
-        dbprint("--Buffalo: prototype entry\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--Buffalo: prototype entry\n");
     }
 
     else if (entry == 0) {
         /* zero */
-        dbprint("--Buffalo: entry is zero\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--Buffalo: entry is zero\n");
     }
 
     else {
         /* zero */
-        dbprint("--Buffalo: unknown\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--Buffalo: unknown\n");
     }
 }
 
@@ -334,19 +334,19 @@ addr_t v2p_nopae (vmi_instance_t vmi, addr_t dtb, addr_t vaddr)
     addr_t paddr = 0;
     uint32_t pgd, pte;
 
-    dbprint("--PTLookup: lookup vaddr = 0x%.16"PRIx64"\n", vaddr);
-    dbprint("--PTLookup: dtb = 0x%.16"PRIx64"\n", dtb);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: lookup vaddr = 0x%.16"PRIx64"\n", vaddr);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: dtb = 0x%.16"PRIx64"\n", dtb);
     pgd = get_pgd_nopae(vmi, vaddr, dtb);
-    dbprint("--PTLookup: pgd = 0x%.8"PRIx32"\n", pgd);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pgd = 0x%.8"PRIx32"\n", pgd);
 
     if (entry_present(vmi->os_type, pgd)) {
         if (page_size_flag(pgd)) {
             paddr = get_large_paddr(vmi, vaddr, pgd);
-            dbprint("--PTLookup: 4MB page 0x%"PRIx32"\n", pgd);
+            dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: 4MB page 0x%"PRIx32"\n", pgd);
         }
         else {
             pte = get_pte_nopae(vmi, vaddr, pgd);
-            dbprint("--PTLookup: pte = 0x%.8"PRIx32"\n", pte);
+            dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte = 0x%.8"PRIx32"\n", pte);
             if (entry_present(vmi->os_type, pte)) {
                 paddr = get_paddr_nopae(vaddr, pte);
             }
@@ -358,7 +358,7 @@ addr_t v2p_nopae (vmi_instance_t vmi, addr_t dtb, addr_t vaddr)
     else {
         buffalo_nopae(vmi, pgd, 0);
     }
-    dbprint("--PTLookup: paddr = 0x%.16"PRIx64"\n", paddr);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: paddr = 0x%.16"PRIx64"\n", paddr);
     return paddr;
 }
 
@@ -367,30 +367,30 @@ addr_t v2p_pae (vmi_instance_t vmi, addr_t dtb, addr_t vaddr)
     addr_t paddr = 0;
     uint64_t pdpe, pgd, pte;
 
-    dbprint("--PTLookup: lookup vaddr = 0x%.16"PRIx64"\n", vaddr);
-    dbprint("--PTLookup: dtb = 0x%.16"PRIx64"\n", dtb);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: lookup vaddr = 0x%.16"PRIx64"\n", vaddr);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: dtb = 0x%.16"PRIx64"\n", dtb);
     pdpe = get_pdpi(vmi, vaddr, dtb);
-    dbprint("--PTLookup: pdpe = 0x%.16"PRIx64"\n", pdpe);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pdpe = 0x%.16"PRIx64"\n", pdpe);
     if (!entry_present(vmi->os_type, pdpe)) {
         return paddr;
     }
     pgd = get_pgd_pae(vmi, vaddr, pdpe);
-    dbprint("--PTLookup: pgd = 0x%.16"PRIx64"\n", pgd);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pgd = 0x%.16"PRIx64"\n", pgd);
 
     if (entry_present(vmi->os_type, pgd)) {
         if (page_size_flag(pgd)) {
             paddr = get_large_paddr(vmi, vaddr, pgd);
-            dbprint("--PTLookup: 2MB page\n");
+            dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: 2MB page\n");
         }
         else {
             pte = get_pte_pae(vmi, vaddr, pgd);
-            dbprint("--PTLookup: pte = 0x%.16"PRIx64"\n", pte);
+            dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte = 0x%.16"PRIx64"\n", pte);
             if (entry_present(vmi->os_type, pte)) {
                 paddr = get_paddr_pae(vaddr, pte);
             }
         }
     }
-    dbprint("--PTLookup: paddr = 0x%.16"PRIx64"\n", paddr);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: paddr = 0x%.16"PRIx64"\n", paddr);
     return paddr;
 }
 
@@ -405,33 +405,33 @@ addr_t v2p_ia32e (vmi_instance_t vmi, addr_t dtb, addr_t vaddr)
 
     // determine what MAXPHYADDR is
 
-    dbprint("--PTLookup: lookup vaddr = 0x%.16"PRIx64"\n", vaddr);
-    dbprint("--PTLookup: dtb = 0x%.16"PRIx64"\n", dtb);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: lookup vaddr = 0x%.16"PRIx64"\n", vaddr);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: dtb = 0x%.16"PRIx64"\n", dtb);
     pml4e = get_pml4e(vmi, vaddr, dtb);
-    dbprint("--PTLookup: pml4e = 0x%.16"PRIx64"\n", pml4e);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pml4e = 0x%.16"PRIx64"\n", pml4e);
 
     if (entry_present(vmi->os_type, pml4e)) {
         pdpte = get_pdpte_ia32e(vmi, vaddr, pml4e);
-        dbprint("--PTLookup: pdpte = 0x%.16"PRIx64"\n", pdpte);
+        dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pdpte = 0x%.16"PRIx64"\n", pdpte);
 
         if (entry_present(vmi->os_type, pdpte)) {
             if (page_size_flag(pdpte)) { // pdpte maps a 1GB page
                 paddr = get_gigpage_ia32e(vaddr, pdpte);
-                dbprint("--PTLookup: 1GB page\n");
+                dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: 1GB page\n");
             }
             else {
                 pde = get_pde_ia32e(vmi, vaddr, pdpte);
-                dbprint("--PTLookup: pde = 0x%.16"PRIx64"\n", pde);
+                dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pde = 0x%.16"PRIx64"\n", pde);
             }
 
             if (entry_present(vmi->os_type, pde)) {
                 if (page_size_flag(pde)) { // pde maps a 2MB page
                     paddr = get_2megpage_ia32e(vaddr, pde);
-                    dbprint("--PTLookup: 2MB page\n");
+                    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: 2MB page\n");
                 }
                 else {
                     pte = get_pte_ia32e(vmi, vaddr, pde);
-                    dbprint("--PTLookup: pte = 0x%.16"PRIx64"\n", pte);
+                    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte = 0x%.16"PRIx64"\n", pte);
                 }
 
                 if (entry_present(vmi->os_type, pte)) {
@@ -441,7 +441,7 @@ addr_t v2p_ia32e (vmi_instance_t vmi, addr_t dtb, addr_t vaddr)
         }
     }
 
-    dbprint("--PTLookup: paddr = 0x%.16"PRIx64"\n", paddr);
+    dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: paddr = 0x%.16"PRIx64"\n", paddr);
     return paddr;
 }
 
@@ -715,7 +715,7 @@ addr_t vmi_translate_kv2p (vmi_instance_t vmi, addr_t virt_address)
         driver_get_vcpureg(vmi, &cr3, CR3, 0);
     }
     if (!cr3) {
-        dbprint("--early bail on v2p lookup because cr3 is zero\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--early bail on v2p lookup because cr3 is zero\n");
         return 0;
     }
     else {
@@ -730,7 +730,7 @@ addr_t vmi_translate_uv2p_nocache (vmi_instance_t vmi, addr_t virt_address,
     addr_t dtb = vmi_pid_to_dtb(vmi, pid);
 
     if (!dtb) {
-        dbprint("--early bail on v2p lookup because dtb is zero\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--early bail on v2p lookup because dtb is zero\n");
         return 0;
     }
     else {
@@ -748,7 +748,7 @@ addr_t vmi_translate_uv2p (vmi_instance_t vmi, addr_t virt_address, vmi_pid_t pi
     addr_t dtb = vmi_pid_to_dtb(vmi, pid);
 
     if (!dtb) {
-        dbprint("--early bail on v2p lookup because dtb is zero\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "--early bail on v2p lookup because dtb is zero\n");
         return 0;
     }
     else {

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -54,7 +54,7 @@ status_t linux_init(vmi_instance_t vmi) {
     if (VMI_SUCCESS
             == linux_system_map_symbol_to_address(vmi, "swapper_pg_dir", NULL,
                     &vmi->kpgd)) {
-        dbprint("--got vaddr for swapper_pg_dir (0x%.16"PRIx64").\n",
+        dbprint(VMI_DEBUG_MISC, "--got vaddr for swapper_pg_dir (0x%.16"PRIx64").\n",
                 vmi->kpgd);
         if (driver_is_pv(vmi)) {
             vmi->kpgd = vmi_translate_kv2p(vmi, vmi->kpgd);
@@ -74,7 +74,7 @@ status_t linux_init(vmi_instance_t vmi) {
         }
     }
 
-    dbprint("**set vmi->kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
+    dbprint(VMI_DEBUG_MISC, "**set vmi->kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
     ret = linux_system_map_symbol_to_address(vmi, "init_task", NULL,
             &vmi->init_task);

--- a/libvmi/os/windows/kpcr.c
+++ b/libvmi/os/windows/kpcr.c
@@ -736,31 +736,31 @@ find_windows_version(
     vmi_read_16_pa(vmi, KdVersionBlock + 0x14, &size);
 
     if (memcmp(&size, "\x08\x02", 2) == 0) {
-        dbprint("--OS Guess: Windows 2000\n");
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Windows 2000\n");
         return VMI_OS_WINDOWS_2000;
     }
     else if (memcmp(&size, "\x90\x02", 2) == 0) {
-        dbprint("--OS Guess: Windows XP\n");
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Windows XP\n");
         return VMI_OS_WINDOWS_XP;
     }
     else if (memcmp(&size, "\x18\x03", 2) == 0) {
-        dbprint("--OS Guess: Windows 2003\n");
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Windows 2003\n");
         return VMI_OS_WINDOWS_2003;
     }
     else if (memcmp(&size, "\x28\x03", 2) == 0) {
-        dbprint("--OS Guess: Windows Vista\n");
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Windows Vista\n");
         return VMI_OS_WINDOWS_VISTA;
     }
     else if (memcmp(&size, "\x30\x03", 2) == 0) {
-        dbprint("--OS Guess: Windows 2008\n");
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Windows 2008\n");
         return VMI_OS_WINDOWS_2008;
     }
     else if (memcmp(&size, "\x40\x03", 2) == 0) {
-        dbprint("--OS Guess: Windows 7\n");
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Windows 7\n");
         return VMI_OS_WINDOWS_7;
     }
     else {
-        dbprint("--OS Guess: Unknown (0x%.4x)\n", size);
+        dbprint(VMI_DEBUG_MISC, "--OS Guess: Unknown (0x%.4x)\n", size);
         return VMI_OS_WINDOWS_UNKNOWN;
     }
 }
@@ -842,7 +842,7 @@ find_kdversionblock_address_fast(
     }   // outer for
 
     if (kdvb_address)
-        dbprint("--Found KD version block at PA %.16"PRIx64"\n",
+        dbprint(VMI_DEBUG_MISC, "--Found KD version block at PA %.16"PRIx64"\n",
                 kdvb_address);
     boyer_moore_fini(bm);
     return kdvb_address;
@@ -924,7 +924,7 @@ done:
     g_slist_free(va_pages);
 
     if (VMI_SUCCESS == ret)
-        dbprint("--Found KD version block at PA %.16"PRIx64" VA %.16"PRIx64"\n",
+        dbprint(VMI_DEBUG_MISC, "--Found KD version block at PA %.16"PRIx64" VA %.16"PRIx64"\n",
                 *kdvb_pa, *kdvb_va);
     boyer_moore_fini(bm);
     return ret;
@@ -947,7 +947,7 @@ init_kdversion_block(
     windows = vmi->os_data;
 
     if(VMI_FAILURE == find_kdversionblock_address_faster(vmi, &KdVersionBlock_phys, &KdVersionBlock_virt)) {
-        dbprint("**Failed to find KdVersionBlock\n");
+        dbprint(VMI_DEBUG_MISC, "**Failed to find KdVersionBlock\n");
         goto error_exit;
     }
 
@@ -957,7 +957,7 @@ init_kdversion_block(
             ("LibVMI Suggestion: set win_kdvb=0x%"PRIx64" in libvmi.conf for faster startup.\n",
              windows->kdversion_block);
     }
-    dbprint("**set KdVersionBlock address=0x%"PRIx64"\n",
+    dbprint(VMI_DEBUG_MISC, "**set KdVersionBlock address=0x%"PRIx64"\n",
             windows->kdversion_block);
 
     return VMI_SUCCESS;

--- a/libvmi/os/windows/memory.c
+++ b/libvmi/os/windows/memory.c
@@ -49,7 +49,7 @@ windows_kernel_symbol_to_address(
     else {
         driver_get_vcpureg(vmi, &cr3, CR3, 0);
     }
-    dbprint("--windows symbol lookup (%s)\n", symbol);
+    dbprint(VMI_DEBUG_MISC, "--windows symbol lookup (%s)\n", symbol);
 
     if (kernel_base_address) {
         *kernel_base_address = windows->ntoskrnl_va;
@@ -58,11 +58,11 @@ windows_kernel_symbol_to_address(
     /* check kpcr if we have a cr3 */
     if ( /*cr3 && */ VMI_SUCCESS ==
         windows_kpcr_lookup(vmi, symbol, address)) {
-        dbprint("--got symbol from kpcr (%s --> 0x%"PRIx64").\n", symbol,
+        dbprint(VMI_DEBUG_MISC, "--got symbol from kpcr (%s --> 0x%"PRIx64").\n", symbol,
                 *address);
         return VMI_SUCCESS;
     }
-    dbprint("--kpcr lookup failed, trying kernel PE export table\n");
+    dbprint(VMI_DEBUG_MISC, "--kpcr lookup failed, trying kernel PE export table\n");
 
     /* check exports */
     if (VMI_SUCCESS
@@ -71,11 +71,11 @@ windows_kernel_symbol_to_address(
         addr_t rva = *address;
 
         *address = windows->ntoskrnl_va + rva;
-        dbprint("--got symbol from PE export table (%s --> 0x%.16"PRIx64").\n",
+        dbprint(VMI_DEBUG_MISC, "--got symbol from PE export table (%s --> 0x%.16"PRIx64").\n",
              symbol, *address);
         return VMI_SUCCESS;
     }
-    dbprint("--kernel PE export table failed, nothing left to try\n");
+    dbprint(VMI_DEBUG_MISC, "--kernel PE export table failed, nothing left to try\n");
 
     return VMI_FAILURE;
 }

--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -231,7 +231,7 @@ get_aon_index(
 
     if (-1 == index) {
         dbprint
-            ("--PEParse: Falling back to linear search for aon index\n");
+            (VMI_DEBUG_MISC, "--PEParse: Falling back to linear search for aon index\n");
         // This could be useful for malformed PE headers where the list isn't
         // in alpha order (e.g., malware)
         index = get_aon_index_linear(vmi, symbol, et, base_addr, pid);
@@ -252,21 +252,21 @@ peparse_validate_pe_image(
     //vmi_print_hex (image, MAX_HEADER_BYTES);
 
     if (IMAGE_DOS_HEADER != dos_header->signature) {
-        dbprint("--PEPARSE: DOS header signature not found\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: DOS header signature not found\n");
         return VMI_FAILURE;
     }
 
     uint32_t ofs_to_pe = dos_header->offset_to_pe;
 
     if (ofs_to_pe > len - fixed_header_sz) {
-        dbprint("--PEPARSE: DOS header offset to PE value too big\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: DOS header offset to PE value too big\n");
         return VMI_FAILURE;
     }
 
     struct pe_header *pe_header =
         (struct pe_header *) (image + ofs_to_pe);
     if (IMAGE_NT_SIGNATURE != pe_header->signature) {
-        dbprint("--PEPARSE: PE header signature invalid\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: PE header signature invalid\n");
         return VMI_FAILURE;
     }
 
@@ -277,7 +277,7 @@ peparse_validate_pe_image(
 
     if (IMAGE_PE32_MAGIC != pe_opt_header->magic &&
         IMAGE_PE32_PLUS_MAGIC != pe_opt_header->magic) {
-        dbprint("--PEPARSE: Optional header magic value unknown\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: Optional header magic value unknown\n");
         return VMI_FAILURE;
     }
 
@@ -295,14 +295,14 @@ peparse_get_image_phys(
     uint32_t nbytes = vmi_read_pa(vmi, base_paddr, (void *)image, len);
 
     if(nbytes != len) {
-        dbprint("--PEPARSE: failed to read a continuous PE header\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: failed to read a continuous PE header\n");
         return VMI_FAILURE;
     }
 
     if(VMI_SUCCESS != peparse_validate_pe_image(image, len)) {
-        dbprint("--PEPARSE: failed to validate a continuous PE header\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: failed to validate a continuous PE header\n");
         if(vmi->init_mode & VMI_INIT_COMPLETE) {
-            dbprint("--PEPARSE: You might want to use peparse_get_image_virt here!\n");
+            dbprint(VMI_DEBUG_MISC, "--PEPARSE: You might want to use peparse_get_image_virt here!\n");
         }
 
         return VMI_FAILURE;
@@ -323,12 +323,12 @@ peparse_get_image_virt(
     uint32_t nbytes = vmi_read_va(vmi, base_vaddr, pid, (void *)image, len);
 
     if(nbytes != len) {
-        dbprint("--PEPARSE: failed to read PE header\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: failed to read PE header\n");
         return VMI_FAILURE;
     }
 
     if(VMI_SUCCESS != peparse_validate_pe_image(image, len)) {
-        dbprint("--PEPARSE: failed to validate PE header(s)\n");
+        dbprint(VMI_DEBUG_MISC, "--PEPARSE: failed to validate PE header(s)\n");
         return VMI_FAILURE;
     }
 
@@ -366,7 +366,7 @@ peparse_assign_headers(
         *optional_header_type = magic;
     }
 
-    dbprint("--PEParse: magic is 0x%"PRIx16"\n", magic);
+    dbprint(VMI_DEBUG_MISC, "--PEParse: magic is 0x%"PRIx16"\n", magic);
 
     if(magic == IMAGE_PE32_MAGIC && oh_pe32 != NULL) {
         *oh_pe32 = (struct optional_header_pe32 *) op_h_t;
@@ -417,7 +417,7 @@ peparse_get_idd_rva(
 done:
     if(rva == 0) {
         // Could this be legit? If not, we might want to switch this to a status_t function
-        dbprint("--PEParse: Image data directory RVA is 0\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: Image data directory RVA is 0\n");
     }
 
     return rva;
@@ -509,19 +509,19 @@ peparse_get_export_table(
     export_header_va = base_vaddr + export_header_rva;
 
     dbprint
-        ("--PEParse: found export table at [VA] 0x%.16"PRIx64" = 0x%.16"PRIx64" + 0x%"PRIx64"\n",
+        (VMI_DEBUG_MISC, "--PEParse: found export table at [VA] 0x%.16"PRIx64" = 0x%.16"PRIx64" + 0x%"PRIx64"\n",
          export_header_va, ((windows_instance_t)vmi->os_data)->ntoskrnl_va,
          export_header_rva);
 
     nbytes = vmi_read_va(vmi, export_header_va, pid, et, sizeof(*et));
     if (nbytes != sizeof(struct export_table)) {
-        dbprint("--PEParse: failed to map export header\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: failed to map export header\n");
         return VMI_FAILURE;
     }
 
     /* sanity check */
     if (et->export_flags || !et->name) {
-        dbprint("--PEParse: bad export directory table\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: bad export directory table\n");
         return VMI_FAILURE;
     }
 
@@ -545,19 +545,19 @@ windows_export_to_rva(
 
     // get export table structure
     if (peparse_get_export_table(vmi, base_vaddr, pid, &et, &et_rva, &et_size) != VMI_SUCCESS) {
-        dbprint("--PEParse: failed to get export table\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: failed to get export table\n");
         return VMI_FAILURE;
     }
 
     // find AddressOfNames index for export symbol
     if ((aon_index = get_aon_index(vmi, symbol, &et, base_vaddr, pid)) == -1) {
-        dbprint("--PEParse: failed to get aon index\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: failed to get aon index\n");
         return VMI_FAILURE;
     }
 
     // find AddressOfFunctions index for export symbol
     if ((aof_index = get_aof_index(vmi, aon_index, &et, base_vaddr, pid)) == -1) {
-        dbprint("--PEParse: failed to get aof index\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: failed to get aof index\n");
         return VMI_FAILURE;
     }
 
@@ -568,7 +568,7 @@ windows_export_to_rva(
         // If the function's RVA is inside the exports section (as given by the
         // VirtualAddress and Size fields in the idd), the symbol is forwarded.
         if(*rva>=et_rva && *rva < et_rva+et_size) {
-            dbprint("--PEParse: %s @ %u:0x%"PRIx64" is forwarded\n", symbol, pid, base_vaddr);
+            dbprint(VMI_DEBUG_MISC, "--PEParse: %s @ %u:0x%"PRIx64" is forwarded\n", symbol, pid, base_vaddr);
             return VMI_FAILURE;
         } else {
             return VMI_SUCCESS;
@@ -595,12 +595,12 @@ windows_rva_to_export(
 
     // get export table structure
     if (peparse_get_export_table(vmi, base_vaddr, pid, &et, &et_rva, &et_size) != VMI_SUCCESS) {
-        dbprint("--PEParse: failed to get export table\n");
+        dbprint(VMI_DEBUG_MISC, "--PEParse: failed to get export table\n");
         return NULL;
     }
 
     if(rva>=et_rva && rva < et_rva+et_size) {
-        dbprint("--PEParse: symbol @ %u:0x%"PRIx64" is forwarded\n", pid, base_vaddr+rva);
+        dbprint(VMI_DEBUG_MISC, "--PEParse: symbol @ %u:0x%"PRIx64" is forwarded\n", pid, base_vaddr+rva);
         return NULL;
     }
 
@@ -627,7 +627,7 @@ windows_rva_to_export(
                 return symbol;
             }
 
-            dbprint("--PEParse: symbol @ %u:0x%"PRIx64" is exported by ordinal only\n", pid, base_vaddr+rva);
+            dbprint(VMI_DEBUG_MISC, "--PEParse: symbol @ %u:0x%"PRIx64" is exported by ordinal only\n", pid, base_vaddr+rva);
             break;
         }
     }

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -142,7 +142,7 @@ get_check_magic_func(
     default:
         rtn = &check_magic_unknown;
         dbprint
-            ("--%s: illegal value in vmi->os.windows_instance.version\n",
+            (VMI_DEBUG_MISC, "--%s: illegal value in vmi->os.windows_instance.version\n",
              __FUNCTION__);
         break;
     }
@@ -181,7 +181,7 @@ find_pname_offset(
 
             if (check(value)) { // look for specific magic #
                 dbprint
-                    ("--%s: found magic value 0x%.8"PRIx32" @ offset 0x%.8"PRIx64"\n",
+                    (VMI_DEBUG_MISC, "--%s: found magic value 0x%.8"PRIx32" @ offset 0x%.8"PRIx64"\n",
                      __FUNCTION__, value, block_pa + offset);
 
                 unsigned char haystack[0x500];
@@ -202,7 +202,7 @@ find_pname_offset(
                     vmi->init_task =
                         block_pa + offset;
                     dbprint
-                        ("--%s: found Idle process at 0x%.8"PRIx64" + 0x%x\n",
+                        (VMI_DEBUG_MISC, "--%s: found Idle process at 0x%.8"PRIx64" + 0x%x\n",
                          __FUNCTION__, block_pa + offset, i);
                     boyer_moore_fini(bm);
                     return i;
@@ -277,11 +277,11 @@ windows_find_eprocess(
         windows->pname_offset =
             find_pname_offset(vmi, check);
         if (windows->pname_offset == 0) {
-            dbprint("--failed to find pname_offset\n");
+            dbprint(VMI_DEBUG_MISC, "--failed to find pname_offset\n");
             return 0;
         }
         else {
-            dbprint("**set os.windows_instance.pname_offset (0x%"PRIx64")\n",
+            dbprint(VMI_DEBUG_MISC, "**set os.windows_instance.pname_offset (0x%"PRIx64")\n",
                     windows->pname_offset);
         }
     }

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -39,6 +39,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <inttypes.h>
+#include "debug.h"
 #include "libvmi.h"
 #include "os/os_interface.h"
 
@@ -174,11 +175,12 @@ typedef struct _windows_unicode_string32 {
  * convenience.c
  */
 #ifndef VMI_DEBUG
-#define dbprint(format, args...) ((void)0)
+#define dbprint(category, format, args...) ((void)0)
 #else
     void dbprint(
+    vmi_debug_flag_t category,
     char *format,
-    ...) __attribute__((format(printf,1,2)));
+    ...) __attribute__((format(printf,2,3)));
 #endif
     void errprint(
     char *format,

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -101,7 +101,7 @@ vmi_read_va(
     size_t buf_offset = 0;
 
     if (NULL == buf) {
-        dbprint("--%s: buf passed as NULL, returning without read\n",
+        dbprint(VMI_DEBUG_READ, "--%s: buf passed as NULL, returning without read\n",
                 __FUNCTION__);
         return 0;
     }
@@ -181,7 +181,7 @@ vmi_read_ksym(
     addr_t vaddr = vmi_translate_ksym2v(vmi, sym);
 
     if (0 == vaddr) {
-        dbprint("--%s: vmi_translate_ksym2v failed for '%s'\n",
+        dbprint(VMI_DEBUG_READ, "--%s: vmi_translate_ksym2v failed for '%s'\n",
                 __FUNCTION__, sym);
         return 0;
     }
@@ -469,7 +469,7 @@ vmi_read_win_unicode_struct_va(
         read = vmi_read_va(vmi, vaddr, pid, &us64, struct_size);
         if (read != struct_size) {
             dbprint
-                ("--%s: failed to read UNICODE_STRING at VA 0x%.16"PRIx64" for pid %d\n",
+                (VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING at VA 0x%.16"PRIx64" for pid %d\n",
                  __FUNCTION__, vaddr, pid);
             goto out_error;
         }   // if
@@ -483,7 +483,7 @@ vmi_read_win_unicode_struct_va(
         read = vmi_read_va(vmi, vaddr, pid, &us32, struct_size);
         if (read != struct_size) {
             dbprint
-                ("--%s: failed to read UNICODE_STRING at VA 0x%.16"PRIx64" for pid %d\n",
+                (VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING at VA 0x%.16"PRIx64" for pid %d\n",
                  __FUNCTION__, vaddr, pid);
             goto out_error;
         }   // if
@@ -500,7 +500,7 @@ vmi_read_win_unicode_struct_va(
     read = vmi_read_va(vmi, buffer_va, pid, us->contents, us->length);
     if (read != us->length) {
         dbprint
-            ("--%s: failed to read buffer at VA 0x%.16"PRIx64" for pid %d\n",
+            (VMI_DEBUG_READ, "--%s: failed to read buffer at VA 0x%.16"PRIx64" for pid %d\n",
              __FUNCTION__, buffer_va, pid);
         goto out_error;
     }   // if
@@ -569,11 +569,11 @@ vmi_convert_str_encoding(
     cd = iconv_open(out->encoding, in->encoding);   // outset, inset
     if ((iconv_t) (-1) == cd) { // init failure
         if (EINVAL == errno) {
-            dbprint("%s: conversion from '%s' to '%s' not supported\n",
+            dbprint(VMI_DEBUG_READ, "%s: conversion from '%s' to '%s' not supported\n",
                     __FUNCTION__, in->encoding, out->encoding);
         }
         else {
-            dbprint("%s: Initializiation failure: %s\n", __FUNCTION__,
+            dbprint(VMI_DEBUG_READ, "%s: Initializiation failure: %s\n", __FUNCTION__,
                     strerror(errno));
         }   // if-else
         goto fail;
@@ -583,21 +583,21 @@ vmi_convert_str_encoding(
 
     iconv_val = iconv(cd, &incurr, &inlen, &outcurr, &outlen);
     if ((size_t) - 1 == iconv_val) {
-        dbprint("%s: iconv failed, in string '%s' length %zu, "
+        dbprint(VMI_DEBUG_READ, "%s: iconv failed, in string '%s' length %zu, "
                 "out string '%s' length %zu\n", __FUNCTION__,
                 in->contents, in->length, out->contents, outlen);
         switch (errno) {
         case EILSEQ:
-            dbprint("invalid multibyte sequence");
+            dbprint(VMI_DEBUG_READ, "invalid multibyte sequence");
             break;
         case EINVAL:
-            dbprint("incomplete multibyte sequence");
+            dbprint(VMI_DEBUG_READ, "incomplete multibyte sequence");
             break;
         case E2BIG:
-            dbprint("no more room");
+            dbprint(VMI_DEBUG_READ, "no more room");
             break;
         default:
-            dbprint("error: %s\n", strerror(errno));
+            dbprint(VMI_DEBUG_READ, "error: %s\n", strerror(errno));
             break;
         }   // switch
         goto fail;

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -39,7 +39,7 @@ vmi_write_pa(
     size_t count)
 {
     if (NULL == buf) {
-        dbprint("--%s: buf passed as NULL, returning without write\n",
+        dbprint(VMI_DEBUG_WRITE, "--%s: buf passed as NULL, returning without write\n",
                 __FUNCTION__);
         return 0;
     }
@@ -65,7 +65,7 @@ vmi_write_va(
     size_t buf_offset = 0;
 
     if (NULL == buf) {
-        dbprint("--%s: buf passed as NULL, returning without write\n",
+        dbprint(VMI_DEBUG_WRITE, "--%s: buf passed as NULL, returning without write\n",
                 __FUNCTION__);
         return 0;
     }


### PR DESCRIPTION
Trying to debug LibVMI with the debug output currently is quite a challenge considering the verbosity of the debug output. While generally it is OK to just run the app with all debug output piped into a file and grepping later for the type of debug output that one is interested in, with events that debugging flow is quite inconvenient. 

With this PR dbprint is refactored as to take a debug category as the first input so that one can select which output to get printed. This is only a first pass, haven't categorized everything appropriately so far (there is a bunch that are still under VMI_DEBUG_MISC).

RFC
