### PR TITLE
Fixes event support for Xen 4.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,7 +287,7 @@ xen_event_space=' '
                         AC_DEFINE([XEN_EVENTS_VERSION], [410], [Define the xen events version.])
                         AC_MSG_NOTICE([4.1 style events enabled.])
                     [else]
-                        [if test "$have_xc_mem_access_enable" = "yes"]
+                        [if test "$have_xc_mem_event_enable" = "yes"]
                         [then]
                             [if test "$have_hvmmem_access_t" = "yes"]
                             [then]


### PR DESCRIPTION
When using Xen 4.5, compiling LibVMI with event support is not possible (./configure --enable-xen-events=yes refuses to enable events and yields "missing event support") due to a minor mixup in the configure.ac file.

To test: after making this change to configure.ac and building as usual, libvmi/examples/event-example works as expected on Xen 4.5.  I haven't tested this on other Xen versions.