### PR TITLE
Small performance tune on VMI_GET_BIT

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -291,7 +291,7 @@ typedef struct {
 /**
  * Macro to test bitfield values
  */
-#define VMI_GET_BIT(reg, bit) ((reg & (1ULL<<bit)) ? 1:0)
+#define VMI_GET_BIT(reg, bit) (!!(reg & (1ULL<<bit)))
 
 /**
  * Generic representation of Unicode string to be used within libvmi


### PR DESCRIPTION
The double inversion technique is used throughout the Xen codebase when dealing with bitmasks. This won't compile into a branch as ? does.
