### PR TITLE
Create compatibility wrapper for HVMMEM_access and the new XENMEM_access...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,19 @@ xen_event_space=' '
                 AC_CHECK_LIB(xenctrl, [xc_mem_event_enable], [AC_DEFINE([XENEVENT41], [1], "Xen memory event 4.1 style")], [no41events="1"])
                 AC_CHECK_LIB(xenctrl, [xc_mem_access_enable], [AC_DEFINE([XENEVENT42], [1], "Xen memory event 4.2 style")], [no42events="1"])
                 AC_CHECK_DEFINE(XENCTRL_HAS_XC_INTERFACE, xenctrl.h) 
-                
+
+                AC_CHECK_TYPE(
+                    [hvmmem_access_t],
+                    AC_DEFINE([XEN_MEMACCESS_VERSION], [44], [Define the Xen mem_access version.]),
+                    [],
+                    [#include <xenctrl.h> #include <xen/hvm/save.h>])
+
+                AC_CHECK_TYPE(
+                    [xenmem_access_t],
+                    AC_DEFINE([XEN_MEMACCESS_VERSION], [45], [Define the Xen mem_access_version.]),
+                    [],
+                    [#include <xenctrl.h> #include <xen/memory.h>])
+
                 # MSR events are only available in Xen 4.3+
                 AC_CHECK_DEFINE(MEM_EVENT_REASON_MSR, xen/mem_event.h) 
 

--- a/libvmi/driver/xen_events.h
+++ b/libvmi/driver/xen_events.h
@@ -61,7 +61,12 @@
 #if ENABLE_XEN == 1 && ENABLE_XEN_EVENTS==1
 #include <xenctrl.h>
 #include <xen/mem_event.h>
+
+#if XEN_MEMACCESS_VERSION == 44
 #include <xen/hvm/save.h>
+#elif XEN_MEMACCESS_VERSION == 45
+#include <xen/memory.h>
+#endif
 
 typedef int spinlock_t;
 #ifdef XENCTRL_HAS_XC_INTERFACE
@@ -89,6 +94,61 @@ typedef struct {
     spinlock_t ring_lock;
     unsigned long long max_pages;
 } xen_mem_event_t;
+
+// Compatibility wrapper around mem_access versions
+#if XEN_MEMACCESS_VERSION == 44
+typedef enum {
+    // Xen 4.0-4.4 type flags
+    MEMACCESS_N = HVMMEM_access_n,
+    MEMACCESS_R = HVMMEM_access_r,
+    MEMACCESS_W = HVMMEM_access_w,
+    MEMACCESS_RW = HVMMEM_access_rw,
+    MEMACCESS_X = HVMMEM_access_x,
+    MEMACCESS_RX = HVMMEM_access_rx,
+    MEMACCESS_WX = HVMMEM_access_wx,
+    MEMACCESS_RWX = HVMMEM_access_rwx,
+    /*
+     * Page starts off as r-x, but automatically
+     * change to r-w on a write
+     */
+    MEMACCESS_RX2RW = HVMMEM_access_rx2rw,
+    /*
+     * Log access: starts off as n, automatically
+     * goes to rwx, generating an event without
+     * pausing the vcpu
+     */
+    MEMACCESS_N2RWX = HVMMEM_access_n2rwx
+} compat_memaccess_t;
+
+typedef hvmmem_access_t mem_access_t;
+
+#elif XEN_MEMACCESS_VERSION == 45
+typedef enum {
+    // Xen 4.5+ type flags
+    MEMACCESS_N = XENMEM_access_n,
+    MEMACCESS_R = XENMEM_access_r,
+    MEMACCESS_W = XENMEM_access_w,
+    MEMACCESS_RW = XENMEM_access_rw,
+    MEMACCESS_X = XENMEM_access_x,
+    MEMACCESS_RX = XENMEM_access_rx,
+    MEMACCESS_WX = XENMEM_access_wx,
+    MEMACCESS_RWX = XENMEM_access_rwx,
+    /*
+     * Page starts off as r-x, but automatically
+     * change to r-w on a write
+     */
+    MEMACCESS_RX2RW = XENMEM_access_rx2rw,
+    /*
+     * Log access: starts off as n, automatically
+     * goes to rwx, generating an event without
+     * pausing the vcpu
+     */
+    MEMACCESS_N2RWX = XENMEM_access_n2rwx
+} compat_memaccess_t;
+typedef xenmem_access_t mem_access_t;
+
+#endif
+
 #else
 typedef struct {
 } xen_mem_event_t;

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -45,9 +45,9 @@ vmi_mem_access_t combine_mem_access(vmi_mem_access_t base, vmi_mem_access_t add)
         return add;
 
     // Can't combine rights with X_ON_WRITE
-    if (add == VMI_MEMACCESS_X_ON_WRITE)
+    if (add == VMI_MEMACCESS_RX2RW || add == VMI_MEMACCESS_N2RWX)
         return VMI_MEMACCESS_INVALID;
-    if (base == VMI_MEMACCESS_X_ON_WRITE)
+    if (base == VMI_MEMACCESS_RX2RW || base == VMI_MEMACCESS_N2RWX)
         return VMI_MEMACCESS_INVALID;
 
     return (base | add);

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1548,7 +1548,8 @@ typedef enum {
     VMI_MEMACCESS_RX         = (VMI_MEMACCESS_R | VMI_MEMACCESS_X),
     VMI_MEMACCESS_WX         = (VMI_MEMACCESS_W | VMI_MEMACCESS_X),
     VMI_MEMACCESS_RWX        = (VMI_MEMACCESS_R | VMI_MEMACCESS_W | VMI_MEMACCESS_X),
-    VMI_MEMACCESS_X_ON_WRITE = (1 << 4)
+    VMI_MEMACCESS_RX2RW      = (1 << 4),
+    VMI_MEMACCESS_N2RWX      = (1 << 5)
 } vmi_mem_access_t;
 
 /* The level of granularity used in the configuration of a memory event.


### PR DESCRIPTION
... flags and make all flags available via LibVMI.

This PR adds support to the upcoming Xen change from HVMMEM_access to the more generic XENMEM_access (http://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=fce5281c5a7f37eb0157a32626f7184e106aafe6). I also renamed the incorrectly named LibVMI flag X_ON_WRITE flag to RX2RW and included the thus far missing flag N2RWX in this PR.
