### PR TITLE
Pass the page pointer to the user

### DIFF
--- a/libvmi/arch/amd64.c
+++ b/libvmi/arch/amd64.c
@@ -195,6 +195,10 @@ addr_t v2p_ia32e (vmi_instance_t vmi,
     info->size = VMI_PS_4KB;
     info->paddr = get_paddr_ia32e(vaddr, info->x86_ia32e.pte_value);
 
+    if(info->paddr) {
+        info->page = vmi_read_page(vmi, info->paddr >> vmi->page_shift);
+    }
+
 done:
     dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: paddr = 0x%.16"PRIx64"\n", info->paddr);
     return info->paddr;

--- a/libvmi/arch/intel.c
+++ b/libvmi/arch/intel.c
@@ -286,7 +286,10 @@ addr_t v2p_nopae (vmi_instance_t vmi,
 
     info->size = VMI_PS_4KB;
     info->paddr = get_paddr_nopae(vaddr, info->x86_legacy.pte_value);
-    goto done;
+
+    if(info->paddr) {
+        info->page = vmi_read_page(vmi, info->paddr >> vmi->page_shift);
+    }
 
 done:
     dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: paddr = 0x%.16"PRIx64"\n", info->paddr);
@@ -335,6 +338,10 @@ addr_t v2p_pae (vmi_instance_t vmi,
 
     info->size = VMI_PS_4KB;
     info->paddr = get_paddr_pae(vaddr, info->x86_pae.pte_value);
+
+    if(info->paddr) {
+        info->page = vmi_read_page(vmi, info->paddr >> vmi->page_shift);
+    }
 
 done:
     dbprint(VMI_DEBUG_PTLOOKUP, "--PAE PTLookup: paddr = 0x%.16"PRIx64"\n", info->paddr);

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -251,6 +251,8 @@ typedef int32_t vmi_pid_t;
 
 /* Struct for holding page lookup information */
 typedef struct page_info {
+    void  *page;        // pointer to the page for performance sensitive operations
+                        // WARNING: the pointer is only valid as long as no other pages are accessed by LibVMI
     addr_t vaddr;       // virtual address
     addr_t dtb;         // dtb used for translation
     addr_t paddr;       // physical address

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -43,6 +43,7 @@ extern "C" {
  *
  * @return GSList of page_info_t structures, or NULL on error.
  * The caller is responsible for freeing the list and the structs.
+ * The page_info_t instances do not contain valid page pointers.
  */
 GSList* vmi_get_va_pages(
     vmi_instance_t vmi,


### PR DESCRIPTION
For performance critical applications the additional memcpy operation involved in reading data from mapped pages is undesirable. By passing the pointer to the user to the mapped page held by LibVMI, the user can take charge of accessing the data contained within that page and issuing memcpy only when necessary.

The operation in which this pointer is usable is by issuing a vmi_pagetable_lookup_extended, which returns the page_info_t structure and the mapped page of the resulting physical address.

As the comment in the header describes, the pointer is only valid as long as the user does not use any of the LibVMI API that may result in the page getting unmapped. This is a reasonable situation that power users can arguably work with.
