### PR TITLE
Return 0 when pid is invalid.

### DIFF
--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -78,6 +78,9 @@ vmi_read(
             } else {
                 dtb = vmi->kpgd;
             }
+            if (!dtb) {
+                return 0;
+            }
             start_addr = ctx->addr;
             break;
         case VMI_TM_PROCESS_DTB:
@@ -91,6 +94,7 @@ vmi_read(
             errprint("%s error: translation mechanism is not defined.\n", __FUNCTION__);
             return 0;
     }
+
 
     while (count > 0) {
         size_t read_len = 0;
@@ -290,6 +294,9 @@ vmi_read_str(
                 dtb = vmi_pid_to_dtb(vmi, ctx->pid);
             } else {
                 dtb = vmi->kpgd;
+            }
+            if (!dtb) {
+                return 0;
             }
             addr = ctx->addr;
             break;

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -75,6 +75,9 @@ vmi_write(
             } else {
                 dtb = vmi->kpgd;
             }
+            if (!dtb) {
+                return 0;
+            }
             start_addr = ctx->addr;
             break;
         case VMI_TM_PROCESS_DTB:

--- a/tests/test_translate.c
+++ b/tests/test_translate.c
@@ -1,5 +1,5 @@
-/* The LibVMI Library is an introspection library that simplifies access to 
- * memory in a target virtual machine or in a file containing a dump of 
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
  * a system's physical memory.  LibVMI is based on the XenAccess Library.
  *
  * Copyright 2012 VMITools Project
@@ -78,6 +78,30 @@ START_TEST (test_libvmi_piddtb)
 }
 END_TEST
 
+
+START_TEST (test_libvmi_invalid_pid)
+{
+    vmi_instance_t vmi = NULL;
+    status_t status = VMI_SUCCESS;
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_PROCESS_PID,
+        .addr = 0x8000000,
+        .pid = 0xfeedbeef,
+        .ksym = NULL,
+        };
+    uint8_t buffer[8];
+    size_t bytes_read = 0;
+
+    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+
+    bytes_read = vmi_read(vmi, &ctx, &buffer, sizeof(buffer));
+
+    vmi_destroy(vmi);
+    fail_unless(bytes_read == 0, "invalid pid accepted");
+}
+END_TEST
+
+
 /* test vmi_translate_kv2p */
 START_TEST (test_libvmi_kv2p)
 {
@@ -136,5 +160,6 @@ TCase *translate_tcase (void)
     // uv2p
     tcase_add_test(tc_translate, test_libvmi_kv2p);
     tcase_add_test(tc_translate, test_libvmi_piddtb);
+    tcase_add_test(tc_translate, test_libvmi_invalid_pid);
     return tc_translate;
 }


### PR DESCRIPTION
Invalid pid means that no dtb could be found for the pid.