### PR TITLE
Coverity fix with vmi_get_bit

### DIFF
--- a/libvmi/convenience.c
+++ b/libvmi/convenience.c
@@ -102,21 +102,6 @@ get_reg32(
     return (unsigned long) r;
 }
 
-int
-vmi_get_bit(
-    reg_t reg,
-    int bit)
-{
-    reg_t mask = 1 << bit;
-
-    if (reg & mask) {
-        return 1;
-    }
-    else {
-        return 0;
-    }
-}
-
 addr_t
 aligned_addr(
     vmi_instance_t vmi,

--- a/libvmi/driver/xen.c
+++ b/libvmi/driver/xen.c
@@ -703,7 +703,7 @@ xen_discover_guest_addr_width(
             goto _bail;
         }
         xen_get_instance(vmi)->addr_width =
-            (vmi_get_bit(hw_ctxt.msr_efer, 8) == 0 ? 4 : 8);
+            (VMI_GET_BIT(hw_ctxt.msr_efer, 8) == 0 ? 4 : 8);
     }
     else {  // PV
         xen_domctl_t domctl = { 0 };

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -205,9 +205,6 @@ typedef struct _windows_unicode_string32 {
     int line);
     unsigned long get_reg32(
     reg_t r);
-    int vmi_get_bit(
-    reg_t reg,
-    int bit);
     addr_t aligned_addr(
     vmi_instance_t vmi,
     addr_t addr);


### PR DESCRIPTION
CID 703173 (#1 of 1): Unintentional integer overflow (OVERFLOW_BEFORE_WIDEN)overflow_before_widen: Potentially overflowing expression 1 << bit with type int (32 bits, signed) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type reg_t (64 bits, unsigned).
