### PR TITLE
added size_t size to vmi_instance struct

### DIFF
--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -148,6 +148,8 @@ struct vmi_instance {
     uint32_t step_vcpus[MAX_SINGLESTEP_VCPUS]; /**< counter of events on vcpus for which we have internal singlestep enabled */
 
     gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
+    
+    size_t size;
 };
 
 /** Page-level memevent struct to also hold byte-level events in the embedded hashtable */


### PR DESCRIPTION
vmi_instance->size  was missing for xen with snapshot enabled