### PR TITLE
Enabled tinyints as input to pyvmi write_8_* functions

### DIFF
--- a/tools/pyvmi/pyvmi.c
+++ b/tools/pyvmi/pyvmi.c
@@ -1012,7 +1012,9 @@ pyvmi_write_8_pa(
     addr_t paddr;
     uint8_t value;
 
-    if (!PyArg_ParseTuple(args, "Kc", &paddr, &value)) {
+    if (!PyArg_ParseTuple(args, "Kc", &paddr, &value) &&
+        !PyArg_ParseTuple(args, "KB", &paddr, &value)
+    ) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1105,7 +1107,8 @@ pyvmi_write_8_va(
     int pid;
     uint8_t value;
 
-    if (!PyArg_ParseTuple(args, "Kic", &vaddr, &pid, &value)) {
+    if (!PyArg_ParseTuple(args, "Kic", &vaddr, &pid, &value) &&
+        !PyArg_ParseTuple(args, "KiB", &vaddr, &pid, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;
@@ -1200,7 +1203,8 @@ pyvmi_write_8_ksym(
     char *sym;
     uint8_t value;
 
-    if (!PyArg_ParseTuple(args, "sc", &sym, &value)) {
+    if (!PyArg_ParseTuple(args, "sc", &sym, &value) &&
+        !PyArg_ParseTuple(args, "sB", &sym, &value)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid argument(s) to function");
         return NULL;


### PR DESCRIPTION
Ref Bryan's mailing list post on 12/08/15:
Question: The va, pa, and ksym 8-bit write functions accept single characters, should they also accept 8-bit integers?
Bryan: Yes, they should take 8-bit integers.

This patch adds a second PyArg_ParseTuple function call inside pyvmi.c "write_8_*" functions.  The second PyArg_ParseTuple tries to format the incoming value as a tinyint, and only executes if the first (existing) call fails to successfully extract a character.

See attached for before and after behavior.

[write_8_testing.py.txt](https://github.com/libvmi/libvmi/files/68657/write_8_testing.py.txt)