### PR TITLE
Generic cleanup of the Xen driver code

### DIFF
--- a/libvmi/driver/xen.h
+++ b/libvmi/driver/xen.h
@@ -24,6 +24,9 @@
  * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef XEN_H
+#define XEN_H
+
 #include "driver/xen_events.h"
 
 #if ENABLE_XEN == 1
@@ -176,3 +179,5 @@ size_t xen_get_dgpma(
     void** medial_addr_ptr,
     size_t count);
 #endif
+
+#endif /* XEN_H */

--- a/libvmi/driver/xen_events.c
+++ b/libvmi/driver/xen_events.c
@@ -54,11 +54,6 @@
 
 #include "libvmi.h"
 #include "private.h"
-#include "driver/xen.h"
-#include "driver/xen_private.h"
-#include "driver/xen_events.h"
-
-#include <string.h>
 
 /*----------------------------------------------------------------------------
  * Helper functions
@@ -73,6 +68,12 @@
  *  all of the features LibVMI needs.
  */
 #if ENABLE_XEN==1 && ENABLE_XEN_EVENTS==1 && defined(XENCTRL_HAS_XC_INTERFACE) && defined(XEN_EVENTS_VERSION)
+
+#include "driver/xen.h"
+#include "driver/xen_private.h"
+#include "driver/xen_events.h"
+
+#include <string.h>
 
 static inline xen_events_t *xen_get_events(vmi_instance_t vmi)
 {

--- a/libvmi/driver/xen_private.h
+++ b/libvmi/driver/xen_private.h
@@ -27,14 +27,21 @@
 #define XEN_PRIVATE_H
 
 #include "libvmi.h"
+#include "driver/xen.h"
 
-xen_instance_t *xen_get_instance (vmi_instance_t vmi);
+static inline
+xen_instance_t *xen_get_instance(
+    vmi_instance_t vmi)
+{
+    return ((xen_instance_t *) vmi->driver);
+}
 
-#ifdef XENCTRL_HAS_XC_INTERFACE // Xen >= 4.1
-xc_interface *
-#else
-int
-#endif
-xen_get_xchandle (vmi_instance_t vmi);
 
-#endif
+static inline
+libvmi_xenctrl_handle_t xen_get_xchandle(
+    vmi_instance_t vmi)
+{
+    return xen_get_instance(vmi)->xchandle;
+}
+
+#endif /* XEN_PRIVATE_H */


### PR DESCRIPTION
This is mostly a code alignment fix PR to make the code more readable. I also replaced xen_get_instance and xen_get_xchandle with static inline functions as these are used very heavily all over the code and its a waste to have them as separate functions. Internal calls to xen_get_domainid(vmi) have also been replaced with xen_get_instance(vmi)->domainid to use the inline version.

In addition, the the pause call has been extended to only pause the VM if its not already paused. This is required as starting with Xen 4.4.1 pause/unpause requests are counted by Xen (it's no longer a simple toggle). 
