### PR TITLE
Add support to disable particular OS support. This is useful for example...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,20 @@ AC_ARG_ENABLE([file],
       [enable_file=yes])
 AM_CONDITIONAL([FILE], [test x"$enable_file" = xyes])
 
+AC_ARG_ENABLE([windows],
+      [AS_HELP_STRING([--disable-windows],
+         [Support introspecting Windows (XP - 8)])],
+      [enable_windows=$enableval],
+      [enable_windows=yes])
+AM_CONDITIONAL([WINDOWS], [test x"$enable_windows" = xyes])
+
+AC_ARG_ENABLE([linux],
+      [AS_HELP_STRING([--disable-linux],
+         [Support introspecting Linux])],
+      [enable_linux=$enableval],
+      [enable_linux=yes])
+AM_CONDITIONAL([LINUX], [test x"$enable_linux" = xyes])
+
 AC_ARG_ENABLE([vmifs],
       [AS_HELP_STRING([--disable-vmifs],
          [Build VMIFS tool: maps memory to a file through FUSE])],
@@ -308,6 +322,16 @@ file_space='      '
 [fi]
 AM_CONDITIONAL([HAVE_FILE], [test x"$have_file" = "xyes"])
 
+[if test "$enable_windows" = "yes"]
+[then]
+    AC_DEFINE([ENABLE_WINDOWS], [1], [Define to 1 to Windows support.])
+[fi]
+
+[if test "$enable_linux" = "yes"]
+[then]
+    AC_DEFINE([ENABLE_LINUX], [1], [Define to 1 to Linux support.])
+[fi]
+
 have_vmifs='no'
 vmifs_space='       '
 [if test "$enable_vmifs" = "yes"]
@@ -405,6 +429,12 @@ KVM Support  | --enable-kvm=$enable_kvm$kvm_space     | $have_kvm
 File Support | --enable-file=$enable_file$file_space    | $have_file
 Shm-snapshot | --enable-shm-snapshot=$enable_shm_snapshot$shm_snapshot_space | $have_shm_snapshot
 -------------|---------------------------|----------------------------
+
+OS           | Option                    
+-------------|--------------------------------------------------------
+Windows      | --enable-windows=$enable_windows
+Linux        | --enable-linux=$enable_linux
+
 
 Tools        | Option                    | Reason
 -------------|---------------------------|----------------------------

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = config
-h_sources = libvmi.h libvmi_extra.h peparse.h x86.h
+h_sources = libvmi.h libvmi_extra.h x86.h
 h_private = \
     private.h \
     debug.h \
@@ -8,8 +8,6 @@ h_private = \
     arch/intel.h \
     arch/amd64.h \
     os/os_interface.h \
-    os/windows/windows.h \
-    os/linux/linux.h \
     driver/driver_interface.h \
     driver/driver_wrapper.h \
     driver/memory_cache.h
@@ -30,17 +28,7 @@ c_sources = \
     arch/amd64.c \
     driver/driver_interface.c \
     driver/memory_cache.c \
-    os/os_interface.c \
-    os/linux/core.c \
-    os/linux/memory.c \
-    os/linux/symbols.c \
-    os/windows/core.c \
-    os/windows/kdbg.c \
-    os/windows/memory.c \
-    os/windows/symbols.c \
-    os/windows/peparse.c \
-    os/windows/process.c \
-    os/windows/unicode.c
+    os/os_interface.c
 
 drivers =
 if HAVE_FILE
@@ -67,13 +55,32 @@ drivers += driver/xen/xen_events.h \
 endif
 endif
 
+os =
+if WINDOWS
+h_sources += peparse.h
+os += os/windows/windows.h \
+      os/windows/core.c \
+      os/windows/kdbg.c \
+      os/windows/memory.c \
+      os/windows/symbols.c \
+      os/windows/peparse.c \
+      os/windows/process.c \
+      os/windows/unicode.c
+endif
+if LINUX
+os += os/linux/linux.h \
+      os/linux/core.c \
+      os/linux/memory.c \
+      os/linux/symbols.c
+endif
+
 library_includedir=$(includedir)/$(LIBRARY_NAME)
 library_include_HEADERS = $(h_sources)
 
 AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES= libvmi.la
-libvmi_la_SOURCES= $(h_sources) $(h_private) $(drivers) $(c_sources)
+libvmi_la_SOURCES= $(h_sources) $(h_private) $(drivers) $(os) $(c_sources)
 libvmi_la_LIBADD= config/libconfig.la
 libvmi_la_CFLAGS= -fvisibility=hidden $(GLIB_CFLAGS) $(JANSSON_CFLAGS)
 libvmi_la_LDFLAGS= -release $(RELEASE) $(GLIB_LIBS) $(JANSSON_LIBS)

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -66,6 +66,10 @@ win_ver_t
 vmi_get_winver(
     vmi_instance_t vmi)
 {
+#ifndef ENABLE_WINDOWS
+    errprint("**LibVMI wasn't compiled with Windows support!\n");
+    return VMI_OS_WINDOWS_NONE;
+#else
     windows_instance_t windows_instance = NULL;
 
     if (VMI_OS_WINDOWS != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode))
@@ -82,6 +86,7 @@ vmi_get_winver(
         windows_instance->version = find_windows_version(vmi, kdbg);
     }
     return windows_instance->version;
+#endif
 }
 
 const char *
@@ -117,7 +122,12 @@ vmi_get_winver_manual(
     vmi_instance_t vmi,
     addr_t kdbg_pa)
 {
+#ifdef ENABLE_WINDOWS
     return find_windows_version(vmi, kdbg_pa);
+#else
+    errprint("**LibVMI wasn't compiled with Windows support!\n");
+    return VMI_OS_WINDOWS_NONE;
+#endif
 }
 
 uint64_t

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -472,16 +472,23 @@ vmi_init_private(
         }
 
         /* setup OS specific stuff */
-        if (VMI_OS_LINUX == (*vmi)->os_type) {
+        switch ( (*vmi)->os_type )
+        {
+#ifdef ENABLE_LINUX
+        case VMI_OS_LINUX:
             if(VMI_FAILURE == linux_init(*vmi)) {
                 goto error_exit;
             }
-        }
-        else if (VMI_OS_WINDOWS == (*vmi)->os_type) {
+            break;
+#endif
+#ifdef ENABLE_WINDOWS
+        case VMI_OS_WINDOWS:
             if(VMI_FAILURE == windows_init(*vmi)) {
                 goto error_exit;
             }
-        } else {
+            break;
+#endif
+        default:
             goto error_exit;
         }
 


### PR DESCRIPTION
... on ARM to disable Windows support as there are no Windows guests available for that platform. Not building the Windows specific code reduces the memory footprint of the library.
