### PR TITLE
0 can be a valid physical address.

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -338,12 +338,7 @@ vmi_pid_t vmi_dtb_to_pid (vmi_instance_t vmi, addr_t dtb)
 void *
 vmi_read_page (vmi_instance_t vmi, addr_t frame_num)
 {
-    if (!frame_num) {
-        return NULL ;
-    }
-    else {
-        return driver_read_page(vmi, frame_num);
-    }
+    return driver_read_page(vmi, frame_num);
 }
 
 GSList* vmi_get_va_pages(vmi_instance_t vmi, addr_t dtb) {

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -97,13 +97,13 @@ vmi_read(
 
         if(dtb) {
             paddr = vmi_pagetable_lookup(vmi, dtb, start_addr + buf_offset);
+            if (!paddr) {
+                return buf_offset;
+            }
         } else {
             paddr = start_addr + buf_offset;
         }
 
-        if (!paddr) {
-            return buf_offset;
-        }
 
         /* access the memory */
         pfn = paddr >> vmi->page_shift;
@@ -331,12 +331,11 @@ vmi_read_str(
         addr += len;
         if(dtb) {
             paddr = vmi_pagetable_lookup(vmi, dtb, addr);
+            if (!paddr) {
+                return rtnval;
+            }
         } else {
             paddr = addr;
-        }
-
-        if (!paddr) {
-            return rtnval;
         }
 
         /* access the memory */

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -95,12 +95,11 @@ vmi_write(
 
         if(dtb) {
             paddr = vmi_pagetable_lookup(vmi, dtb, start_addr + buf_offset);
+            if (!paddr) {
+                return buf_offset;
+            }
         } else {
             paddr = start_addr + buf_offset;
-        }
-
-        if (!paddr) {
-            return buf_offset;
         }
 
         /* determine how much we can write to this page */


### PR DESCRIPTION
Leave it to the driver to fail if it's not.

I was playing around with other ways to dump guest memory and noticed the discrepancy at 0, which `xc_map_foreign_range` will map just fine, but can't be read by the `dump-memory` example.

I'd like to get a couple pairs of eyes on this in case there is some place where non-zero is assumed and not otherwise handled.  Using 0 as the key for the memory_cache seems to work fine.