### PR TITLE
Changed VMI_GET_BIT Macro to be able to check for bits 32 - 63

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -291,7 +291,7 @@ typedef struct {
 /**
  * Macro to test bitfield values
  */
-#define VMI_GET_BIT(reg, bit) ((reg & (1<<bit)) ? 1:0)
+#define VMI_GET_BIT(reg, bit) ((reg & (1ULL<<bit)) ? 1:0)
 
 /**
  * Generic representation of Unicode string to be used within libvmi


### PR DESCRIPTION
If the register is 64 bits currently only the least significant 32 bits can be checked
