### PR TITLE
Fix building LibVMI with xen-events on old Xen libraries and add static ...

### DIFF
--- a/libvmi/driver/xen_events.c
+++ b/libvmi/driver/xen_events.c
@@ -1019,19 +1019,9 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_event_t event, vmi_mem_acces
 
     // Convert betwen vmi_mem_access_t and mem_access_t
     // Xen does them backwards....
-    switch(page_access_flag){
-        case VMI_MEMACCESS_INVALID: return VMI_FAILURE;
-        case VMI_MEMACCESS_N: access = MEMACCESS_RWX; break;
-        case VMI_MEMACCESS_R: access = MEMACCESS_WX; break;
-        case VMI_MEMACCESS_W: access = MEMACCESS_RX; break;
-        case VMI_MEMACCESS_X: access = MEMACCESS_RW; break;
-        case VMI_MEMACCESS_RW: access = MEMACCESS_X; break;
-        case VMI_MEMACCESS_RX: access = MEMACCESS_W; break;
-        case VMI_MEMACCESS_WX: access = MEMACCESS_R; break;
-        case VMI_MEMACCESS_RWX: access = MEMACCESS_N; break;
-        case VMI_MEMACCESS_W2X: access = MEMACCESS_RX2RW; break;
-        case VMI_MEMACCESS_RWX2N: access = MEMACCESS_N2RWX; break;
-    }
+    access = memaccess_conversion[page_access_flag];
+    if (access == MEMACCESS_INVALID)
+        return VMI_FAILURE;
 
     dbprint(VMI_DEBUG_XEN, "--Setting memaccess for domain %lu on physical address: %"PRIu64" npages: %"PRIu64"\n",
         dom, event.physical_address, npages);

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -276,6 +276,14 @@ status_t register_mem_event(vmi_instance_t vmi, vmi_event_t *event)
     vmi_memevent_granularity_t granularity = event->mem_event.granularity;
     addr_t page_key = event->mem_event.physical_address >> 12;
 
+    if (event->mem_event.in_access >= __VMI_MEMACCESS_MAX ||
+        event->mem_event.in_access == VMI_MEMACCESS_INVALID)
+    {
+        dbprint(VMI_DEBUG_EVENTS, "Invalid VMI_MEMACCESS requested: %d\n",
+                event->mem_event.in_access);
+        return VMI_FAILURE;
+    }
+
     // Page already has event(s) registered
     page = g_hash_table_lookup(vmi->mem_events, &page_key);
     if (NULL != page)

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1803,7 +1803,9 @@ typedef enum {
     VMI_EVENT_MEMORY,    /* Read/write/execute on a region of memory */
     VMI_EVENT_REGISTER,  /* Read/write of a specific register */
     VMI_EVENT_SINGLESTEP,/* Instructions being executed on a set of VCPUs */
-    VMI_EVENT_INTERRUPT  /* Interrupts being delivered */
+    VMI_EVENT_INTERRUPT,  /* Interrupts being delivered */
+
+    __VMI_EVENT_MAX
 } vmi_event_type_t;
 
 /* max number of vcpus we can set single step on at one time for a domain */
@@ -1819,6 +1821,8 @@ typedef enum {
     VMI_REGACCESS_R = (1 << 1),
     VMI_REGACCESS_W = (1 << 2),
     VMI_REGACCESS_RW = (VMI_REGACCESS_R | VMI_REGACCESS_W),
+
+    __VMI_REGACCESS_MAX
 } vmi_reg_access_t;
 
 /* Page permissions used both for configuring type of memory operations to
@@ -1838,7 +1842,9 @@ typedef enum {
 
     // Special cases
     VMI_MEMACCESS_W2X        = (1 << 4),
-    VMI_MEMACCESS_RWX2N      = (1 << 5)
+    VMI_MEMACCESS_RWX2N      = (1 << 5),
+
+    __VMI_MEMACCESS_MAX
 } vmi_mem_access_t;
 
 /* The level of granularity used in the configuration of a memory event.
@@ -1850,7 +1856,9 @@ typedef enum {
 typedef enum {
     VMI_MEMEVENT_INVALID,
     VMI_MEMEVENT_BYTE,
-    VMI_MEMEVENT_PAGE
+    VMI_MEMEVENT_PAGE,
+
+    __VMI_MEMEVENT_MAX
 } vmi_memevent_granularity_t;
 
 typedef struct {


### PR DESCRIPTION
...conversion matrix for flags.

Old xen libs don't define HVMMEM_access_n2rwx (for example the Ubuntu version Travis-CI has) thus failing to build with --enable-xen-events.
