### PR TITLE
Make domids explicitly 64-bit wide

### DIFF
--- a/examples/win-guid.c
+++ b/examples/win-guid.c
@@ -262,14 +262,14 @@ int main(int argc, char **argv) {
         return 1;
     }   // if
 
-    uint32_t domid = VMI_INVALID_DOMID;
+    uint64_t domid = VMI_INVALID_DOMID;
     GHashTable *config = g_hash_table_new(g_str_hash, g_str_equal);
 
     if(strcmp(argv[1],"name")==0) {
         g_hash_table_insert(config, "name", argv[2]);
     } else
     if(strcmp(argv[1],"domid")==0) {
-        domid = atoi(argv[2]);
+        domid = strtoull(argv[2], NULL, 0);
         g_hash_table_insert(config, "domid", &domid);
     } else {
         printf("You have to specify either name or domid!\n");

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -239,7 +239,7 @@ static status_t
 set_driver_type(
     vmi_instance_t vmi,
     vmi_mode_t mode,
-    unsigned long id,
+    uint64_t id,
     const char *name)
 {
     if (VMI_AUTO == mode) {
@@ -277,7 +277,7 @@ static status_t
 set_id_and_name(
     vmi_instance_t vmi,
     vmi_mode_t mode,
-    unsigned long id,
+    uint64_t id,
     const char *name)
 {
 
@@ -357,7 +357,7 @@ static status_t
 vmi_init_private(
     vmi_instance_t *vmi,
     uint32_t flags,
-    unsigned long id,
+    uint64_t id,
     const char *name,
     vmi_config_t config)
 {
@@ -565,13 +565,13 @@ vmi_init_custom(
     } else if (VMI_CONFIG_GHASHTABLE == config_mode) {
 
         char *name = NULL;
-        unsigned long domid = VMI_INVALID_DOMID;
+        uint64_t domid = VMI_INVALID_DOMID;
         GHashTable *configtbl = (GHashTable *)config;
         gpointer idptr = NULL;
 
         name = (char *)g_hash_table_lookup(configtbl, "name");
         if(g_hash_table_lookup_extended(configtbl, "domid", NULL, &idptr)) {
-            domid = *(unsigned long *)idptr;
+            domid = *(uint64_t *)idptr;
         }
 
         if (name != NULL && domid != VMI_INVALID_DOMID) {

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -43,27 +43,27 @@
 #include "driver/kvm/kvm.h"
 #endif
 
-status_t driver_init_mode(vmi_instance_t vmi, unsigned long id, const char *name)
+status_t driver_init_mode(vmi_instance_t vmi, uint64_t domainid, const char *name)
 {
     unsigned long count = 0;
 
     /* see what systems are accessable */
 #if ENABLE_XEN == 1
-    if (VMI_SUCCESS == xen_test(id, name)) {
+    if (VMI_SUCCESS == xen_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found Xen\n");
         vmi->mode = VMI_XEN;
         count++;
     }
 #endif
 #if ENABLE_KVM == 1
-    if (VMI_SUCCESS == kvm_test(id, name)) {
+    if (VMI_SUCCESS == kvm_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found KVM\n");
         vmi->mode = VMI_KVM;
         count++;
     }
 #endif
 #if ENABLE_FILE == 1
-    if (VMI_SUCCESS == file_test(id, name)) {
+    if (VMI_SUCCESS == file_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found file\n");
         vmi->mode = VMI_FILE;
         count++;

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -37,21 +37,21 @@ typedef struct driver_interface {
         vmi_instance_t);
     void (*destroy_ptr) (
         vmi_instance_t);
-    unsigned long (*get_id_from_name_ptr) (
+    uint64_t (*get_id_from_name_ptr) (
         vmi_instance_t,
         const char *);
     status_t (*get_name_from_id_ptr) (
         vmi_instance_t,
-        unsigned long,
+        uint64_t,
         char **);
-    unsigned long (*get_id_ptr) (
+    uint64_t (*get_id_ptr) (
         vmi_instance_t);
     void (*set_id_ptr) (
         vmi_instance_t,
-        unsigned long);
+        uint64_t);
     status_t (*check_id_ptr) (
         vmi_instance_t,
-        unsigned long);
+        uint64_t);
     status_t (*get_name_ptr) (
         vmi_instance_t,
         char **);
@@ -138,7 +138,7 @@ typedef struct driver_interface {
 
 status_t driver_init_mode(
     vmi_instance_t vmi,
-    unsigned long id,
+    uint64_t domainid,
     const char *name);
 
 status_t driver_init(

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1286,14 +1286,14 @@ kvm_destroy(
     }
 }
 
-unsigned long
+uint64_t
 kvm_get_id_from_name(
     vmi_instance_t vmi,
     const char *name)
 {
     virConnectPtr conn = NULL;
     virDomainPtr dom = NULL;
-    unsigned long id;
+    uint64_t domainid;
 
     conn =
         virConnectOpenAuth("qemu:///system", virConnectAuthPtrDefault,
@@ -1309,20 +1309,20 @@ kvm_get_id_from_name(
         return -1;
     }
 
-    id = (unsigned long) virDomainGetID(dom);
+    domainid = (uint64_t) virDomainGetID(dom);
 
     if (dom)
         virDomainFree(dom);
     if (conn)
         virConnectClose(conn);
 
-    return id;
+    return domainid;
 }
 
 status_t
 kvm_get_name_from_id(
     vmi_instance_t vmi,
-    unsigned long domid,
+    uint64_t domainid,
     char **name)
 {
     virConnectPtr conn = NULL;
@@ -1336,7 +1336,7 @@ kvm_get_name_from_id(
         return VMI_FAILURE;
     }
 
-    dom = virDomainLookupByID(conn, domid);
+    dom = virDomainLookupByID(conn, domainid);
     if (NULL == dom) {
         dbprint(VMI_DEBUG_KVM, "--failed to find kvm domain\n");
         return VMI_FAILURE;
@@ -1352,7 +1352,7 @@ kvm_get_name_from_id(
     return VMI_SUCCESS;
 }
 
-unsigned long
+uint64_t
 kvm_get_id(
     vmi_instance_t vmi)
 {
@@ -1362,15 +1362,15 @@ kvm_get_id(
 void
 kvm_set_id(
     vmi_instance_t vmi,
-    unsigned long id)
+    uint64_t domainid)
 {
-    kvm_get_instance(vmi)->id = id;
+    kvm_get_instance(vmi)->id = domainid;
 }
 
 status_t
 kvm_check_id(
     vmi_instance_t vmi,
-    unsigned long id)
+    uint64_t domainid)
 {
     virConnectPtr conn = NULL;
     virDomainPtr dom = NULL;
@@ -1383,7 +1383,7 @@ kvm_check_id(
         return VMI_FAILURE;
     }
 
-    dom = virDomainLookupByID(conn, id);
+    dom = virDomainLookupByID(conn, domainid);
     if (NULL == dom) {
         dbprint(VMI_DEBUG_KVM, "--failed to find kvm domain\n");
         return VMI_FAILURE;
@@ -1662,7 +1662,7 @@ kvm_is_pv(
 
 status_t
 kvm_test(
-    unsigned long id,
+    uint64_t domainid,
     const char *name)
 {
     virConnectPtr conn = NULL;

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -34,21 +34,21 @@ status_t kvm_init_vmi(
     vmi_instance_t vmi);
 void kvm_destroy(
     vmi_instance_t vmi);
-unsigned long kvm_get_id_from_name(
+uint64_t kvm_get_id_from_name(
     vmi_instance_t vmi,
     const char *name);
 status_t kvm_get_name_from_id(
     vmi_instance_t vmi,
-    unsigned long domid,
+    uint64_t domainid,
     char **name);
-unsigned long kvm_get_id(
+uint64_t kvm_get_id(
     vmi_instance_t vmi);
 void kvm_set_id(
     vmi_instance_t vmi,
-    unsigned long id);
+    uint64_t domainid);
 status_t kvm_check_id(
     vmi_instance_t vmi,
-    unsigned long id);
+    uint64_t domainid);
 status_t kvm_get_name(
     vmi_instance_t vmi,
     char **name);
@@ -77,7 +77,7 @@ status_t kvm_write(
 int kvm_is_pv(
     vmi_instance_t vmi);
 status_t kvm_test(
-    unsigned long id,
+    uint64_t domainid,
     const char *name);
 status_t kvm_pause_vm(
     vmi_instance_t vmi);

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -38,7 +38,7 @@
 typedef struct kvm_instance {
     virConnectPtr conn;
     virDomainPtr dom;
-    unsigned long id;
+    uint32_t id;
     char *name;
     char *ds_path;
     int socket_fd;

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -516,7 +516,7 @@ xen_put_memory(
 // General Interface Functions (1-1 mapping to driver_* function)
 
 // formerly vmi_get_domain_id
-unsigned long
+uint64_t
 xen_get_domainid_from_name(
     vmi_instance_t vmi,
     const char *name)
@@ -535,7 +535,7 @@ xen_get_domainid_from_name(
     unsigned int size = 0;
     int i = 0;
     xs_transaction_t xth = XBT_NULL;
-    unsigned long domainid = VMI_INVALID_DOMID;
+    uint64_t domainid = VMI_INVALID_DOMID;
     char *tmp;
 
     struct xs_handle *xsh = OPEN_XS_DAEMON();
@@ -548,7 +548,7 @@ xen_get_domainid_from_name(
         /* read in name */
         char *idStr = domains[i];
 
-        tmp = malloc(snprintf(NULL, 0, "/local/domain/%s/name", idStr)+1);
+        tmp = g_malloc0(snprintf(NULL, 0, "/local/domain/%s/name", idStr)+1);
         sprintf(tmp, "/local/domain/%s/name", idStr);
         char *nameCandidate = xs_read(xsh, xth, tmp, NULL);
         free(tmp);
@@ -581,7 +581,7 @@ _bail:
 status_t
 xen_get_name_from_domainid(
     vmi_instance_t vmi,
-    unsigned long domid,
+    uint64_t domainid,
     char **name)
 {
 
@@ -591,7 +591,7 @@ xen_get_name_from_domainid(
 #else
 
     status_t ret = VMI_FAILURE;
-    if (domid == VMI_INVALID_DOMID) {
+    if (domainid == VMI_INVALID_DOMID) {
         return ret;
     }
 
@@ -599,15 +599,14 @@ xen_get_name_from_domainid(
     int size = 0;
     int i = 0;
     xs_transaction_t xth = XBT_NULL;
-    unsigned long domainid = VMI_INVALID_DOMID;
 
     struct xs_handle *xsh = OPEN_XS_DAEMON();
 
     if (!xsh)
         goto _bail;
 
-    char *tmp = malloc(snprintf(NULL, 0, "/local/domain/%lu/name", domid)+1);
-    sprintf(tmp, "/local/domain/%lu/name", domid);
+    char *tmp = g_malloc0(snprintf(NULL, 0, "/local/domain/%lu/name", domainid)+1);
+    sprintf(tmp, "/local/domain/%lu/name", domainid);
     char *nameCandidate = xs_read(xsh, xth, tmp, NULL);
     free(tmp);
 
@@ -623,7 +622,7 @@ _bail:
 #endif
 }
 
-unsigned long
+uint64_t
 xen_get_domainid(
     vmi_instance_t vmi)
 {
@@ -633,7 +632,7 @@ xen_get_domainid(
 void
 xen_set_domainid(
     vmi_instance_t vmi,
-    unsigned long domainid)
+    uint64_t domainid)
 {
     xen_get_instance(vmi)->domainid = domainid;
 }
@@ -641,10 +640,17 @@ xen_set_domainid(
 status_t
 xen_check_domainid(
     vmi_instance_t vmi,
-    unsigned long domainid) {
+    uint64_t domainid) {
 
     status_t ret = VMI_FAILURE;
     libvmi_xenctrl_handle_t xchandle = XENCTRL_HANDLE_INVALID;
+
+    domid_t max_domid = ~0;
+    if ( domainid > max_domid ) {
+        dbprint(VMI_DEBUG_XEN,
+                "Domain ID is invalid, larger then the max supported on Xen!\n");
+        return ret;
+    }
 
     /* open handle to the libxc interface */
     xchandle = xc_interface_open(
@@ -2454,24 +2460,24 @@ xen_is_pv(
 
 status_t
 xen_test(
-    unsigned long id,
+    uint64_t domainid,
     const char *name)
 {
-    if (id == VMI_INVALID_DOMID && name == NULL) {
+    if (domainid == VMI_INVALID_DOMID && name == NULL) {
         errprint("VMI_ERROR: xen_test: domid or name must be specified\n");
         return VMI_FAILURE;
     }
 
-    if (id == VMI_INVALID_DOMID) { /* name != NULL */
-        unsigned long domid = xen_get_domainid_from_name(NULL, name);
-        if (domid != VMI_INVALID_DOMID) {
+    if (domainid == VMI_INVALID_DOMID) { /* name != NULL */
+        domainid = xen_get_domainid_from_name(NULL, name);
+        if (domainid != VMI_INVALID_DOMID) {
             return VMI_SUCCESS;
         } else {
             return VMI_FAILURE;
         }
     }
 
-    return xen_check_domainid(NULL, id);
+    return xen_check_domainid(NULL, domainid);
 }
 
 status_t

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -38,21 +38,21 @@ status_t xen_init_vmi(
     vmi_instance_t vmi);
 void xen_destroy(
     vmi_instance_t vmi);
-unsigned long xen_get_domainid_from_name(
+uint64_t xen_get_domainid_from_name(
     vmi_instance_t vmi,
     const char *name);
 status_t xen_get_name_from_domainid(
     vmi_instance_t vmi,
-    unsigned long domid,
+    uint64_t domainid,
     char **name);
-unsigned long xen_get_domainid(
+uint64_t xen_get_domainid(
     vmi_instance_t vmi);
 void xen_set_domainid(
     vmi_instance_t vmi,
-    unsigned long domainid);
+    uint64_t domainid);
 status_t xen_check_domainid(
     vmi_instance_t vmi,
-    unsigned long domainid);
+    uint64_t domainid);
 status_t xen_get_domainname(
     vmi_instance_t vmi,
     char **name);
@@ -87,7 +87,7 @@ status_t xen_write(
 int xen_is_pv(
     vmi_instance_t vmi);
 status_t xen_test(
-    unsigned long id,
+    uint64_t domainid,
     const char *name);
 status_t xen_pause_vm(
     vmi_instance_t vmi);

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -87,7 +87,7 @@ typedef struct xen_instance {
 
     libvmi_xenctrl_handle_t xchandle; /**< handle to xenctrl library (libxc) */
 
-    unsigned long domainid; /**< domid that we are accessing */
+    uint64_t domainid; /**< domid that we are accessing */
 
     int xen_version;        /**< version of Xen libxa is running on */
 

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -75,7 +75,7 @@ typedef uint32_t vmi_mode_t;
 
 #define VMI_CONFIG_GHASHTABLE (1 << 27) /**< config GHashTable provided */
 
-#define VMI_INVALID_DOMID ~0 /**< invalid domain id */
+#define VMI_INVALID_DOMID ~0ULL /**< invalid domain id */
 
 typedef enum status {
 
@@ -1511,7 +1511,7 @@ char *vmi_get_name(
  * @param[in] vmi LibVMI instance
  * @return VM id, or zero on error
  */
-unsigned long vmi_get_vmid(
+uint64_t vmi_get_vmid(
     vmi_instance_t vmi);
 
 /**

--- a/tools/performance/user_virt_addr-linux.c
+++ b/tools/performance/user_virt_addr-linux.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
     struct timeval ktv_start;
     struct timeval ktv_end;
 
-    uint32_t dom = atoi(argv[1]);
+    uint64_t dom = strtoull(argv[1], NULL, 0);
     vmi_pid_t pid = atoi(argv[2]);
     int loops = atoi(argv[3]);
     int i = 0;

--- a/tools/performance/user_virt_addr-windows.c
+++ b/tools/performance/user_virt_addr-windows.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
     struct timeval ktv_start;
     struct timeval ktv_end;
 
-    uint32_t dom = atoi(argv[1]);
+    uint64_t dom = strtoull(argv[1], NULL, 0);
     vmi_pid_t pid = atoi(argv[2]);
     int loops = atoi(argv[3]);
     int i = 0;

--- a/tools/pyvmi/pyvmi.c
+++ b/tools/pyvmi/pyvmi.c
@@ -177,7 +177,7 @@ pyvmi_init(
     if(vmname) {
         desc(object)=vmname;
     } else {
-        uint32_t domid = vmi_get_vmid(vmi(object));
+        uint64_t domid = vmi_get_vmid(vmi(object));
         char *domidstring = malloc(snprintf(NULL, 0, "domid-%u", domid)+1);
         sprintf(domidstring, "domid-%u", domid);
         desc(object)=domidstring;

--- a/tools/vmifs/vmifs.c
+++ b/tools/vmifs/vmifs.c
@@ -130,14 +130,14 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    uint32_t domid = VMI_INVALID_DOMID;
+    uint64_t domid = VMI_INVALID_DOMID;
     GHashTable *config = g_hash_table_new(g_str_hash, g_str_equal);
 
     if(strcmp(argv[1],"name")==0) {
         g_hash_table_insert(config, "name", argv[2]);
     } else
     if(strcmp(argv[1],"domid")==0) {
-        domid = atoi(argv[2]);
+        domid = strtoull(argv[2], NULL, 0);
         g_hash_table_insert(config, "domid", &domid);
     } else {
         printf("You have to specify either name or domid!\n");


### PR DESCRIPTION
LibVMI interprets the incoming domid as unsigned long (which may be 64-bit wide). Thus, if the user inits via GHashTable input with a 32-bit domid, and the 32-bit after the domid is not 0, LibVMI will fail to init. Making domid explicitly 64-bit within LibVMI avoids this confusion.