### PR TITLE
vmi_read_addr_* is only meaningful if the width of the addr is known. Th...

### DIFF
--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -126,6 +126,7 @@ get_ntoskrnl_base(
     return ret;
 }
 
+/* Tries to determine the page mode based on the kpgd found via heuristics */
 static status_t
 find_page_mode(
     vmi_instance_t vmi)
@@ -133,12 +134,14 @@ find_page_mode(
 
     status_t ret = VMI_FAILURE;
     windows_instance_t windows = vmi->os_data;
+    uint32_t mask = ~0;
 
     dbprint(VMI_DEBUG_MISC, "--trying VMI_PM_LEGACY\n");
     vmi->page_mode = VMI_PM_LEGACY;
 
     if (VMI_SUCCESS == arch_init(vmi)) {
-        if (windows->ntoskrnl == vmi_pagetable_lookup(vmi, vmi->kpgd, windows->ntoskrnl_va)) {
+        if (windows->ntoskrnl == vmi_pagetable_lookup(vmi, (vmi->kpgd & mask), windows->ntoskrnl_va)) {
+            vmi->kpgd &= mask;
             goto found_pm;
         }
     }
@@ -147,7 +150,8 @@ find_page_mode(
     vmi->page_mode = VMI_PM_PAE;
 
     if (VMI_SUCCESS == arch_init(vmi)) {
-        if (windows->ntoskrnl == vmi_pagetable_lookup(vmi, vmi->kpgd, windows->ntoskrnl_va)) {
+        if (windows->ntoskrnl == vmi_pagetable_lookup(vmi, (vmi->kpgd & mask), windows->ntoskrnl_va)) {
+            vmi->kpgd &= mask;
             goto found_pm;
         }
     }
@@ -200,9 +204,10 @@ get_kpgd_method2(
     dbprint(VMI_DEBUG_MISC, "--got PA to PsInitialSystemProcess (0x%.16"PRIx64").\n",
             sysproc);
 
-    /* get address for page directory (from system process) */
+    /* Get address for page directory (from system process).
+       We are reading 64-bit value here deliberately as we might not know the page mode yet */
     if (VMI_FAILURE ==
-        vmi_read_addr_pa(vmi,
+        vmi_read_64_pa(vmi,
                          sysproc +
                          windows->pdbase_offset,
                          &vmi->kpgd)) {
@@ -214,16 +219,31 @@ get_kpgd_method2(
         dbprint(VMI_DEBUG_MISC, "--kpgd was zero\n");
         goto error_exit;
     }
-    dbprint(VMI_DEBUG_MISC, "**set kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
     if (VMI_FAILURE ==
-        vmi_read_addr_pa(vmi,
+        vmi_read_64_pa(vmi,
                      sysproc + windows->tasks_offset,
                      &vmi->init_task)) {
         dbprint(VMI_DEBUG_MISC, "--failed to resolve address of System process\n");
         goto error_exit;
     }
+
     vmi->init_task -= windows->tasks_offset;
+
+    /* If the page mode is already known to be 32-bit we just mask the value here.
+       If don't know the page mode yet it will be determined using heuristics in find_page_mode later. */
+    switch(vmi->page_mode) {
+        VMI_PM_LEGACY:
+        VMI_PM_PAE: {
+            uint32_t mask = ~0;
+            vmi->kpgd &= mask;
+            vmi->init_task &= mask;
+            break;
+        }
+        default: break;
+    }
+
+    dbprint(VMI_DEBUG_MISC, "**set kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
     dbprint(VMI_DEBUG_MISC, "**set init_task (0x%.16"PRIx64").\n", vmi->init_task);
 
     return VMI_SUCCESS;

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -249,16 +249,23 @@ vmi_read_addr_pa(
     addr_t paddr,
     addr_t *value)
 {
-    if (vmi->page_mode == VMI_PM_IA32E) {
-        return vmi_read_64_pa(vmi, paddr, value);
-    }
-    else {
-        uint32_t tmp = 0;
-        status_t ret = vmi_read_32_pa(vmi, paddr, &tmp);
+    status_t ret = VMI_FAILURE;
 
-        *value = (uint64_t) tmp;
-        return ret;
+    switch(vmi->page_mode) {
+        case VMI_PM_IA32E:
+            ret = vmi_read_X_pa(vmi, paddr, value, 8);
+            break;
+        case VMI_PM_LEGACY:
+        case VMI_PM_PAE: {
+            uint32_t tmp = 0;
+            status_t ret = vmi_read_X_pa(vmi, paddr, &tmp, 4);
+            *value = (uint64_t) tmp;
+            break;
+        }
+        default: break;
     }
+
+    return ret;
 }
 
 char *
@@ -368,16 +375,23 @@ vmi_read_addr_va(
     vmi_pid_t pid,
     addr_t *value)
 {
-    if (vmi->page_mode == VMI_PM_IA32E) {
-        return vmi_read_64_va(vmi, vaddr, pid, value);
-    }
-    else {
-        uint32_t tmp = 0;
-        status_t ret = vmi_read_32_va(vmi, vaddr, pid, &tmp);
+    status_t ret = VMI_FAILURE;
 
-        *value = (uint64_t) tmp;
-        return ret;
+    switch(vmi->page_mode) {
+        case VMI_PM_IA32E:
+            ret = vmi_read_X_va(vmi, vaddr, pid, value, 8);
+            break;
+        case VMI_PM_LEGACY:
+        case VMI_PM_PAE: {
+            uint32_t tmp = 0;
+            ret = vmi_read_X_va(vmi, vaddr, pid, &tmp, 4);
+            *value = (uint64_t) tmp;
+            break;
+        }
+        default: break;
     }
+
+    return ret;
 }
 
 char *
@@ -683,16 +697,23 @@ vmi_read_addr_ksym(
     char *sym,
     addr_t *value)
 {
-    if (vmi->page_mode == VMI_PM_IA32E) {
-        return vmi_read_64_ksym(vmi, sym, value);
-    }
-    else {
-        uint32_t tmp = 0;
-        status_t ret = vmi_read_32_ksym(vmi, sym, &tmp);
+    status_t ret = VMI_FAILURE;
 
-        *value = (uint64_t) tmp;
-        return ret;
+    switch(vmi->page_mode) {
+        case VMI_PM_IA32E:
+            ret = vmi_read_X_ksym(vmi, sym, value, 8);
+            break;
+        case VMI_PM_LEGACY:
+        case VMI_PM_PAE: {
+            uint32_t tmp = 0;
+            status_t ret = vmi_read_X_ksym(vmi, sym, &tmp, 4);
+            *value = (uint64_t) tmp;
+            break;
+        }
+        default: break;
     }
+
+    return ret;
 }
 
 char *


### PR DESCRIPTION
...e existing setup always fell back on 32-bit addr width when the page mode is unknown, thus breaking file-mode on 64-bit memory dumps. This patch fixes this issue by employing heuristics during page mode detection in Windows to check if we have 32-bit or 64-bit addresses.
