### PR TITLE
Add back missing v2m_table_t definition

### DIFF
--- a/libvmi/driver/kvm/kvm_shm.h
+++ b/libvmi/driver/kvm/kvm_shm.h
@@ -63,4 +63,13 @@ typedef struct v2m_chunk_struct {
     struct v2m_chunk_struct* next;
 } v2m_chunk, *v2m_chunk_t;
 
+/*
+ * v2m table binds a pid and a list of v2m chunks
+ */
+typedef struct v2m_table_struct {
+    pid_t pid;
+    v2m_chunk_t v2m_chunks;
+    struct v2m_table_struct* next;
+} v2m_table, *v2m_table_t;
+
 #endif /* KVM_SHM_H */


### PR DESCRIPTION
(Supposedly) fixes Issue #279, without a KVM test rig at the moment