### PR TITLE
Coverity fixes in arch/intel.c

### DIFF
--- a/libvmi/arch/intel.c
+++ b/libvmi/arch/intel.c
@@ -213,7 +213,7 @@ void buffalo_nopae (vmi_instance_t instance, uint32_t entry, int pde)
 {
     /* similar techniques are surely doable in linux, but for now
      * this is only testing for windows domains */
-    if (!instance->os_type == VMI_OS_WINDOWS) {
+    if (instance->os_type != VMI_OS_WINDOWS) {
         return;
     }
 
@@ -414,7 +414,9 @@ GSList* get_va_pages_pae(vmi_instance_t vmi, addr_t dtb) {
         uint32_t pdpi_entry = pdpi_base + i * entry_size;
 
         uint64_t pdpe;
-        vmi_read_64_pa(vmi, pdpi_entry, &pdpe);
+        if(VMI_FAILURE == vmi_read_64_pa(vmi, pdpi_entry, &pdpe)) {
+            continue;
+        }
 
         if(!ENTRY_PRESENT(vmi->os_type, pdpe)) {
             continue;


### PR DESCRIPTION
CID 703167 (#1 of 1): Missing parentheses (CONSTANT_EXPRESSION_RESULT)missing_parentheses: !instance->os_type == VMI_OS_WINDOWS is always false regardless of the values of its operands. This occurs as the logical operand of if.
CID 1237204 (#1 of 1): Unchecked return value (CHECKED_RETURN)2. check_return: Calling vmi_read_64_pa without checking return value (as is done elsewhere 14 out of 15 times).
CID 1237206 (#1 of 1): Logically dead code (DEADCODE)dead_error_line: Execution cannot reach this statement: return;.
