### PR TITLE
Towards multi-vCPU support for xen events

### DIFF
--- a/libvmi/driver/interface.c
+++ b/libvmi/driver/interface.c
@@ -129,6 +129,9 @@ struct driver_instance {
     *events_listen_ptr)(
     vmi_instance_t,
     uint32_t);
+    int (
+    *are_events_pending_ptr)(
+    vmi_instance_t);
     status_t (
     *set_reg_access_ptr)(
     vmi_instance_t,
@@ -196,6 +199,7 @@ driver_xen_setup(
 #endif
 #if ENABLE_XEN_EVENTS==1
     instance->events_listen_ptr = &xen_events_listen;
+    instance->are_events_pending_ptr = &xen_are_events_pending;
     instance->set_reg_access_ptr = &xen_set_reg_access;
     instance->set_intr_access_ptr = &xen_set_intr_access;
     instance->set_mem_access_ptr = &xen_set_mem_access;
@@ -204,6 +208,7 @@ driver_xen_setup(
     instance->shutdown_single_step_ptr = &xen_shutdown_single_step;
 #else
     instance->events_listen_ptr = NULL;
+    instance->are_events_pending_ptr = NULL;
     instance->set_reg_access_ptr = NULL;
     instance->set_mem_access_ptr = NULL;
     instance->start_single_step_ptr = NULL;
@@ -767,6 +772,19 @@ status_t driver_events_listen(
     }
     else{
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_events_listen function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+int driver_are_events_pending(
+    vmi_instance_t vmi)
+{
+    driver_instance_t ptrs = driver_get_instance(vmi);
+    if (NULL != ptrs && NULL != ptrs->are_events_pending_ptr){
+        return ptrs->are_events_pending_ptr(vmi);
+    }
+    else{
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_are_events_pending function not implemented.\n");
         return VMI_FAILURE;
     }
 }

--- a/libvmi/driver/interface.h
+++ b/libvmi/driver/interface.h
@@ -109,6 +109,8 @@ size_t driver_get_dgvma(
 status_t driver_events_listen(
     vmi_instance_t vmi,
     uint32_t timeout);
+int driver_are_events_pending(
+    vmi_instance_t vmi);
 status_t driver_set_mem_access(
     vmi_instance_t vmi,
     mem_event_t event,

--- a/libvmi/driver/xen_events.c
+++ b/libvmi/driver/xen_events.c
@@ -198,7 +198,7 @@ static int put_mem_response(xen_mem_event_t *mem_event, mem_event_response_t *rs
     return 0;
 }
 
-static int resume_domain(vmi_instance_t vmi, mem_event_response_t *rsp)
+static int resume_domain(vmi_instance_t vmi)
 {
     xc_interface * xch;
     xen_events_t * xe;
@@ -223,13 +223,9 @@ static int resume_domain(vmi_instance_t vmi, mem_event_response_t *rsp)
         return -1;
     }
 
-    // Put the page info on the ring
-    ret = put_mem_response(&xe->mem_event, rsp);
-    if ( ret != 0 )
-        return ret;
-
-    // Tell Xen page is ready
-    ret = xc_mem_access_resume(xch, dom, rsp->gfn);
+    // Tell Xen we have finished processing the requests
+    // The last argument is actually ignored by Xen.
+    ret = xc_mem_access_resume(xch, dom, 0);
     ret = xc_evtchn_notify(xe->mem_event.xce_handle, xe->mem_event.port);
     return ret;
 }
@@ -533,7 +529,8 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
      *       the second violation on the other vCPU would not get delivered..
      */
 
-    errprint("Caught a memory event that had no handler registered in LibVMI\n");
+    errprint("Caught a memory event that had no handler registered in LibVMI @ GFN %"PRIu32" (0x%"PRIx64"), access: %u\n",
+        req.gfn, (req.gfn<<12) + req.offset, out_access);
 
 errdone:
     return VMI_FAILURE;
@@ -567,6 +564,7 @@ status_t process_single_step_event(vmi_instance_t vmi, mem_event_request_t req)
         return VMI_SUCCESS;
     }
 
+    errprint("%s error: no singlestep handler is registered in LibVMI\n", __FUNCTION__);
     return VMI_FAILURE;
 }
 
@@ -1106,6 +1104,19 @@ status_t xen_shutdown_single_step(vmi_instance_t vmi) {
     return VMI_SUCCESS;
 }
 
+int xen_are_events_pending(vmi_instance_t vmi)
+{
+    xen_events_t *xe = xen_get_events(vmi);
+
+    if ( !xe ) {
+        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
+        return -1;
+    }
+
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring);
+
+}
+
 status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
 {
     xc_interface * xch;
@@ -1233,14 +1244,23 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
                 break;
         }
 
-        rc = resume_domain(vmi, &rsp);
+        // Put the response on the ring
+        rc = put_mem_response(&xe->mem_event, &rsp);
         if ( rc != 0 ) {
-            errprint("Error resuming domain.\n");
+            errprint("Error putting event response on the ring.\n");
             return VMI_FAILURE;
         }
+
+        dbprint(VMI_DEBUG_XEN, "--Finished handling event.\n");
     }
 
-    dbprint(VMI_DEBUG_XEN, "--Finished handling event.\n");
+    // We only resume the domain once all requests are processed from the ring
+    rc = resume_domain(vmi);
+    if ( rc != 0 ) {
+        errprint("Error resuming domain.\n");
+        return VMI_FAILURE;
+    }
+
     return vrc;
 }
 #else

--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -100,6 +100,7 @@ typedef struct xen_events {
 
 status_t xen_events_init(vmi_instance_t vmi);
 void xen_events_destroy(vmi_instance_t vmi);
+int xen_are_events_pending(vmi_instance_t vmi);
 status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
 status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t event);
 status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t event, uint8_t enabled);

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -779,6 +779,19 @@ done:
     return rc;
 }
 
+int vmi_are_events_pending(vmi_instance_t vmi)
+{
+
+    if (!(vmi->init_mode & VMI_INIT_EVENTS))
+    {
+        return -1;
+    }
+
+    return driver_are_events_pending(vmi);
+
+}
+
+
 status_t vmi_events_listen(vmi_instance_t vmi, uint32_t timeout)
 {
 

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1867,6 +1867,9 @@ status_t vmi_events_listen(
     vmi_instance_t vmi,
     uint32_t timeout);
 
+int vmi_are_events_pending(
+    vmi_instance_t vmi);
+
 /**
  * Return the pointer to the vmi_event_t if one is set on the given vcpu.
  *


### PR DESCRIPTION
When having multiple vCPUs in a guest and using xen events certain information has to be provided to the user as extra. Foremost, knowing whether more events are pending when a callback is issued is critical, as clearing the event handler in a callback with more events waiting on the ring would cause LibVMI to fall through. Furthermore, in the current implementation LibVMI automatically resumes the domain's execution after an event is handled, which is undesirable when still having unprocessed events on the ring. Therefore in this PR I changed the event handling to only place the responses on the ring in the loop, and issue the resume after all requests are processed.

Further work is required to better determine when it is safe to remove an event handler through vmi_event_clear. We could either have a default setting where events are dropped when the handler is not found anymore, or provide more information to the user about pending events to have them make a more informed decision what they want to do with them. This would require us copying all pending events from Xen to a local storage and checking what type of events we have pending.
