### PR TITLE
Add missing breaks in ARM PT lookup

### DIFF
--- a/libvmi/arch/arm_aarch32.c
+++ b/libvmi/arch/arm_aarch32.c
@@ -115,23 +115,21 @@ addr_t v2p_aarch32 (vmi_instance_t vmi,
                 default:
                     break;
             }
+
+            break;
         }
 
         case 0b10: {
 
-            switch(VMI_GET_BIT(info->arm_aarch32.fld_value, 18)) {
-            default:
-            case 0:
+            if(!VMI_GET_BIT(info->arm_aarch32.fld_value, 18)) {
                 dbprint(VMI_DEBUG_PTLOOKUP, "--ARM AArch32 PTLookup: the entry is a section descriptor for its associated modified virtual addresses\n");
                 info->size = VMI_PS_1MB;
                 info->paddr = (info->arm_aarch32.fld_value & VMI_BIT_MASK(20,31)) | (vaddr & VMI_BIT_MASK(0,19));
-                break;
-            case 1:
+            } else {
                 dbprint(VMI_DEBUG_PTLOOKUP, "--ARM AArch32 PTLookup: the entry is a supersection descriptor for its associated modified virtual addresses\n");
                 // TODO: supersections are unsupported right now (breaks ptlookup when included)
                 //info->size = VMI_PS_16MB;
                 //info->paddr = get_bits_31to24(info->l1_v) | get_bits_23to0(vaddr);
-                break;
             }
 
             break;
@@ -164,6 +162,8 @@ addr_t v2p_aarch32 (vmi_instance_t vmi,
                 default:
                     break;
             }
+
+            break;
         }
 
         default:


### PR DESCRIPTION
This is Coverity ID 83234 Missing break in switch

Execution falls through to the next case statement or default; this might indicate a common typo.
In v2p_aarch32: Missing break statement between cases in switch statement (CWE-484)

Also switching a switch to an if-else to avoid GCC warning of using boolean input for switch.
