### PR TITLE
Fix memory leak on error condition in events init

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -700,6 +700,8 @@ status_t xen_events_init(vmi_instance_t vmi)
         return VMI_FAILURE;
     }
 
+    xen_get_instance(vmi)->events = xe;
+
     dbprint(VMI_DEBUG_XEN, "Init xen events with xch == %llx\n", (unsigned long long)xch);
 
     rc = xc_domain_getinfolist(xch, dom, 1, &dom_info);
@@ -880,8 +882,6 @@ enable_done:
     BACK_RING_INIT(&xe->mem_event.back_ring,
                    (mem_event_sring_t *)xe->mem_event.ring_page,
                    getpagesize());
-
-    xen_get_instance(vmi)->events = xe;
 
     if(!(dom_info.flags & XEN_DOMINF_paused))
     {


### PR DESCRIPTION
When an error occurs xen_events_destroy is called. However, the xen_events structure is only assigned if no errors occured, thus the structure leaks memory when we have an error.

This is Coverity ID 54272 Resource leak

The system resource will not be reclaimed and reused, reducing the future availability of the resource.
In xen_events_init: Leak of memory or pointers to system resources (CWE-404)
