### PR TITLE
Introduce libvmi_extra.h for exposing functions that require GLib

### DIFF
--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = config
 
-h_sources = libvmi.h peparse.h
+h_sources = libvmi.h libvmi_extra.h peparse.h
 c_sources = \
     accessors.c \
     cache.c \

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -1,0 +1,63 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libvmi_extra.h
+ * @brief The Extra LibVMI API is defined here.
+ *
+ * Include this header requires you to compile your application with GLib.
+ */
+#ifndef LIBVMI_EXTRA_H
+#define LIBVMI_EXTRA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma GCC visibility push(default)
+
+#include <glib.h>
+#include <libvmi/libvmi.h>
+
+/** structure to hold virtual address and page size via vmi_get_va_pages */
+typedef struct va_page {
+    addr_t va;
+    page_size_t size;
+} va_page_t;
+
+/**
+ * Retrieve the pages mapped into the address space of a process.
+ * @param[in] vmi Instance
+ * @param[in] dtb The directory table base of the process
+ *
+ * @return GSList of va_page_t structures, or NULL on error.
+ * The caller is responsible for freeing the list and the structs.
+ */
+GSList* vmi_get_va_pages(
+    vmi_instance_t vmi,
+    addr_t dtb);
+
+#pragma GCC visibility pop
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBVMI_EXTRA_H */

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -697,7 +697,7 @@ GSList* get_va_pages_ia32e(vmi_instance_t vmi, addr_t dtb) {
     return ret;
 }
 
-GSList* get_va_pages(vmi_instance_t vmi, addr_t dtb) {
+GSList* vmi_get_va_pages(vmi_instance_t vmi, addr_t dtb) {
 
     GSList *ret = NULL;
 

--- a/libvmi/os/windows/kpcr.c
+++ b/libvmi/os/windows/kpcr.c
@@ -862,7 +862,7 @@ find_kdversionblock_address_faster(
 
     status_t ret = VMI_FAILURE;
     addr_t memsize = vmi_get_memsize(vmi);
-    GSList *va_pages = get_va_pages(vmi, (addr_t)cr3);
+    GSList *va_pages = vmi_get_va_pages(vmi, (addr_t)cr3);
     size_t read = 0;
     void *bm = 0;   // boyer-moore internal state
     int find_ofs = 0;

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -41,6 +41,7 @@
 #include <inttypes.h>
 #include "debug.h"
 #include "libvmi.h"
+#include "libvmi_extra.h"
 #include "os/os_interface.h"
 
 /**
@@ -152,12 +153,6 @@ typedef struct step_and_reg_event_wrapper {
     uint64_t steps;
     event_callback_t cb;
 } step_and_reg_event_wrapper_t;
-
-/** structure to hold virtual address and page size during get_va_pages */
-struct va_page {
-    addr_t va;
-    page_size_t size;
-};
 
 /** Windows' UNICODE_STRING structure (x86) */
 typedef struct _windows_unicode_string32 {
@@ -317,9 +312,6 @@ typedef struct _windows_unicode_string32 {
     void *vmi_read_page(
     vmi_instance_t vmi,
     addr_t frame_num);
-    GSList* get_va_pages(
-    vmi_instance_t vmi,
-    addr_t dtb);
 
 /*-----------------------------------------
  * strmatch.c


### PR DESCRIPTION
Splitting this work from the other PR as it is not strictly relevant.
