### PR TITLE
Allow introspecting cloned Xen domains

### DIFF
--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -929,9 +929,10 @@ xen_get_memsize(
     // note: may also available through xen_get_instance(vmi)->info.max_memkb
     // or xenstore /local/domain/%d/memory/target
     status_t ret = VMI_FAILURE;
+    uint64_t pages = xen_get_instance(vmi)->info.nr_pages + xen_get_instance(vmi)->info.nr_shared_pages;
 
-    if(xen_get_instance(vmi)->info.nr_pages > 0) {
-        *size = XC_PAGE_SIZE * xen_get_instance(vmi)->info.nr_pages;
+    if(pages > 0) {
+        *size = XC_PAGE_SIZE * pages;
         ret = VMI_SUCCESS;
     }
 


### PR DESCRIPTION
When using the Xen memory sharing feature to create clones causes nr_pages to no longer report the correct size of the VM's total memory. This PR fixes the issue by adding nr_shared_pages to the memory calculation, allowing LibVMI to fully init on cloned domains.
