### PR TITLE
Fix implicit function declaration warning

### DIFF
--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -23,6 +23,7 @@
 #include "arch_interface.h"
 #include "intel.h"
 #include "amd64.h"
+#include "arm_aarch32.h"
 #include <stdlib.h>
 
 status_t arch_init(vmi_instance_t vmi) {


### PR DESCRIPTION
arch/arch_interface.c:52:19: warning: implicit declaration of function
'aarch32_init' is invalid in C99 [-Wimplicit-function-declaration]
ret = aarch32_init(vmi);
