### PR TITLE
Move Windows unicode read-code into the OS specific layer

### DIFF
--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -31,7 +31,8 @@ c_sources = \
     os/windows/memory.c \
     os/windows/symbols.c \
     os/windows/peparse.c \
-    os/windows/process.c
+    os/windows/process.c \
+    os/windows/unicode.c
 
 library_includedir=$(includedir)/$(LIBRARY_NAME)
 library_include_HEADERS = $(h_sources)

--- a/libvmi/convenience.c
+++ b/libvmi/convenience.c
@@ -30,6 +30,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <iconv.h>  // conversion between character sets
+
 #ifndef VMI_DEBUG
 /* Nothing */
 #else
@@ -134,6 +136,86 @@ is_addr_aligned(
     addr_t addr)
 {
     return (addr == aligned_addr(vmi, addr));
+}
+
+status_t
+vmi_convert_str_encoding(
+    const unicode_string_t *in,
+    unicode_string_t *out,
+    const char *outencoding)
+{
+    iconv_t cd = 0;
+    size_t iconv_val = 0;
+
+    size_t inlen = in->length;
+    size_t outlen = 2 * (inlen + 1);
+
+    char *instart = in->contents;
+    char *incurr = in->contents;
+
+    memset(out, 0, sizeof(*out));
+    out->contents = safe_malloc(outlen);
+    memset(out->contents, 0, outlen);
+
+    char *outstart = out->contents;
+    char *outcurr = out->contents;
+
+    out->encoding = outencoding;
+
+    cd = iconv_open(out->encoding, in->encoding);   // outset, inset
+    if ((iconv_t) (-1) == cd) { // init failure
+        if (EINVAL == errno) {
+            dbprint(VMI_DEBUG_READ, "%s: conversion from '%s' to '%s' not supported\n",
+                    __FUNCTION__, in->encoding, out->encoding);
+        }
+        else {
+            dbprint(VMI_DEBUG_READ, "%s: Initializiation failure: %s\n", __FUNCTION__,
+                    strerror(errno));
+        }   // if-else
+        goto fail;
+    }   // if
+
+    // init success
+
+    iconv_val = iconv(cd, &incurr, &inlen, &outcurr, &outlen);
+    if ((size_t) - 1 == iconv_val) {
+        dbprint(VMI_DEBUG_READ, "%s: iconv failed, in string '%s' length %zu, "
+                "out string '%s' length %zu\n", __FUNCTION__,
+                in->contents, in->length, out->contents, outlen);
+        switch (errno) {
+        case EILSEQ:
+            dbprint(VMI_DEBUG_READ, "invalid multibyte sequence");
+            break;
+        case EINVAL:
+            dbprint(VMI_DEBUG_READ, "incomplete multibyte sequence");
+            break;
+        case E2BIG:
+            dbprint(VMI_DEBUG_READ, "no more room");
+            break;
+        default:
+            dbprint(VMI_DEBUG_READ, "error: %s\n", strerror(errno));
+            break;
+        }   // switch
+        goto fail;
+    }   // if failure
+
+    // conversion success
+    out->length = (size_t) (outcurr - outstart);
+    (void) iconv_close(cd);
+    return VMI_SUCCESS;
+
+fail:
+    if (out->contents) {
+        free(out->contents);
+    }
+    // make failure really obvious
+    memset(out, 0, sizeof(*out));
+
+    if ((iconv_t) (-1) != cd) { // init succeeded
+        (void) iconv_close(cd);
+    }   // if
+
+    return VMI_FAILURE;
 }
 
 void

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -131,6 +131,7 @@ status_t linux_init(vmi_instance_t vmi) {
     os_interface->os_ksym2v = linux_system_map_symbol_to_address;
     os_interface->os_usym2rva = NULL;
     os_interface->os_rva2sym = NULL;
+    os_interface->os_read_unicode_struct = NULL;
     os_interface->os_teardown = linux_teardown;
 
     vmi->os_interface = os_interface;

--- a/libvmi/os/os_interface.h
+++ b/libvmi/os/os_interface.h
@@ -43,6 +43,9 @@ typedef status_t (*os_user_symbol_to_rva_t)(vmi_instance_t instance,
 typedef char* (*os_rva_to_symbol_t)(vmi_instance_t vmi, addr_t rva,
         addr_t base_vaddr, vmi_pid_t pid);
 
+typedef unicode_string_t* (*os_read_unicode_struct_t)(vmi_instance_t vmi,
+        addr_t vaddr, vmi_pid_t pid);
+
 typedef status_t (*os_teardown_t)(vmi_instance_t vmi);
 
 struct os_interface {
@@ -52,6 +55,7 @@ struct os_interface {
     os_kernel_symbol_to_address_t os_ksym2v;
     os_user_symbol_to_rva_t os_usym2rva;
     os_rva_to_symbol_t os_rva2sym;
+    os_read_unicode_struct_t os_read_unicode_struct;
     os_teardown_t os_teardown;
 };
 typedef struct os_interface *os_interface_t;

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -627,6 +627,7 @@ windows_init(
     os_interface->os_ksym2v = windows_kernel_symbol_to_address;
     os_interface->os_usym2rva = windows_export_to_rva;
     os_interface->os_rva2sym = windows_rva_to_export;
+    os_interface->os_read_unicode_struct = windows_read_unicode_struct;
     os_interface->os_teardown = windows_teardown;
 
     vmi->os_interface = os_interface;

--- a/libvmi/os/windows/unicode.c
+++ b/libvmi/os/windows/unicode.c
@@ -1,0 +1,101 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+ * retains certain rights in this software.
+ *
+ * Author: Bryan D. Payne (bdpayne@acm.org)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libvmi.h"
+#include "private.h"
+#include <string.h>
+#include <wchar.h>
+#include <iconv.h>  // conversion between character sets
+#include <errno.h>
+
+unicode_string_t *
+windows_read_unicode_struct(
+    vmi_instance_t vmi,
+    addr_t vaddr,
+    vmi_pid_t pid)
+{
+    unicode_string_t *us = 0;   // return val
+    size_t struct_size = 0;
+    size_t read = 0;
+    addr_t buffer_va = 0;
+    uint16_t buffer_len = 0;
+
+    if (VMI_PM_IA32E == vmi_get_page_mode(vmi)) {   // 64 bit guest
+        win64_unicode_string_t us64 = { 0 };
+        struct_size = sizeof(us64);
+        // read the UNICODE_STRING struct
+        read = vmi_read_va(vmi, vaddr, pid, &us64, struct_size);
+        if (read != struct_size) {
+            dbprint(VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING\n",__FUNCTION__);
+            goto out_error;
+        }   // if
+        buffer_va = (vaddr & 0xFFFFFFFF00000000) + (us64.pBuffer >> 32);
+        buffer_len = us64.length;
+    }
+    else {
+        win32_unicode_string_t us32 = { 0 };
+        struct_size = sizeof(us32);
+        // read the UNICODE_STRING struct
+        read = vmi_read_va(vmi, vaddr, pid, &us32, struct_size);
+        if (read != struct_size) {
+            dbprint(VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING\n",__FUNCTION__);
+            goto out_error;
+        }   // if
+        buffer_va = us32.pBuffer;
+        buffer_len = us32.length;
+    }   // if-else
+
+    // allocate the return value
+    us = safe_malloc(sizeof(unicode_string_t));
+
+    us->length = buffer_len;
+    us->contents = safe_malloc(sizeof(uint8_t) * (buffer_len + 2));
+
+    read = vmi_read_va(vmi, buffer_va, pid, us->contents, us->length);
+    if (read != us->length) {
+        dbprint
+            (VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING buffer\n",__FUNCTION__);
+        goto out_error;
+    }   // if
+
+    // end with NULL (needed?)
+    us->contents[buffer_len] = 0;
+    us->contents[buffer_len + 1] = 0;
+
+    us->encoding = "UTF-16";
+
+    return us;
+
+out_error:
+    if (us) {
+        if (us->contents) {
+            free(us->contents);
+        }
+        free(us);
+    }
+    return 0;
+}
+

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -82,4 +82,7 @@ addr_t windows_find_eprocess_list_pgd(vmi_instance_t vmi, addr_t pgd);
 
 status_t init_from_kdbg(vmi_instance_t vmi);
 status_t windows_kdbg_lookup(vmi_instance_t vmi, const char *symbol, addr_t *address);
+
+unicode_string_t *windows_read_unicode_struct(vmi_instance_t vmi, addr_t vaddr, vmi_pid_t pid);
+
 #endif /* OS_WINDOWS_H_ */


### PR DESCRIPTION
The implementation of vmi_read_unicode_str is OS specific but the location of the code has not reflected this fact. This PR moves the unicode read-code into the OS layer so that the library is more consistent internally. The OS independent portion of unicode conversion code is moved into convenience.c as that is a more logical location for it.
