### PR TITLE
Fix for step_event with callback resetting

### DIFF
--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -221,6 +221,8 @@ void step_and_reg_events(vmi_instance_t vmi, vmi_event_t *singlestep_event)
 
         if (0 == wrap->steps)
         {
+            --(vmi->step_vcpus[wrap->vcpu_id]);
+
             if (wrap->cb)
             {
                 wrap->cb(vmi, wrap->event);
@@ -230,7 +232,6 @@ void step_and_reg_events(vmi_instance_t vmi, vmi_event_t *singlestep_event)
                 vmi_register_event(vmi, wrap->event);
             }
 
-            --(vmi->step_vcpus[wrap->vcpu_id]);
             if (!vmi->step_vcpus[wrap->vcpu_id])
             {
                 // No more events on this vcpu need registering


### PR DESCRIPTION
If a user calls vmi_step_event in the callback from another vmi_step_event, it results in the VM being stuck in singlestep state as the counter goes out of sync. Why this problem only surfaces now is a mystery as I have been using this API without a problem for a while now.
