### PR TITLE
Minor performance tweaks

### DIFF
--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -118,11 +118,9 @@ struct vmi_instance {
 #if ENABLE_PAGE_CACHE == 1
     GHashTable *memory_cache;  /**< hash table for memory cache */
 
-    GList *memory_cache_lru;  /**< list holding the most recently used pages */
+    GQueue *memory_cache_lru;  /**< queue holding the most recently used pages */
 
     uint32_t memory_cache_age; /**< max age of memory cache entry */
-
-    uint32_t memory_cache_size;/**< current size of memory cache */
 
     uint32_t memory_cache_size_max;/**< max size of memory cache */
 #else

--- a/libvmi/x86.h
+++ b/libvmi/x86.h
@@ -31,6 +31,9 @@ extern "C" {
 #define PTRS_PER_PAE_PTE 512
 #define PTRS_PER_PAE_PGD 512
 
+#define PTRS_PER_NOPAE_PTE 1024
+#define PTRS_PER_NOPAE_PGD 1024
+
 /*
  * If READ_WRITE bit is set, the page is read/write. Otherwise when
  * it is not set, the page is read-only. The WP bit in CR0


### PR DESCRIPTION
These changes nominally reduce the number of calls to things like `g_hash_table_lookup`, but mostly  just makes it easier to see the bottlenecks due to:
1. Overall number of hypervisor related system calls
2. Cache size effects on the performance of specific applications

The g_queue functions appear to be available in glib 2.4 and greater.