### PR TITLE
Return a status_t from arch v2p functions.

### DIFF
--- a/libvmi/arch/arch_interface.h
+++ b/libvmi/arch/arch_interface.h
@@ -23,7 +23,7 @@
 
 #include "private.h"
 
-typedef addr_t  (*arch_v2p_t)(vmi_instance_t vmi, addr_t dtb, addr_t vaddr, page_info_t *info);
+typedef status_t (*arch_v2p_t)(vmi_instance_t vmi, addr_t dtb, addr_t vaddr, page_info_t *info);
 typedef GSList* (*arch_get_va_pages_t)(vmi_instance_t vmi, addr_t dtb);
 
 struct arch_interface {

--- a/libvmi/arch/arm_aarch32.c
+++ b/libvmi/arch/arm_aarch32.c
@@ -78,11 +78,12 @@ void get_fine_second_level_descriptor(vmi_instance_t vmi, uint32_t vaddr, page_i
 // Based on ARM Reference Manual
 // Chapter B4 Virtual Memory System Architecture
 // B4.7 Hardware page table translation
-addr_t v2p_aarch32 (vmi_instance_t vmi,
+status_t v2p_aarch32 (vmi_instance_t vmi,
     addr_t dtb,
     addr_t vaddr,
     page_info_t *info)
 {
+    status_t status = VMI_FAILURE;
 
     dbprint(VMI_DEBUG_PTLOOKUP, "--ARM AArch32 PTLookup: vaddr = 0x%.16"PRIx64", dtb = 0x%.16"PRIx64"\n", vaddr, dtb);
 
@@ -106,12 +107,14 @@ addr_t v2p_aarch32 (vmi_instance_t vmi,
                     // large page
                     info->size = VMI_PS_64KB;
                     info->paddr = (info->arm_aarch32.sld_value & VMI_BIT_MASK(16,31)) | (vaddr & VMI_BIT_MASK(0,15));
+                    status = VMI_SUCCESS;
                     break;
                 case 0b10:
                 case 0b11:
                     // small page
                     info->size = VMI_PS_4KB;
                     info->paddr = (info->arm_aarch32.sld_value & VMI_BIT_MASK(12,31)) | (vaddr & VMI_BIT_MASK(0,11));
+                    status = VMI_SUCCESS;
                 default:
                     break;
             }
@@ -130,6 +133,7 @@ addr_t v2p_aarch32 (vmi_instance_t vmi,
                 info->size = VMI_PS_16MB;
                 info->paddr = (info->arm_aarch32.fld_value & VMI_BIT_MASK(24,31)) | (vaddr & VMI_BIT_MASK(0,23));
             }
+            status = VMI_SUCCESS;
 
             break;
         }
@@ -147,16 +151,19 @@ addr_t v2p_aarch32 (vmi_instance_t vmi,
                     // large page
                     info->size = VMI_PS_64KB;
                     info->paddr = (info->arm_aarch32.sld_value & VMI_BIT_MASK(16,31)) | (vaddr & VMI_BIT_MASK(0,15));
+                    status = VMI_SUCCESS;
                     break;
                 case 0b10:
                     // small page
                     info->size = VMI_PS_4KB;
                     info->paddr = (info->arm_aarch32.sld_value & VMI_BIT_MASK(12,31)) | (vaddr & VMI_BIT_MASK(0,11));
+                    status = VMI_SUCCESS;
                     break;
                 case 0b11:
                     // tiny page
                     info->size = VMI_PS_1KB;
                     info->paddr = (info->arm_aarch32.sld_value & VMI_BIT_MASK(10,31)) | (vaddr & VMI_BIT_MASK(0,9));
+                    status = VMI_SUCCESS;
                     break;
                 default:
                     break;
@@ -170,7 +177,8 @@ addr_t v2p_aarch32 (vmi_instance_t vmi,
     }
 
     dbprint(VMI_DEBUG_PTLOOKUP, "--ARM PTLookup: PA = 0x%"PRIx64"\n", info->paddr);
-    return info->paddr;
+
+    return status;
 }
 
 GSList* get_va_pages_aarch32(vmi_instance_t vmi, addr_t dtb) {

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -222,6 +222,12 @@ typedef struct _windows_unicode_string32 {
     vmi_instance_t vmi,
     addr_t frame_num);
 
+status_t vmi_pagetable_lookup_cache(
+    vmi_instance_t vmi,
+    addr_t dtb,
+    addr_t vaddr,
+    addr_t *paddr);
+
 /*-------------------------------------
  * cache.c
  */

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -96,8 +96,7 @@ vmi_read(
         size_t read_len = 0;
 
         if(dtb) {
-            paddr = vmi_pagetable_lookup(vmi, dtb, start_addr + buf_offset);
-            if (!paddr) {
+            if (VMI_SUCCESS != vmi_pagetable_lookup_cache(vmi, dtb, start_addr + buf_offset, &paddr)) {
                 return buf_offset;
             }
         } else {
@@ -307,8 +306,7 @@ vmi_read_str(
 
         addr += len;
         if(dtb) {
-            paddr = vmi_pagetable_lookup(vmi, dtb, addr);
-            if (!paddr) {
+            if (VMI_SUCCESS != vmi_pagetable_lookup_cache(vmi, dtb, addr, &paddr)) {
                 return rtnval;
             }
         } else {

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -93,8 +93,7 @@ vmi_write(
         size_t write_len = 0;
 
         if(dtb) {
-            paddr = vmi_pagetable_lookup(vmi, dtb, start_addr + buf_offset);
-            if (!paddr) {
+            if (VMI_SUCCESS != vmi_pagetable_lookup_cache(vmi, dtb, start_addr + buf_offset, &paddr)) {
                 return buf_offset;
             }
         } else {


### PR DESCRIPTION
This is a lot work for the edge of a virtual address being mapped to physical page 0.

I also changed `vmi_uv2p()` to call `vmi_pagetable_lookup_extended()` instead of `vmi_uv2p_nocache()`, which was calling `vmi_pagetable_lookup()`, which does try the cache.  This does not change any API, so callers would have to call `vmi_pagetable_lookup_extended()` to know that 0 was the valid paddr.

`vmi_pagetable_lookup_cache()` added for cases where:
 1. A return status is desirable (`vmi_pagetable_lookup()` does not do this)
 2. A cached value from the v2p cache is acceptable (`vmi_pagetable_lookup_extended()` does not do this)

This is used 3 times in various read/write functions to replace the call to `vmi_pagetable_lookup()`.