### PR TITLE
Fix clang warnings in xen_events

### DIFF
--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -118,7 +118,6 @@ typedef enum {
     MEMACCESS_N2RWX = MEMACCESS_INVALID
 #endif
 } compat_memaccess_t;
-
 typedef hvmmem_access_t mem_access_t;
 
 #else /* XEN_EVENTS_VERSION */


### PR DESCRIPTION
warning: implicit conversion from enumeration
type 'compat_memaccess_t' to different enumeration type 'hvmmem_access_t'

warning: comparison of constant
'MEMACCESS_INVALID' (-1) with expression of type 'mem_access_t'
(aka 'hvmmem_access_t') is always false
