### PR TITLE
Expose vmi_init_paging to (re)initialize the arch interface

### DIFF
--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -54,5 +54,9 @@ status_t arch_init(vmi_instance_t vmi) {
             break;
     }
 
+    if(VMI_FAILURE == ret) {
+        vmi->page_mode = VMI_PM_UNKNOWN;
+    }
+
     return ret;
 }

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -607,6 +607,23 @@ vmi_init_complete_custom(
     return vmi_init_custom(vmi, flags, config);
 }
 
+page_mode_t
+vmi_init_paging(
+    vmi_instance_t vmi,
+    uint8_t force_reinit)
+{
+    if (VMI_PM_UNKNOWN != vmi->page_mode) {
+        if(!force_reinit) {
+            return vmi->page_mode;
+        } else {
+            vmi->page_mode = VMI_PM_UNKNOWN;
+        }
+    }
+
+    arch_init(vmi);
+    return vmi->page_mode;
+}
+
 status_t
 vmi_destroy(
     vmi_instance_t vmi)

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -402,6 +402,20 @@ status_t vmi_init_complete_custom(
     vmi_config_t config);
 
 /**
+ * Initialize or reinitialize the paging specific functionality of LibVMI.
+ * This function is most useful when dynamically monitoring the booting of
+ * an OS in VMI_INIT_PARTIAL mode.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] force_reinit Force the reinitialization of the paging mode
+ *  even if one was already setup previously.
+ * @return The current page mode of the architecture or VMI_PM_UNKNOWN.
+ */
+page_mode_t vmi_init_paging(
+    vmi_instance_t vmi,
+    uint8_t force_reinit);
+
+/**
  * Destroys an instance by freeing memory and closing any open handles.
  *
  * @param[in] vmi Instance to destroy


### PR DESCRIPTION
VMI_INIT_PARTIAL can now succeed in two ways: 1) giving access only to physical pages and vCPU registers 2) also allowing for v2p translation using dtb values. As during boot the page mode switches around, exposing arch reinit allows for keeping up with the latest page mode in-use without having to throw away the entire vmi instance to reinitialize everything. Once the final page mode is setup the user can switch to full mode as before with vmi_init_complete and derivatives (if required).
