### PR TITLE
Extend vmi_pid_t to 128-bit so that it can be casted to be process_conte...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,8 @@ AM_PROG_CC_C_O
 AM_PROG_LIBTOOL
 AM_SANITY_CHECK
 
+AC_CHECK_TYPE([__int128_t],[], [AC_ERROR(__int128_t not supported by the compiler!)], [])
+
 have_xen='no'
 xen_space='      '
 have_xen_events='no'

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -147,7 +147,7 @@ int main (int argc, char **argv)
 
         /* NOTE: _EPROCESS.UniqueProcessId is a really VOID*, but is never > 32 bits,
          * so this is safe enough for x64 Windows for example purposes */
-        vmi_read_32_va(vmi, current_process + pid_offset, 0, &pid);
+        vmi_read_32_va(vmi, current_process + pid_offset, 0, (uint32_t *)&pid);
 
         procname = vmi_read_str_va(vmi, current_process + name_offset, 0);
 

--- a/examples/shm-snapshot-process-list.c
+++ b/examples/shm-snapshot-process-list.c
@@ -81,7 +81,7 @@ void list_processes(vmi_instance_t vmi, addr_t current_process,
 
         /* NOTE: _EPROCESS.UniqueProcessId is a really VOID*, but is never > 32 bits,
          * so this is safe enough for x64 Windows for example purposes */
-        vmi_read_32_va(vmi, current_process + pid_offset, 0, &pid);
+        vmi_read_32_va(vmi, current_process + pid_offset, 0, (uint32_t*)&pid);
 
         procname = vmi_read_str_va(vmi, current_process + name_offset, 0);
 

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -247,7 +247,19 @@ typedef enum registers {
 typedef uint64_t addr_t;
 
 /* type def for consistent pid_t usage */
-typedef int32_t vmi_pid_t;
+typedef __int128_t vmi_pid_t;
+
+/* Struct for holding process context for VA translation */
+typedef struct process_context {
+    union {
+        vmi_pid_t __pid;
+        struct {
+            int32_t pid;
+            addr_t dtb;
+        };
+    };
+} __attribute__ ((packed))
+process_context_t;
 
 /* Struct for holding page lookup information */
 typedef struct page_info {

--- a/libvmi/os/linux/memory.c
+++ b/libvmi/os/linux/memory.c
@@ -60,7 +60,7 @@ linux_get_taskstruct_addr_from_pid(
     list_head = next_process;
 
     do {
-        vmi_read_32_va(vmi, next_process + pid_offset, 0, &task_pid);
+        vmi_read_32_va(vmi, next_process + pid_offset, 0, (uint32_t*)&task_pid);
 
         /* if pid matches, then we found what we want */
         if (task_pid == pid) {
@@ -202,7 +202,7 @@ error_exit:
     return pgd;
 }
 
-int
+vmi_pid_t
 linux_pgd_to_pid(
     vmi_instance_t vmi,
     addr_t pgd)
@@ -228,7 +228,7 @@ linux_pgd_to_pid(
     }
 
     /* now follow the pointer to the memory descriptor and grab the pid value */
-    vmi_read_32_va(vmi, ts_addr + pid_offset, 0, &pid);
+    vmi_read_32_va(vmi, ts_addr + pid_offset, 0, (uint32_t*)&pid);
 
 error_exit:
     return pid;

--- a/libvmi/os/windows/memory.c
+++ b/libvmi/os/windows/memory.c
@@ -141,7 +141,7 @@ windows_pgd_to_pid(
 
     /* now follow the pointer to the memory descriptor and grab the pgd value */
     vmi_read_32_va(vmi, eprocess + pid_offset - tasks_offset, 0,
-                     &pid);
+                     (uint32_t*)&pid);
 
 error_exit:
     return pid;

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -314,7 +314,7 @@ windows_find_eprocess_list_pid(
         vmi_instance_t vmi,
         vmi_pid_t pid)
 {
-    size_t len = sizeof(vmi_pid_t);
+    size_t len = sizeof(int32_t);
     int pid_offset = 0;
 
     if (vmi->os_data == NULL) {

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -99,6 +99,7 @@ vmi_read_va(
     addr_t pfn = 0;
     addr_t offset = 0;
     size_t buf_offset = 0;
+    process_context_t *ctx = (process_context_t *)&pid;
 
     if (NULL == buf) {
         dbprint(VMI_DEBUG_READ, "--%s: buf passed as NULL, returning without read\n",
@@ -109,11 +110,12 @@ vmi_read_va(
     while (count > 0) {
         size_t read_len = 0;
 
-        if (pid) {
-            paddr = vmi_translate_uv2p(vmi, vaddr + buf_offset, pid);
-        }
-        else {
+        if (!ctx->pid) {
             paddr = vmi_translate_kv2p(vmi, vaddr + buf_offset);
+        } else if(ctx->pid > 0) {
+            paddr = vmi_translate_uv2p(vmi, vaddr + buf_offset, pid);
+        } else {
+            paddr = vmi_pagetable_lookup(vmi, vaddr, ctx->dtb);
         }
 
         if (!paddr) {

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -63,6 +63,7 @@ vmi_write_va(
     addr_t pfn = 0;
     addr_t offset = 0;
     size_t buf_offset = 0;
+    process_context_t *ctx = (process_context_t *)&pid;
 
     if (NULL == buf) {
         dbprint(VMI_DEBUG_WRITE, "--%s: buf passed as NULL, returning without write\n",
@@ -73,11 +74,12 @@ vmi_write_va(
     while (count > 0) {
         size_t write_len = 0;
 
-        if (pid) {
-            paddr = vmi_translate_uv2p(vmi, vaddr + buf_offset, pid);
-        }
-        else {
+        if (!ctx->pid) {
             paddr = vmi_translate_kv2p(vmi, vaddr + buf_offset);
+        } else if (ctx->pid > 0) {
+            paddr = vmi_translate_uv2p(vmi, vaddr + buf_offset, pid);
+        } else {
+            paddr = vmi_pagetable_lookup(vmi, vaddr, ctx->dtb);
         }
 
         if (!paddr) {


### PR DESCRIPTION
...xt_t which contains both a 32-bit pid and 64-bit dtb.

This PR allows one to safely cast process_context_t to vmi_pid_t to be used in the various *va functions available in LibVMI, while also being backwards compatibly where the vmi_pid_t was just an integer.

By casting a process_context_t to vmi_pid_t we can pass a dtb directly for libvmi to be used, instead of libvmi using its internal process list walking to determine the dtb from the pid. For this, the process_context_t has to specify a negative (invalid) pid, which triggers libvmi to use the dtb value in the context for the VA translation.
