### PR TITLE
Fix domain name string leak

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -446,16 +446,15 @@ set_id_and_name(
             }
         }
 
-       if(name != NULL) {
-               vmi->image_type = strndup(name, 100);
-               driver_set_name(vmi, name);
-       } else {
-               // create placeholder for image_type
-               char *idstring = malloc(snprintf(NULL, 0, "domid-%lu", id) + 1);
-               sprintf(idstring, "domid-%lu", id);
-               vmi->image_type = idstring;
-       }
-
+        if(name != NULL) {
+            vmi->image_type = name;
+            driver_set_name(vmi, name);
+        } else {
+            // create placeholder for image_type
+            char *idstring = malloc(snprintf(NULL, 0, "domid-%lu", id) + 1);
+            sprintf(idstring, "domid-%lu", id);
+            vmi->image_type = idstring;
+        }
     }
     dbprint("**set image_type = %s\n", vmi->image_type);
     return VMI_SUCCESS;


### PR DESCRIPTION
==00:00:01:17.086 21490== 20 bytes in 1 blocks are definitely lost in loss record 2 of 9
==00:00:01:17.086 21490==    at 0x4C294C4: malloc (vg_replace_malloc.c:292)
==00:00:01:17.086 21490==    by 0x505777A: read_message (xs.c:1145)
==00:00:01:17.086 21490==    by 0x5057AE4: xs_talkv (xs.c:428)
==00:00:01:17.086 21490==    by 0x5057E28: xs_single (xs.c:546)
==00:00:01:17.086 21490==    by 0x5058584: xs_read (xs.c:592)
==00:00:01:17.086 21490==    by 0x5EC15DC: xen_get_name_from_domainid (xen.c:621)
==00:00:01:17.086 21490==    by 0x5EBAB86: vmi_init_private (core.c:437)
==00:00:01:17.086 21490==    by 0x5EBAE8A: vmi_init_custom (core.c:670)
