### PR TITLE
Fix returning uninitialized status_t in Xen on error

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -800,7 +800,7 @@ status_t
 xen_init_vmi(
     vmi_instance_t vmi)
 {
-    status_t ret;
+    status_t ret = VMI_FAILURE;
     xen_instance_t *xen = xen_get_instance(vmi);
     /* setup the info struct */
     int rc = xc_domain_getinfo(xen->xchandle,


### PR DESCRIPTION
This is CID 83235 (#1 of 1): 
Uninitialized scalar variable (UNINIT)4. uninit_use: Using uninitialized value ret.
