### PR TITLE
Support out of tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@
 ACLOCAL_AMFLAGS = -I m4
 
 #Build in these directories:
-SUBDIRS= $(LIBRARY_NAME) examples tests @vmifs_dir@
+SUBDIRS= $(LIBRARY_NAME) examples @test_dir@ @vmifs_dir@
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libvmi.pc

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,8 @@ AC_CONFIG_FILES(Makefile \
 [if test "$have_check" = "yes"]
 [then]
     AC_CONFIG_FILES(tests/Makefile)
+    test_dir="tests"
+    AC_SUBST([test_dir])
 [fi]
 
 AC_OUTPUT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,6 +20,6 @@ check_libvmi_SOURCES = \
     $(top_builddir)/libvmi/cache.c \
     $(top_builddir)/libvmi/convenience.c
 
-check_libvmi_CFLAGS = @CHECK_CFLAGS@ @GLIB_CFLAGS@ -I$(top_srcdir)/libvmi/
-check_libvmi_LDADD = $(top_builddir)/libvmi/libvmi.la @CHECK_LIBS@
+check_libvmi_CFLAGS = @CHECK_CFLAGS@ @GLIB_CFLAGS@ -I$(top_srcdir) -I$(top_srcdir)/libvmi/
+check_libvmi_LDADD = $(top_builddir)/libvmi/libvmi.la @CHECK_LIBS@ @GLIB_LIBS@
 check_libvmi_DEPENDENCIES = $(top_srcdir)/libvmi/cache.c $(top_srcdir)/libvmi/convenience.c


### PR DESCRIPTION
Ensure the tests directory is present only when check is available.  Fix
an include error when running "make check" from an out of tree build.
