### PR TITLE
Ensure safety of vmi_clear_event when issued from event callbacks

### DIFF
--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -83,7 +83,7 @@ event_response_t msr_syscall_sysenter_cb(vmi_instance_t vmi, vmi_event_t *event)
 
     print_event(*event);
 
-    vmi_clear_event(vmi, &msr_syscall_sysenter_event);
+    vmi_clear_event(vmi, &msr_syscall_sysenter_event, NULL);
     return 0;
 }
 
@@ -96,7 +96,7 @@ event_response_t syscall_compat_cb(vmi_instance_t vmi, vmi_event_t *event){
 
     print_event(*event);
 
-    vmi_clear_event(vmi, &msr_syscall_compat_event);
+    vmi_clear_event(vmi, &msr_syscall_compat_event, NULL);
     return 0;
 }
 
@@ -109,7 +109,7 @@ event_response_t vsyscall_cb(vmi_instance_t vmi, vmi_event_t *event){
 
     print_event(*event);
 
-    vmi_clear_event(vmi, &kernel_vsyscall_event);
+    vmi_clear_event(vmi, &kernel_vsyscall_event, NULL);
     return 0;
 }
 
@@ -122,7 +122,7 @@ event_response_t ia32_sysenter_target_cb(vmi_instance_t vmi, vmi_event_t *event)
 
     print_event(*event);
 
-    vmi_clear_event(vmi, &kernel_sysenter_target_event);
+    vmi_clear_event(vmi, &kernel_sysenter_target_event, NULL);
     return 0;
 }
 
@@ -135,7 +135,7 @@ event_response_t syscall_lm_cb(vmi_instance_t vmi, vmi_event_t *event){
 
     print_event(*event);
 
-    vmi_clear_event(vmi, &msr_syscall_lm_event);
+    vmi_clear_event(vmi, &msr_syscall_lm_event, NULL);
     return 0;
 }
 
@@ -163,7 +163,7 @@ event_response_t cr3_one_task_callback(vmi_instance_t vmi, vmi_event_t *event){
     }
     else{
         printf("PID %i is executing, not my process!\n", pid);
-        vmi_clear_event(vmi, &msr_syscall_sysenter_event);
+        vmi_clear_event(vmi, &msr_syscall_sysenter_event, NULL);
     }
     return 0;
 }
@@ -178,7 +178,7 @@ event_response_t cr3_all_tasks_callback(vmi_instance_t vmi, vmi_event_t *event){
 
     if(vmi_register_event(vmi, &msr_syscall_sysenter_event) == VMI_FAILURE)
         fprintf(stderr, "Could not install sysenter syscall handler.\n");
-    vmi_clear_event(vmi, &msr_syscall_sysenter_event);
+    vmi_clear_event(vmi, &msr_syscall_sysenter_event, NULL);
     return 0;
 }
 

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -78,11 +78,11 @@ event_response_t mm_callback(vmi_instance_t vmi, vmi_event_t *event) {
 
     if( current_pid == pid && event->mem_event.gla == rip) {
         printf("\tCought the original RIP executing again!");
-        vmi_clear_event(vmi, event);
+        vmi_clear_event(vmi, event, NULL);
         interrupted = 1;
     } else {
         printf("\tEvent on same page, but not the same RIP");
-        vmi_clear_event(vmi, event);
+        vmi_clear_event(vmi, event, NULL);
 
         /* These two calls are equivalent */
         //vmi_step_event(vmi, event, event->vcpu_id, 1, NULL);
@@ -107,7 +107,7 @@ event_response_t cr3_callback(vmi_instance_t vmi, vmi_event_t *event){
         if(mm_enabled) {
             mm_enabled = 0;
             printf(" -- Disabling mem-event\n");
-            vmi_clear_event(vmi, &mm_event);
+            vmi_clear_event(vmi, &mm_event, NULL);
         }
     }
     return 0;

--- a/libvmi/driver/xen/xen_events_legacy.c
+++ b/libvmi/driver/xen/xen_events_legacy.c
@@ -411,10 +411,10 @@ status_t process_unhandled_mem(vmi_instance_t vmi, memevent_page_t *page,
     // Queue each VMI_MEMEVENT_BYTE
     if (page->byte_events)
     {
-        event_iter_t i;
+        GHashTableIter i;
         addr_t *pa;
         vmi_event_t *loop;
-        for_each_event(vmi, i, page->byte_events, &pa, &loop)
+        ghashtable_foreach(page->byte_events, i, &pa, &loop)
         {
             vmi_step_event(vmi, loop, req->vcpu_id, 1, NULL);
         }

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -497,11 +497,13 @@ status_t vmi_register_event(
  *
  * @param[in] vmi LibVMI instance
  * @param[in] event Definition of event to clear
+ * @param[in] free_routine Function to call when it is safe to free event.
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t vmi_clear_event(
     vmi_instance_t vmi,
-    vmi_event_t *event);
+    vmi_event_t *event,
+    void (*free_routine)(vmi_event_t *event));
 
 /**
  * Return the pointer to the vmi_event_t if one is set on the given register.

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -148,6 +148,10 @@ struct vmi_instance {
     uint32_t step_vcpus[MAX_SINGLESTEP_VCPUS]; /**< counter of events on vcpus for which we have internal singlestep enabled */
 
     gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
+
+    gboolean event_callback; /**< flag indicating that libvmi is currently issuing an event callback */
+
+    GHashTable *clear_events; /**< table to save vmi_clear_event requests when event_callback is set */
 };
 
 /** Page-level memevent struct to also hold byte-level events in the embedded hashtable */
@@ -388,8 +392,7 @@ status_t vmi_pagetable_lookup_cache(
         gpointer key,
         gpointer value,
         gpointer data);
-    typedef GHashTableIter event_iter_t;
-    #define for_each_event(vmi, iter, table, key, val) \
+    #define ghashtable_foreach(table, iter, key, val) \
         g_hash_table_iter_init(&iter, table); \
         while(g_hash_table_iter_next(&iter,(void**)key,(void**)val))
 


### PR DESCRIPTION
When we are monitoring a VM with multiple vCPUs there could be multiple requests triggered by an event on the ringpage already. When the handler issues a vmi_clear_event in the callback of the first request, the second request will be left without a handler and LibVMI will shutdown as it doesn't know what to do. With this PR we queue all vmi_clear_event requests that happen in event callbacks so that the driver can safely process them when it can ensure that no more requests are left on the ring. This can only be done by pausing all vCPUs, processing any leftover requests that may have been placed there since last time we checked, then removing each event that was queued. 