### PR TITLE
Fixing vmi->size references in debug messages

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -431,8 +431,11 @@ vmi_init_private(
         errprint("Failed to get memory size.\n");
         goto error_exit;
     }
-    dbprint(VMI_DEBUG_CORE, "**set size = %"PRIu64" [0x%"PRIx64"]\n", (*vmi)->size,
-        (*vmi)->size);
+
+    dbprint(VMI_DEBUG_CORE, "**set allocated_ram_size = %"PRIx64", "
+                            "max_physical_address = 0x%"PRIx64"\n",
+                            (*vmi)->allocated_ram_size,
+                            (*vmi)->max_physical_address);
 
     // for file mode we need os-specific heuristics to deduce the architecture
     // for live mode, having arch_interface set even in VMI_PARTIAL mode

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -87,7 +87,7 @@ file_get_memory(
 error_print:
     dbprint(VMI_DEBUG_WRITE, "%s: failed to read %d bytes at "
             "PA (offset) 0x%.16"PRIx64" [VM size 0x%.16"PRIx64"]\n", __FUNCTION__,
-            length, paddr, vmi->size);
+            length, paddr, vmi->allocated_ram_size);
 error_noprint:
     if (memory)
         free(memory);

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -130,8 +130,8 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
 
     /* testing to see CR3 value */
     if (!driver_is_pv(vmi) && cr3 >= vmi->max_physical_address) {   // sanity check on CR3
-        dbprint(VMI_DEBUG_CORE, "** Note cr3 value [0x%"PRIx64"] exceeds memsize [0x%"PRIx64"]\n",
-                cr3, vmi->size);
+        dbprint(VMI_DEBUG_CORE, "** Note cr3 value [0x%"PRIx64"] exceeds max_physical_address [0x%"PRIx64"]\n",
+                cr3, vmi->max_physical_address);
     }
 
     vmi->page_mode = pm;


### PR DESCRIPTION
These references made compiling with debug flags turned on impossible. We should probably add a test case for debug build as well (I'll open an issue for that so we don't forget).