### PR TITLE
Fix debug output to always include config file

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -55,7 +55,7 @@ open_config_file(
     /* first check home directory of sudo user */
     if ((sudo_user = getenv("SUDO_USER")) != NULL) {
         if ((pw_entry = getpwnam(sudo_user)) != NULL) {
-            location = g_malloc0(snprintf(NULL,0,"%s/etc/libvmi.conf",
+            location = safe_malloc(snprintf(NULL,0,"%s/etc/libvmi.conf",
                                           pw_entry->pw_dir)+1);
             sprintf(location, "%s/etc/libvmi.conf",
                      pw_entry->pw_dir);
@@ -71,7 +71,7 @@ open_config_file(
     }
 
     /* next check home directory for current user */
-    location = g_malloc0(snprintf(NULL,0,"%s/etc/libvmi.conf",
+    location = safe_malloc(snprintf(NULL,0,"%s/etc/libvmi.conf",
                                   getenv("HOME"))+1);
     sprintf(location, "%s/etc/libvmi.conf", getenv("HOME"));
     dbprint(VMI_DEBUG_CORE, "--looking for config file at %s\n", location);
@@ -85,7 +85,7 @@ open_config_file(
 
     /* finally check in /etc */
     dbprint(VMI_DEBUG_CORE, "--looking for config file at /etc/libvmi.conf\n");
-    location = g_malloc0(strlen("/etc/libvmi.conf")+1);
+    location = safe_malloc(strlen("/etc/libvmi.conf")+1);
     sprintf(location, "/etc/libvmi.conf");
     f = fopen(location, "r");
     if (f) {

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -62,11 +62,11 @@ open_config_file(
             dbprint(VMI_DEBUG_CORE, "--looking for config file at %s\n", location);
 
             f = fopen(location, "r");
-            free(location);
 
             if (f) {
                 goto success;
             }
+            free(location);
         }
     }
 
@@ -77,22 +77,26 @@ open_config_file(
     dbprint(VMI_DEBUG_CORE, "--looking for config file at %s\n", location);
 
     f = fopen(location, "r");
-    free(location);
 
     if (f) {
         goto success;
     }
+    free(location);
 
     /* finally check in /etc */
     dbprint(VMI_DEBUG_CORE, "--looking for config file at /etc/libvmi.conf\n");
-    f = fopen("/etc/libvmi.conf", "r");
+    location = g_malloc0(strlen("/etc/libvmi.conf")+1);
+    sprintf(location, "/etc/libvmi.conf");
+    f = fopen(location, "r");
     if (f) {
         goto success;
     }
+    free(location);
 
     return NULL;
 success:
     dbprint(VMI_DEBUG_CORE, "**Using config file at %s\n", location);
+    free(location);
     return f;
 }
 


### PR DESCRIPTION
Previously, `location` was a NULL pointer when the check succeeded in `/etc`.  This led to the strange message:
```
--looking for config file at /home/robert/etc/libvmi.conf
--looking for config file at /root/etc/libvmi.conf
--looking for config file at /etc/libvmi.conf
**Using config file at
```