### PR TITLE
Add max_physical_addressable value distinct from memsize.

### DIFF
--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -69,7 +69,7 @@ main(
         goto error_exit;
     }
 
-    size = vmi_get_memsize(vmi);
+    size = vmi_get_max_physical_address(vmi);
 
     while (address < size) {
 

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -147,7 +147,14 @@ uint64_t
 vmi_get_memsize(
     vmi_instance_t vmi)
 {
-    return vmi->size;
+    return vmi->allocated_ram_size;
+}
+
+addr_t
+vmi_get_max_physical_address(
+    vmi_instance_t vmi)
+{
+    return vmi->max_physical_address;
 }
 
 unsigned int

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -427,7 +427,7 @@ vmi_init_private(
     }
 
     /* get the memory size */
-    if (driver_get_memsize(*vmi, &(*vmi)->size) == VMI_FAILURE) {
+    if (driver_get_memsize(*vmi, &(*vmi)->allocated_ram_size, &(*vmi)->max_physical_address) == VMI_FAILURE) {
         errprint("Failed to get memory size.\n");
         goto error_exit;
     }

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -60,7 +60,8 @@ typedef struct driver_interface {
         const char *);
     status_t (*get_memsize_ptr) (
         vmi_instance_t,
-        uint64_t *);
+        uint64_t *,
+        addr_t *);
     status_t (*get_vcpureg_ptr) (
         vmi_instance_t,
         reg_t *,

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -148,10 +148,11 @@ driver_set_name(
 static inline status_t
 driver_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size)
+    uint64_t *allocated_ram_size,
+    addr_t *max_physical_address)
 {
     if (vmi->driver.initialized && vmi->driver.get_memsize_ptr) {
-        return vmi->driver.get_memsize_ptr(vmi, size);
+        return vmi->driver.get_memsize_ptr(vmi, allocated_ram_size, max_physical_address);
     }
     else {
         dbprint

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -60,7 +60,7 @@ file_get_memory(
 {
     void *memory = 0;
 
-    if (paddr + length > vmi->size) {
+    if (paddr + length >= vmi->max_physical_address) {
         dbprint
             (VMI_DEBUG_FILE, "--%s: request for PA range [0x%.16"PRIx64"-0x%.16"PRIx64"] reads past end of file\n",
              __FUNCTION__, paddr, paddr + length);
@@ -215,7 +215,8 @@ file_set_name(
 status_t
 file_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size)
+    uint64_t *allocated_ram_size,
+    addr_t *max_physical_address)
 {
     status_t ret = VMI_FAILURE;
     struct stat s;
@@ -224,7 +225,8 @@ file_get_memsize(
         errprint("Failed to stat file.\n");
         goto error_exit;
     }
-    *size = s.st_size;
+    *allocated_ram_size = s.st_size;
+    *max_physical_address = s.st_size;
     ret = VMI_SUCCESS;
 
 error_exit:

--- a/libvmi/driver/file/file.h
+++ b/libvmi/driver/file/file.h
@@ -37,7 +37,8 @@ void file_set_name(
     const char *name);
 status_t file_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size);
+    uint64_t *allocated_ram_size,
+    addr_t *maximum_physical_address);
 status_t file_get_vcpureg(
     vmi_instance_t vmi,
     reg_t *value,

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1426,7 +1426,8 @@ kvm_set_name(
 status_t
 kvm_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size)
+    uint64_t *allocated_ram_size,
+    addr_t *maximum_physical_address)
 {
     virDomainInfo info;
 
@@ -1434,7 +1435,8 @@ kvm_get_memsize(
         dbprint(VMI_DEBUG_KVM, "--failed to get vm info\n");
         goto error_exit;
     }
-    *size = info.maxMem * 1024; // convert KBytes to bytes
+    *allocated_ram_size = info.maxMem * 1024; // convert KBytes to bytes
+    *maximum_physical_address = *allocated_ram_size;
 
     return VMI_SUCCESS;
 error_exit:

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -57,7 +57,8 @@ void kvm_set_name(
     const char *name);
 status_t kvm_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size);
+    uint64_t *allocate_ram_size,
+    addr_t *maximum_physical_address);
 status_t kvm_get_vcpureg(
     vmi_instance_t vmi,
     reg_t *value,

--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -128,11 +128,11 @@ static memory_cache_entry_t create_new_entry (vmi_instance_t vmi, addr_t paddr,
     //
     // TODO: perform other reasonable checks
 
-    if (vmi->hvm && (paddr + length - 1 > vmi->size)) {
-        errprint("--requesting PA [0x%"PRIx64"] beyond memsize [0x%"PRIx64"]\n",
-                paddr + length, vmi->size);
-        errprint("\tpaddr: %"PRIx64", length %"PRIx32", vmi->size %"PRIx64"\n", paddr, length,
-                vmi->size);
+    if (vmi->hvm && (paddr + length >= vmi->max_physical_address)) {
+        errprint("--requesting PA [0x%"PRIx64"] beyond max physical address [0x%"PRIx64"]\n",
+                paddr + length, vmi->max_physical_address);
+        errprint("\tpaddr: %"PRIx64", length %"PRIx32", vmi->max_physical_address %"PRIx64"\n", paddr, length,
+                vmi->max_physical_address);
         return 0;
     }
 

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -335,8 +335,8 @@ xen_setup_shm_snapshot_mode(
     //  chunk 1: start_pfn, end_pfn, next == "chunk 2"
     //  chunk 2: start_pfn, end_pfn, next == NULL
     xen_pmem_chunk_t pmem_list = NULL;
-    xen_get_memsize(vmi, &vmi->size);
-    if (VMI_SUCCESS != probe_mappable_pages(vmi, &pmem_list, vmi->size)) {
+    xen_get_memsize(vmi, &vmi->allocated_ram_size, &vmi->max_physical_address);
+    if (VMI_SUCCESS != probe_mappable_pages(vmi, &pmem_list, vmi->max_physical_address)) {
         errprint("fail to probe mappable pages\n");
         return VMI_FAILURE;
     }
@@ -838,6 +838,19 @@ xen_init_vmi(
     }
 #endif /* VMI_DEBUG */
 
+    xen->max_gpfn = xc_domain_maximum_gpfn(xen->xchandle, xen->domainid);
+    if (xen->max_gpfn <= 0) {
+        errprint("Failed to get max gpfn for Xen.\n");
+        goto _bail;
+    }
+
+    /* For Xen PV domains, where xc_domain_maximum_gpfn() returns a number
+     * more like nr_pages, which is usually less than max_pages or the
+     * calculated number of pages based on memkb, just fake it to be sane. */
+    if ((xen->max_gpfn << 12) < (xen->info.max_memkb * 1024)) {
+        xen->max_gpfn = (xen->info.max_memkb * 1024) >> 12;
+    }
+
 #if ENABLE_XEN_EVENTS==1
     /* Only enable events IFF(mode & VMI_INIT_EVENTS)
      * Additional checks performed within xen_events_init
@@ -949,19 +962,27 @@ void xen_set_domainname(
 status_t
 xen_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size)
+    uint64_t *allocated_ram_size,
+    addr_t *max_physical_address)
 {
     // note: may also available through xen_get_instance(vmi)->info.max_memkb
     // or xenstore /local/domain/%d/memory/target
-    status_t ret = VMI_FAILURE;
     uint64_t pages = xen_get_instance(vmi)->info.nr_pages + xen_get_instance(vmi)->info.nr_shared_pages;
 
-    if(pages > 0) {
-        *size = XC_PAGE_SIZE * pages;
-        ret = VMI_SUCCESS;
+    if(pages == 0) {
+        return VMI_FAILURE;
     }
 
-    return ret;
+    *allocated_ram_size = XC_PAGE_SIZE * pages;
+
+    addr_t max_gpfn = xen_get_instance(vmi)->max_gpfn;
+    if (max_gpfn == 0) {
+        return VMI_FAILURE;
+    }
+
+    *max_physical_address = max_gpfn * XC_PAGE_SIZE;
+
+    return VMI_SUCCESS;
 }
 
 #if defined(I386) || defined(X86_64)

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -827,8 +827,7 @@ xen_init_vmi(
     vmi->num_vcpus = xen->info.max_vcpu_id + 1;
 
     /* determine if target is hvm or pv */
-    vmi->hvm = xen->hvm =
-        xen->info.hvm;
+    vmi->hvm = xen->hvm = xen->info.hvm;
 #ifdef VMI_DEBUG
     if (xen->hvm) {
         dbprint(VMI_DEBUG_XEN, "**set hvm to true (HVM).\n");
@@ -838,9 +837,18 @@ xen_init_vmi(
     }
 #endif /* VMI_DEBUG */
 
+#if __XEN_INTERFACE_VERSION__ < 0x00040600
     xen->max_gpfn = xc_domain_maximum_gpfn(xen->xchandle, xen->domainid);
+#else
+    if (xc_domain_maximum_gpfn(xen->xchandle, xen->domainid, &xen->max_gpfn)) {
+        errprint("Failed to get max gpfn for Xen.\n");
+        ret = VMI_FAILURE;
+        goto _bail;
+    }
+#endif
     if (xen->max_gpfn <= 0) {
         errprint("Failed to get max gpfn for Xen.\n");
+        ret = VMI_FAILURE;
         goto _bail;
     }
 

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -61,7 +61,8 @@ void xen_set_domainname(
     const char *name);
 status_t xen_get_memsize(
     vmi_instance_t vmi,
-    uint64_t *size);
+    uint64_t *allocated_ram_size,
+    addr_t *maximum_physical_address);
 status_t xen_get_vcpureg(
     vmi_instance_t vmi,
     reg_t *value,

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -95,7 +95,12 @@ typedef struct xen_instance {
 
     xc_dominfo_t info;      /**< libxc info: domid, ssidref, stats, etc */
 
+
+#if __XEN_INTERFACE_VERSION__ < 0x00040600
     int max_gpfn;           /**< result of xc_domain_maximum_gpfn() */
+#else
+    xen_pfn_t max_gpfn;           /**< result of xc_domain_maximum_gpfn() */
+#endif
 
     uint8_t addr_width;     /**< guest's address width in bytes: 4 or 8 */
 

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -95,6 +95,8 @@ typedef struct xen_instance {
 
     xc_dominfo_t info;      /**< libxc info: domid, ssidref, stats, etc */
 
+    int max_gpfn;           /**< result of xc_domain_maximum_gpfn() */
+
     uint8_t addr_width;     /**< guest's address width in bytes: 4 or 8 */
 
 #ifdef HAVE_LIBXENSTORE

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1614,8 +1614,9 @@ uint64_t vmi_get_offset(
 
 /**
  * Gets the memory size of the guest or file that LibVMI is currently
- * accessing.  This is effectively the max physical address that you
- * can access in the system.
+ * accessing.  This is the amount of RAM allocated to the guest, but
+ * does not necessarily indicate the highest addressable physical address;
+ * get_max_physical_address() should be used.
  *
  * NOTE: if memory ballooning alters the allocation of memory to a
  *  VM after vmi_init, this information will have become stale
@@ -1625,6 +1626,22 @@ uint64_t vmi_get_offset(
  * @return Memory size
  */
 uint64_t vmi_get_memsize(
+    vmi_instance_t vmi);
+
+/**
+ * Gets highest addressable physical memory address of the guest or file that
+ * LibVMI is currently accessing plus one.  That is, any address less then the
+ * returned value "may be" a valid physical memory address, but the layout of
+ * the guest RAM is hypervisor specific, so there can and will be holes that
+ * are not memory pages and can't be read by libvmi.
+ *
+ * NOTE: if memory ballooning alters the allocation of memory to a VM after
+ *  vmi_init, this information will have become stale and a re-initialization
+ *  will be required.
+ *
+ * @param[in] vmi LibVMI instance @return physical memory size
+ */
+addr_t vmi_get_max_physical_address(
     vmi_instance_t vmi);
 
 /**

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -129,7 +129,7 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     dbprint(VMI_DEBUG_CORE, "**sanity checking cr3 = 0x%.16"PRIx64"\n", cr3);
 
     /* testing to see CR3 value */
-    if (!driver_is_pv(vmi) && cr3 > vmi->size) {   // sanity check on CR3
+    if (!driver_is_pv(vmi) && cr3 >= vmi->max_physical_address) {   // sanity check on CR3
         dbprint(VMI_DEBUG_CORE, "** Note cr3 value [0x%"PRIx64"] exceeds memsize [0x%"PRIx64"]\n",
                 cr3, vmi->size);
     }

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -85,7 +85,7 @@ get_ntoskrnl_base(
     uint8_t page[VMI_PS_4KB];
     addr_t ret = 0;
 
-    for(; page_paddr + VMI_PS_4KB < vmi->size; page_paddr += VMI_PS_4KB) {
+    for(; page_paddr + VMI_PS_4KB < vmi->max_physical_address; page_paddr += VMI_PS_4KB) {
 
         uint8_t page[VMI_PS_4KB];
         status_t rc = peparse_get_image_phys(vmi, page_paddr, VMI_PS_4KB, page);
@@ -103,13 +103,13 @@ get_ntoskrnl_base(
         addr_t export_header_offset =
             peparse_get_idd_rva(IMAGE_DIRECTORY_ENTRY_EXPORT, &optional_header_type, optional_pe_header, NULL, NULL);
 
-        if(!export_header_offset || page_paddr + export_header_offset > vmi->size)
+        if(!export_header_offset || page_paddr + export_header_offset >= vmi->max_physical_address)
             continue;
 
         uint32_t nbytes = vmi_read_pa(vmi, page_paddr + export_header_offset, &et, sizeof(struct export_table));
         if(nbytes == sizeof(struct export_table) && !(et.export_flags || !et.name) ) {
 
-            if(page_paddr + et.name + 12 > vmi->size) {
+            if(page_paddr + et.name + 12 >= vmi->max_physical_address) {
                 continue;
             }
 

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -144,7 +144,7 @@ find_pname_offset(
         check = get_check_magic_func(vmi);
     }
 
-    for (block_pa = 4096; block_pa + BLOCK_SIZE <= vmi->size; block_pa += BLOCK_SIZE) {
+    for (block_pa = 4096; block_pa + BLOCK_SIZE < vmi->max_physical_address; block_pa += BLOCK_SIZE) {
         read = vmi_read_pa(vmi, block_pa, block_buffer, BLOCK_SIZE);
         if (BLOCK_SIZE != read) {
             continue;
@@ -209,7 +209,7 @@ find_process_by_name(
         check = get_check_magic_func(vmi);
     }
 
-    for (block_pa = start_address; block_pa + VMI_PS_4KB <= vmi->size;
+    for (block_pa = start_address; block_pa + VMI_PS_4KB < vmi->max_physical_address;
          block_pa += VMI_PS_4KB) {
         read = vmi_read_pa(vmi, block_pa, block_buffer, VMI_PS_4KB);
         if (VMI_PS_4KB != read) {

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -93,7 +93,9 @@ struct vmi_instance {
 
     arch_interface_t arch_interface; /**< architecture specific functions */
 
-    uint64_t size;          /**< total size of target's memory */
+    uint64_t allocated_ram_size; /**< total size of target's allocated memory */
+
+    addr_t max_physical_address; /**< maximum valid physical memory address + 1 */
 
     int hvm;                /**< nonzero if HVM */
 

--- a/tests/test_accessor.c
+++ b/tests/test_accessor.c
@@ -1,5 +1,5 @@
-/* The LibVMI Library is an introspection library that simplifies access to 
- * memory in a target virtual machine or in a file containing a dump of 
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
  * a system's physical memory.  LibVMI is based on the XenAccess Library.
  *
  * Copyright 2012 VMITools Project
@@ -43,12 +43,33 @@ START_TEST (test_vmi_get_name)
 }
 END_TEST
 
+START_TEST (test_vmi_get_memsize_max_phys_addr)
+{
+    vmi_instance_t vmi = NULL;
+    uint64_t memsize = 0;
+    addr_t max_physical_addr = 0;
+
+    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+
+    memsize = vmi_get_memsize(vmi);
+    max_physical_addr = vmi_get_max_physical_address(vmi);
+
+    fail_unless(memsize > 0, "guest ram size is 0");
+    fail_unless(max_physical_addr > 0, "max physical address is 0");
+
+    fail_unless(max_physical_addr >= memsize, "max physical address is less than memsize");
+
+    vmi_destroy(vmi);
+}
+END_TEST
+
 /* accessor test cases */
 TCase *accessor_tcase (void)
 {
     TCase *tc_accessor = tcase_create("LibVMI Accessor");
 
     tcase_add_test(tc_accessor, test_vmi_get_name);
+    tcase_add_test(tc_accessor, test_vmi_get_memsize_max_phys_addr);
     //vmi_get_vmid
     //vmi_get_access_mode
     //vmi_get_page_mode

--- a/tests/test_shm_snapshot.c
+++ b/tests/test_shm_snapshot.c
@@ -1,5 +1,5 @@
-/* The LibVMI Library is an introspection library that simplifies access to 
- * memory in a target virtual machine or in a file containing a dump of 
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
  * a system's physical memory.  LibVMI is based on the XenAccess Library.
  *
  * Copyright 2012 VMITools Project
@@ -60,12 +60,17 @@ START_TEST (test_vmi_get_dgpma)
 
     addr_t pa = 0x1000; // just because vmi_read_page() deny to fetch frame 0.
     size_t count = 4096;
-    unsigned long max_size = vmi_get_memsize(vmi);
+    unsigned long max_size = vmi_get_max_physical_address(vmi);
     void *buf_readpa = malloc(count);
     void *buf_dgpma = NULL;
     for (; pa + count <= max_size; pa += count) {
         size_t read_pa = vmi_read_pa(vmi, pa, buf_readpa, count);
         size_t read_dgpma = vmi_get_dgpma(vmi, pa, &buf_dgpma, count);
+
+        if (read_pa == 0 && read_dgpma == 0) {
+            continue;
+        }
+
         fail_unless(read_pa == read_dgpma, "vmi_get_dgpma(0x%"PRIx64
             ") read size %d dosn't conform to %d of vmi_read_pa()",
             pa, read_dgpma, read_pa);


### PR DESCRIPTION
This is an attempt to address problems like #258, by keeping track of an additional attribute of the guest, maximum_physical_address, which is different from the maximum amount of RAM allocated to a guest depending on how the hypervisor maps it into the guests physical address space.
