### PR TITLE
This is a QEMU 2.4.0.1 patch for libvmi to introspect QEMU/KVM VMs ru…

### DIFF
--- a/tools/qemu-kvm-patch/kvm-qemu-2.4.0.1-libvmi.patch
+++ b/tools/qemu-kvm-patch/kvm-qemu-2.4.0.1-libvmi.patch
@@ -1,0 +1,372 @@
+diff -Naur qemu-2.4.0.1/hmp.c qemu-2.4.0.1-valerio/hmp.c
+--- qemu-2.4.0.1/hmp.c	2015-09-22 16:00:48.000000000 -0600
++++ qemu-2.4.0.1-valerio/hmp.c	2015-10-12 10:15:52.583843591 -0600
+@@ -905,6 +905,15 @@
+     hmp_handle_error(mon, &err);
+ }
+ 
++void hmp_pmemaccess(Monitor *mon, const QDict *qdict)
++{
++    const char *path = qdict_get_str(qdict, "path");
++    Error *err = NULL;
++
++    qmp_pmemaccess(path, &err);
++    hmp_handle_error(mon, &err);
++}
++
+ void hmp_ringbuf_write(Monitor *mon, const QDict *qdict)
+ {
+     const char *chardev = qdict_get_str(qdict, "device");
+diff -Naur qemu-2.4.0.1/hmp-commands.hx qemu-2.4.0.1-valerio/hmp-commands.hx
+--- qemu-2.4.0.1/hmp-commands.hx	2015-09-22 16:00:48.000000000 -0600
++++ qemu-2.4.0.1-valerio/hmp-commands.hx	2015-10-12 10:31:02.811815385 -0600
+@@ -805,6 +805,20 @@
+ ETEXI
+ 
+     {
++        .name       = "pmemaccess",
++        .args_type  = "path:s",
++        .params     = "file",
++        .help       = "open A UNIX Socket access to physical memory at 'path'",
++        .mhandler.cmd = hmp_pmemaccess,
++    },
++
++STEXI
++@item pmemaccess @var{file}
++@findex pmemaccess
++Mount guest physical memory image at 'path'
++ETEXI
++
++    {
+         .name       = "boot_set",
+         .args_type  = "bootdevice:s",
+         .params     = "bootdevice",
+diff -Naur qemu-2.4.0.1/hmp.h qemu-2.4.0.1-valerio/hmp.h
+--- qemu-2.4.0.1/hmp.h	2015-09-22 16:00:48.000000000 -0600
++++ qemu-2.4.0.1-valerio/hmp.h	2015-10-12 10:15:52.583843591 -0600
+@@ -46,6 +46,7 @@
+ void hmp_cpu(Monitor *mon, const QDict *qdict);
+ void hmp_memsave(Monitor *mon, const QDict *qdict);
+ void hmp_pmemsave(Monitor *mon, const QDict *qdict);
++void hmp_pmemaccess(Monitor *mon, const QDict *qdict);
+ void hmp_ringbuf_write(Monitor *mon, const QDict *qdict);
+ void hmp_ringbuf_read(Monitor *mon, const QDict *qdict);
+ void hmp_cont(Monitor *mon, const QDict *qdict);
+diff -Naur qemu-2.4.0.1/Makefile.target qemu-2.4.0.1-valerio/Makefile.target
+--- qemu-2.4.0.1/Makefile.target	2015-09-22 16:00:47.000000000 -0600
++++ qemu-2.4.0.1-valerio/Makefile.target	2015-10-12 10:15:52.583843591 -0600
+@@ -128,7 +128,7 @@
+ #########################################################
+ # System emulator target
+ ifdef CONFIG_SOFTMMU
+-obj-y += arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o numa.o
++obj-y += arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o numa.o memory-access.o
+ obj-y += qtest.o bootdevice.o
+ obj-y += hw/
+ obj-$(CONFIG_KVM) += kvm-all.o
+diff -Naur qemu-2.4.0.1/memory-access.c qemu-2.4.0.1-valerio/memory-access.c
+--- qemu-2.4.0.1/memory-access.c	1969-12-31 17:00:00.000000000 -0700
++++ qemu-2.4.0.1-valerio/memory-access.c	2015-10-12 10:21:06.155833874 -0600
+@@ -0,0 +1,206 @@
++/*
++ * Access guest physical memory via a domain socket.
++ *
++ * Copyright (C) 2011 Sandia National Laboratories
++ * Original Author: Bryan D. Payne (bdpayne@acm.org)
++ * 
++ * Refurbished for modern QEMU by Valerio Aimale (valerio@aimale.com), in 2015
++ */
++
++#include "memory-access.h"
++//#include "cpu-all.h"
++#include "qemu-common.h"
++#include "exec/cpu-common.h"
++#include "config.h"
++
++#include <stdlib.h>
++#include <stdio.h>
++#include <string.h>
++#include <pthread.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <sys/un.h>
++#include <unistd.h>
++#include <signal.h>
++#include <stdint.h>
++
++struct request{
++    uint8_t type;      // 0 quit, 1 read, 2 write, ... rest reserved
++    uint64_t address;  // address to read from OR write to
++    uint64_t length;   // number of bytes to read OR write
++};
++
++static uint64_t
++connection_read_memory (uint64_t user_paddr, void *buf, uint64_t user_len)
++{
++    hwaddr paddr = (hwaddr) user_paddr;
++    hwaddr len = (hwaddr) user_len;
++    void *guestmem = cpu_physical_memory_map(paddr, &len, 0);
++    if (!guestmem){
++        return 0;
++    }
++    memcpy(buf, guestmem, len);
++    cpu_physical_memory_unmap(guestmem, len, 0, len);
++
++    return len;
++}
++
++static uint64_t
++connection_write_memory (uint64_t user_paddr, void *buf, uint64_t user_len)
++{
++    hwaddr paddr = (hwaddr) user_paddr;
++    hwaddr len = (hwaddr) user_len;
++    void *guestmem = cpu_physical_memory_map(paddr, &len, 1);
++    if (!guestmem){
++        return 0;
++    }
++    memcpy(guestmem, buf, len);
++    cpu_physical_memory_unmap(guestmem, len, 0, len);
++
++    return len;
++}
++
++static void
++send_success_ack (int connection_fd)
++{
++    uint8_t success = 1;
++    int nbytes = write(connection_fd, &success, 1);
++    if (1 != nbytes){
++        fprintf(stderr, "Qemu pmemaccess: failed to send success ack\n");
++    }
++}
++
++static void
++send_fail_ack (int connection_fd)
++{
++    uint8_t fail = 0;
++    int nbytes = write(connection_fd, &fail, 1);
++    if (1 != nbytes){
++        fprintf(stderr, "Qemu pmemaccess: failed to send fail ack\n");
++    }
++}
++
++static void
++connection_handler (int connection_fd)
++{
++    int nbytes;
++    struct request req;
++
++    while (1){
++        // client request should match the struct request format
++        nbytes = read(connection_fd, &req, sizeof(struct request));
++        if (nbytes != sizeof(struct request)){
++            // error
++            continue;
++        }
++        else if (req.type == 0){
++            // request to quit, goodbye
++            break;
++        }
++        else if (req.type == 1){
++            // request to read
++            char *buf = malloc(req.length + 1);
++            nbytes = connection_read_memory(req.address, buf, req.length);
++            if (nbytes != req.length){
++                // read failure, return failure message
++                buf[req.length] = 0; // set last byte to 0 for failure
++                nbytes = write(connection_fd, buf, 1);
++            }
++            else{
++                // read success, return bytes
++                buf[req.length] = 1; // set last byte to 1 for success
++                nbytes = write(connection_fd, buf, nbytes + 1);
++            }
++            free(buf);
++        }
++        else if (req.type == 2){
++            // request to write
++            void *write_buf = malloc(req.length);
++            nbytes = read(connection_fd, &write_buf, req.length);
++            if (nbytes != req.length){
++                // failed reading the message to write
++                send_fail_ack(connection_fd);
++            }
++            else{
++                // do the write
++                nbytes = connection_write_memory(req.address, write_buf, req.length);
++                if (nbytes == req.length){
++                    send_success_ack(connection_fd);
++                }
++                else{
++                    send_fail_ack(connection_fd);
++                }
++            }
++            free(write_buf);
++        }
++        else{
++            // unknown command
++            fprintf(stderr, "Qemu pmemaccess: ignoring unknown command (%d)\n", req.type);
++            char *buf = malloc(1);
++            buf[0] = 0;
++            nbytes = write(connection_fd, buf, 1);
++            free(buf);
++        }
++    }
++
++    close(connection_fd);
++}
++
++static void *
++memory_access_thread (void *p)
++{
++    struct sockaddr_un address;
++    int socket_fd, connection_fd;
++    socklen_t address_length;
++    struct pmemaccess_args *pargs = (struct pmemaccess_args *)p;
++
++    socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
++    if (socket_fd < 0){
++	error_setg(pargs->errp, "Qemu pmemaccess: socket failed");
++        goto error_exit;
++    }
++    unlink(pargs->path);
++    address.sun_family = AF_UNIX;
++    address_length = sizeof(address.sun_family) + sprintf(address.sun_path, "%s", (char *) pargs->path);
++
++    if (bind(socket_fd, (struct sockaddr *) &address, address_length) != 0){
++	error_setg(pargs->errp, "Qemu pmemaccess: bind failed");
++        goto error_exit;
++    }
++    if (listen(socket_fd, 0) != 0){
++	error_setg(pargs->errp, "Qemu pmemaccess: listen failed");
++        goto error_exit;
++    }
++
++    connection_fd = accept(socket_fd, (struct sockaddr *) &address, &address_length);
++    connection_handler(connection_fd);
++
++    close(socket_fd);
++    unlink(pargs->path);
++    free(pargs->path);
++    free(pargs);
++error_exit:
++    return NULL;
++}
++
++void
++qmp_pmemaccess (const char *path, Error **errp)
++{
++    pthread_t thread;
++    sigset_t set, oldset;
++    struct pmemaccess_args *pargs;
++
++    // create the args struct
++    pargs = (struct pmemaccess_args *) malloc(sizeof(struct pmemaccess_args));
++    pargs->errp = errp;
++    // create a copy of path that we can safely use
++    pargs->path = malloc(strlen(path) + 1);
++    memcpy(pargs->path, path, strlen(path) + 1);
++	
++    // start the thread
++    sigfillset(&set);
++    pthread_sigmask(SIG_SETMASK, &set, &oldset);
++    pthread_create(&thread, NULL, memory_access_thread, pargs);
++    pthread_sigmask(SIG_SETMASK, &oldset, NULL);
++
++}
+diff -Naur qemu-2.4.0.1/memory-access.h qemu-2.4.0.1-valerio/memory-access.h
+--- qemu-2.4.0.1/memory-access.h	1969-12-31 17:00:00.000000000 -0700
++++ qemu-2.4.0.1-valerio/memory-access.h	2015-10-12 10:15:52.587843591 -0600
+@@ -0,0 +1,21 @@
++/*
++ * Mount guest physical memory using FUSE.
++ *
++ * Author: Valerio G. Aimale <valerio@aimale.com>
++ */
++
++#ifndef MEMORY_ACCESS_H
++#define MEMORY_ACCESS_H
++
++#include "qapi-types.h"
++#include "qapi/qmp/qdict.h"
++#include "qapi/error.h"
++
++void qmp_pmemaccess (const char *path, Error **errp);
++
++struct pmemaccess_args {
++	char *path;
++	Error **errp;
++};
++
++#endif /* MEMORY_ACCESS_H */
+diff -Naur qemu-2.4.0.1/qapi-schema.json qemu-2.4.0.1-valerio/qapi-schema.json
+--- qemu-2.4.0.1/qapi-schema.json	2015-09-22 16:00:51.000000000 -0600
++++ qemu-2.4.0.1-valerio/qapi-schema.json	2015-10-12 10:28:33.959819998 -0600
+@@ -1389,6 +1389,34 @@
+   'data': {'val': 'int', 'size': 'int', 'filename': 'str'} }
+ 
+ ##
++# @pmemaccess:
++#
++# Open A UNIX Socket access to physical memory
++#
++# @path: the name of the UNIX socket pipe
++#
++# Returns: Nothing on success
++#
++# Since: 2.4.0.1
++#
++# Notes: Derived from previously existing patches. When command
++# succeeds connect to the open socket. Write a binary structure to 
++# the socket as:
++# 
++# struct request {
++#     uint8_t type;   // 0 quit, 1 read, 2 write, ... rest reserved
++#     uint64_t address;   // address to read from OR write to
++#     uint64_t length;    // number of bytes to read OR write
++# };
++# 
++# If it is a read operation, Qemu will return lenght+1 bytes. Read lenght+1
++# bytes. the last byte will be a 1 for success, or a 0 for failure.
++#  
++##
++{ 'command': 'pmemaccess',
++  'data': {'path': 'str'} }
++
++##
+ # @cont:
+ #
+ # Resume guest VCPU execution.
+diff -Naur qemu-2.4.0.1/qmp-commands.hx qemu-2.4.0.1-valerio/qmp-commands.hx
+--- qemu-2.4.0.1/qmp-commands.hx	2015-09-22 16:00:51.000000000 -0600
++++ qemu-2.4.0.1-valerio/qmp-commands.hx	2015-10-12 10:37:43.791802959 -0600
+@@ -467,6 +467,29 @@
+ EQMP
+ 
+     {
++        .name       = "pmemaccess",
++        .args_type  = "path:s",
++        .mhandler.cmd_new = qmp_marshal_input_pmemaccess,
++    },
++
++SQMP
++pmemaccess
++----------
++
++Open A UNIX Socket access to physical memory
++
++Arguments:
++
++- "path": mount point path (json-string)
++
++Example:
++
++-> { "execute": "pmemaccess",
++             "arguments": { "path": "/tmp/guestname" } }
++<- { "return": {} }
++
++EQMP
++    {
+         .name       = "inject-nmi",
+         .args_type  = "",
+         .mhandler.cmd_new = qmp_marshal_input_inject_nmi,


### PR DESCRIPTION
I've produced a QEMU 2.4.0.1 patch for libvmi to work with VM's run under QEMU/kvm.

The patch is derived from old/existing patches. It implements the server-side of socket interface used by libvmi/driver/kvm/kvm.c

Tested directly libvmi->QEMU. Also tested with volatility->libvmi address space driver (via rekal profile) -> QEMU

All seems to be working.