### PR TITLE
Coverity fix in driver/xen.c

### DIFF
--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -901,7 +901,7 @@ xen_get_domainname(
     *name = xs_read(xen_get_instance(vmi)->xshandle, xth, tmp, NULL);
     free(tmp);
 
-    if (NULL == name) {
+    if (*name == NULL) {
         errprint("Couldn't get name of domain %lu from Xenstore\n",
                  xen_get_domainid(vmi));
         goto _bail;


### PR DESCRIPTION
CID 703184 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking name suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
