### PR TITLE
Call v2p_cache_destroy in vmi_destroy

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -749,6 +749,7 @@ vmi_destroy(
     pid_cache_destroy(vmi);
     sym_cache_destroy(vmi);
     rva_cache_destroy(vmi);
+    v2p_cache_destroy(vmi);
 #if ENABLE_SHM_SNAPSHOT == 1
     v2m_cache_destroy(vmi);
 #endif


### PR DESCRIPTION
Fix memory leak of v2p_cache:

==00:00:00:01.294 11115== 184 (88 direct, 96 indirect) bytes in 1 blocks are definitely lost in loss record 9 of 14
==00:00:00:01.294 11115==    at 0x4C294C4: malloc (vg_replace_malloc.c:291)
==00:00:00:01.294 11115==    by 0x5936F30: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.3200.4)
==00:00:00:01.295 11115==    by 0x594B322: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.3200.4)
==00:00:00:01.295 11115==    by 0x5921252: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.3200.4)
==00:00:00:01.295 11115==    by 0x5BE5CC0: v2p_cache_init (cache.c:500)
==00:00:00:01.295 11115==    by 0x5BE6827: vmi_init_private (core.c:496)
==00:00:00:01.295 11115==    by 0x5BE6E2A: vmi_init_custom (core.c:670)
