### PR TITLE
Fix to pyvmi va* and pa* write functions

### DIFF
--- a/tools/pyvmi/pyvmi.c
+++ b/tools/pyvmi/pyvmi.c
@@ -510,7 +510,7 @@ pyvmi_write_pa(
     void *buf;
     int count;
 
-    if (!PyArg_ParseTuple(args, "Is#", &paddr, &buf, &count)) {
+    if (!PyArg_ParseTuple(args, "Ks#", &paddr, &buf, &count)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -537,7 +537,7 @@ pyvmi_write_va(
     void *buf;
     int count;
 
-    if (!PyArg_ParseTuple(args, "Iis#", &vaddr, &pid, &buf, &count)) {
+    if (!PyArg_ParseTuple(args, "Kis#", &vaddr, &pid, &buf, &count)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1012,7 +1012,7 @@ pyvmi_write_8_pa(
     addr_t paddr;
     uint8_t value;
 
-    if (!PyArg_ParseTuple(args, "Ic", &paddr, &value)) {
+    if (!PyArg_ParseTuple(args, "Kc", &paddr, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1035,7 +1035,7 @@ pyvmi_write_16_pa(
     addr_t paddr;
     uint16_t value;
 
-    if (!PyArg_ParseTuple(args, "IH", &paddr, &value)) {
+    if (!PyArg_ParseTuple(args, "KH", &paddr, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1058,7 +1058,7 @@ pyvmi_write_32_pa(
     addr_t paddr;
     uint32_t value;
 
-    if (!PyArg_ParseTuple(args, "II", &paddr, &value)) {
+    if (!PyArg_ParseTuple(args, "KI", &paddr, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1081,7 +1081,7 @@ pyvmi_write_64_pa(
     addr_t paddr;
     uint64_t value;
 
-    if (!PyArg_ParseTuple(args, "IK", &paddr, &value)) {
+    if (!PyArg_ParseTuple(args, "KK", &paddr, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1105,7 +1105,7 @@ pyvmi_write_8_va(
     int pid;
     uint8_t value;
 
-    if (!PyArg_ParseTuple(args, "Iic", &vaddr, &pid, &value)) {
+    if (!PyArg_ParseTuple(args, "Kic", &vaddr, &pid, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1129,7 +1129,7 @@ pyvmi_write_16_va(
     int pid;
     uint16_t value;
 
-    if (!PyArg_ParseTuple(args, "IiH", &vaddr, &pid, &value)) {
+    if (!PyArg_ParseTuple(args, "KiH", &vaddr, &pid, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1153,7 +1153,7 @@ pyvmi_write_32_va(
     int pid;
     uint32_t value;
 
-    if (!PyArg_ParseTuple(args, "IiI", &vaddr, &pid, &value)) {
+    if (!PyArg_ParseTuple(args, "KiI", &vaddr, &pid, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1177,7 +1177,7 @@ pyvmi_write_64_va(
     int pid;
     uint64_t value;
 
-    if (!PyArg_ParseTuple(args, "IiK", &vaddr, &pid, &value)) {
+    if (!PyArg_ParseTuple(args, "KiK", &vaddr, &pid, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;


### PR DESCRIPTION
Ref the "Unable to write memory at specified address" exception:  I think the likely cause of the error was a 64-bit vaddr/paddr being crammed into a unsigned int by PyArg_ParseTuple.  This fix replaces the PyArg_ParseTuple "I" format string (unsigned int) with "K" (unsigned PY_LONG_LONG) to use with memory addresses.  I used "K" for consistency because other functions in pyvmi.c use this type for the same purpose (see pyvmi_read_va for example).  