### PR TITLE
Allow using Rekall profiles for Linux guests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,7 @@ update is made to the kernel, the profile has to be re-generated, thus it's a bi
 as the standard LibVMI configuration entries which are generally stable for specific releases
 of Windows.
 
-Rekall is available at https://code.google.com/p/rekall
+Rekall is available at https://github.com/google/rekall. You will also need to install libjson-c-dev from your distribution's repository or compile it from source that can be found at https://github.com/json-c/json-c.
 
 To create a Rekall profile for Windows you need to determine the PDB filename and GUID of the
 kernel. This can be done either by running the win-guid example shipped with LibVMI, or by
@@ -236,11 +236,10 @@ Once the PDB filename and GUID is known, creating the Rekall profile is done in 
 
 .. code::
 
-    rekall fetch_pdb -f <PDB filename> --guid <GUID> -D .
-    rekall parse_pdb -f <PDB filename> --output <GUID>
+    rekall fetch_pdb --pdb_filename <PDB filename> --guid <GUID> -D .
+    rekall parse_pdb <PDB filename> > rekall-profile.json
 
-The Rekall profile can be used directly in the LibVMI config via the sysmap entry, without having
-to specify any of the offsets normally required for Windows as those offsets will be available
+The Rekall profile can be used directly in the LibVMI config via an additional rekall_profile entry pointing to this file with an absolute path. There is no need to specify any of the offsets normally required as those offsets will be available
 via the profile itself.
 
 Building

--- a/configure.ac
+++ b/configure.ac
@@ -438,18 +438,19 @@ AC_CHECK_PROGS(LEX, lex flex , [no], [path = $PATH])
 [fi]
 AC_PROG_LEX
 
-have_jansson='no'
-PKG_CHECK_MODULES([JANSSON], [jansson >= 2.1], [missing="no"], [missing="yes"])
+have_jsonc='no'
+missing='no'
+AC_CHECK_LIB(json-c, json_object_get_int64,, [missing="yes"])
 [if test x"$missing" = "xno"]
 [then]
-        have_jansson='yes'
-        AC_SUBST([JANSSON_LIBS])
-        AC_SUBST([JANSSON_CFLAGS])
-        AC_DEFINE([REKALL_PROFILES], [1], [Defined to 1 when working Jansson library was found to parse Rekall profiles.])
+        AC_CHECK_HEADERS([json-c/json.h])
+        have_jsonc='yes'
+        AC_DEFINE([REKALL_PROFILES], [1], [Defined to 1 when working JSON-C library was found to parse Rekall profiles.])
 [else]
-    have_jansson='Disabled, missing libjansson-dev.'
-    [echo "No working Jansson library found (libjansson-dev), Rekall system profiles won't be supported."]
+    have_jsonc='Disabled, missing libjson-c-dev.'
+    [echo "No working JSON-C library found (libjson-c-dev), Rekall system profiles won't be supported."]
 [fi]
+AM_CONDITIONAL([REKALL_PROFILES], [test x"$have_jsonc" = "xyes"])
 
 [if test "$enable_address_cache" = "yes"]
 [then]
@@ -524,7 +525,7 @@ VMIFS        | --enable-vmifs=$enable_vmifs$vmifs_space  | $have_vmifs
 
 Extra features
 ----------------------------------------------------------------------
-Support of Rekall profiles: $have_jansson
+Support of Rekall profiles: $have_jsonc
  
 If everything is correct, you can now run 'make' and (optionally)
 'make install'.  Otherwise, you can run './configure' again.

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -8,6 +8,7 @@ h_private = \
     private.h \
     debug.h \
     glib_compat.h \
+    rekall.h \
     arch/arch_interface.h \
     arch/intel.h \
     arch/amd64.h \
@@ -36,6 +37,10 @@ c_sources = \
     driver/driver_interface.c \
     driver/memory_cache.c \
     os/os_interface.c
+
+if REKALL_PROFILES
+c_sources  += rekall.c
+endif
 
 if SHM
 h_public    += shm.h
@@ -83,7 +88,6 @@ os          += os/windows/windows.h \
                os/windows/core.c \
                os/windows/kdbg.c \
                os/windows/memory.c \
-               os/windows/symbols.c \
                os/windows/peparse.c \
                os/windows/process.c \
                os/windows/unicode.c
@@ -104,5 +108,5 @@ AM_CPPFLAGS = -I$(top_srcdir)
 lib_LTLIBRARIES= libvmi.la
 libvmi_la_SOURCES= $(h_public) $(h_private) $(drivers) $(os) $(c_sources)
 libvmi_la_LIBADD= config/libconfig.la
-libvmi_la_CFLAGS= -fvisibility=hidden $(GLIB_CFLAGS) $(JANSSON_CFLAGS)
-libvmi_la_LDFLAGS= -release $(RELEASE) $(GLIB_LIBS) $(JANSSON_LIBS)
+libvmi_la_CFLAGS= -fvisibility=hidden $(GLIB_CFLAGS)
+libvmi_la_LDFLAGS= -release $(RELEASE) $(GLIB_LIBS)

--- a/libvmi/config/grammar.y
+++ b/libvmi/config/grammar.y
@@ -284,6 +284,7 @@ int vmi_parse_config (const char *target_name)
 %token<str>    WIN_KPCR
 %token<str>    WIN_SYSPROC
 %token<str>    SYSMAPTOK
+%token<str>    REKALL_PROFILE
 %token<str>    OSTYPETOK
 %token<str>    WORD
 %token<str>    FILENAME
@@ -317,6 +318,8 @@ assignments:
 assignment:
         |
         sysmap_assignment
+        |
+        rekall_profile_assignment
         |
         ostype_assignment
         |
@@ -518,6 +521,16 @@ sysmap_assignment:
             snprintf(tmp_str, CONFIG_STR_LENGTH, "%s", $4);
             char* sysmap_path = strndup(tmp_str, CONFIG_STR_LENGTH);
             g_hash_table_insert(tmp_entry, $1, sysmap_path);
+            free($4);
+        }
+        ;
+
+rekall_profile_assignment:
+        REKALL_PROFILE EQUALS QUOTE FILENAME QUOTE
+        {
+            snprintf(tmp_str, CONFIG_STR_LENGTH, "%s", $4);
+            char* rekall_profile = strndup(tmp_str, CONFIG_STR_LENGTH);
+            g_hash_table_insert(tmp_entry, $1, rekall_profile);
             free($4);
         }
         ;

--- a/libvmi/config/lexicon.l
+++ b/libvmi/config/lexicon.l
@@ -58,6 +58,7 @@ win_kdbg                { BeginToken(yytext); yylval.str = strndup(yytext, CONFI
 win_kpcr                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KPCR; }
 win_sysproc             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_SYSPROC; }
 sysmap                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return SYSMAPTOK; }
+rekall_profile          { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return REKALL_PROFILE; }
 ostype                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return OSTYPETOK; }
 0x[0-9a-fA-F]+|[0-9]+   {
     BeginToken(yytext);

--- a/libvmi/os/linux/linux.h
+++ b/libvmi/os/linux/linux.h
@@ -23,7 +23,9 @@
 #include "private.h"
 
 struct linux_instance {
-    char *sysmap;           /**< system map file for domain's running kernel */
+    char *sysmap; /**< system map file for domain's running kernel */
+
+    char *rekall_profile; /**< Rekall profile for domain's running kernel */
 
     addr_t tasks_offset; /**< task_struct->tasks */
 
@@ -41,8 +43,8 @@ status_t linux_init(vmi_instance_t instance);
 
 uint64_t linux_get_offset(vmi_instance_t vmi, const char* offset_name);
 
-status_t linux_system_map_symbol_to_address(vmi_instance_t instance,
-        const char *symbol, addr_t *kernel_base_vaddr, addr_t *address);
+status_t linux_symbol_to_address(vmi_instance_t instance,
+        const char *symbol, addr_t *__unused, addr_t *address);
 
 char* linux_system_map_address_to_symbol(vmi_instance_t vmi, 
         addr_t address, addr_t base_vaddr, vmi_pid_t pid);

--- a/libvmi/os/windows/memory.c
+++ b/libvmi/os/windows/memory.c
@@ -45,10 +45,10 @@ windows_kernel_symbol_to_address(
 
     dbprint(VMI_DEBUG_MISC, "--windows symbol lookup (%s)\n", symbol);
 
-    if (windows->sysmap) {
-        dbprint(VMI_DEBUG_MISC, "--trying kernel sysmap\n");
+    if (windows->rekall_profile) {
+        dbprint(VMI_DEBUG_MISC, "--trying Rekall profile\n");
 
-        if (VMI_SUCCESS == windows_system_map_symbol_to_address(vmi, symbol, NULL, &rva)) {
+        if (VMI_SUCCESS == rekall_profile_symbol_to_rva(windows->rekall_profile, symbol, NULL, &rva)) {
             *address = windows->ntoskrnl_va + rva;
             dbprint(VMI_DEBUG_MISC, "--got symbol from kernel sysmap (%s --> 0x%.16"PRIx64").\n",
                  symbol, *address);

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -250,8 +250,8 @@ windows_find_eprocess(
     }
 
     if (!windows->pname_offset) {
-        if(windows->sysmap) {
-            windows_system_map_symbol_to_address(vmi, "_EPROCESS", "ImageFileName", &windows->pname_offset);
+        if(windows->rekall_profile) {
+            rekall_profile_symbol_to_rva(windows->rekall_profile, "_EPROCESS", "ImageFileName", &windows->pname_offset);
         } else {
             windows->pname_offset = find_pname_offset(vmi, check);
         }

--- a/libvmi/os/windows/symbols.c
+++ b/libvmi/os/windows/symbols.c
@@ -30,11 +30,11 @@
 #include <jansson.h>
 
 status_t
-windows_system_map_symbol_to_address(
+windows_rekall_profile_symbol_to_rva(
     vmi_instance_t vmi,
     const char *symbol,
     const char *subsymbol,
-    addr_t *address)
+    addr_t *rva)
 {
 
     status_t ret = VMI_FAILURE;
@@ -44,7 +44,7 @@ windows_system_map_symbol_to_address(
     }
 
     json_error_t error;
-    json_t *root = json_load_file(windows->sysmap, 0, &error);
+    json_t *root = json_load_file(windows->rekall_profile, 0, &error);
     if(!root)
     {
         errprint("Rekall profile error on line %d: %s\n", error.line, error.text);
@@ -65,7 +65,7 @@ windows_system_map_symbol_to_address(
             goto err_exit;
         }
 
-        *address = json_integer_value(jsymbol);
+        *rva = json_integer_value(jsymbol);
         ret = VMI_SUCCESS;
 
     } else {
@@ -84,7 +84,7 @@ windows_system_map_symbol_to_address(
         }
         json_t *jvalue = json_array_get(jmember, 0);
 
-        *address = json_integer_value(jvalue);
+        *rva = json_integer_value(jvalue);
         ret = VMI_SUCCESS;
 
     }
@@ -99,11 +99,11 @@ exit:
 #else
 
 status_t
-windows_system_map_symbol_to_address(
+windows_rekall_profile_symbol_to_rva(
     vmi_instance_t vmi,
     const char *symbol,
     const char *subsymbol,
-    addr_t *address)
+    addr_t *rva)
 {
     return VMI_FAILURE;
 }

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -47,7 +47,7 @@ struct windows_instance {
 
     win_ver_t version; /**< version of Windows */
 
-    char *sysmap;           /**< system map file for domain's running kernel */
+    char *rekall_profile; /**< Rekall profile path for domain's running kernel */
 };
 typedef struct windows_instance *windows_instance_t;
 
@@ -67,12 +67,6 @@ windows_rva_to_export(vmi_instance_t vmi, addr_t rva, addr_t base_vaddr,
         vmi_pid_t pid);
 
 status_t windows_teardown(vmi_instance_t vmi);
-
-status_t windows_system_map_symbol_to_address(
-    vmi_instance_t vmi,
-    const char *symbol,
-    const char *subsymbol,
-    addr_t *address);
 
 typedef int (*check_magic_func)(uint32_t);
 int find_pname_offset(vmi_instance_t vmi, check_magic_func check);

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -44,10 +44,11 @@
 #include "libvmi_extra.h"
 #include "events.h"
 #include "shm.h"
+#include "rekall.h"
+#include "debug.h"
 #include "driver/driver_interface.h"
 #include "arch/arch_interface.h"
 #include "os/os_interface.h"
-#include "debug.h"
 
 /**
  * @brief LibVMI Instance.
@@ -193,7 +194,7 @@ typedef struct _windows_unicode_string32 {
  * Misc functions
  */
 static inline
-canonical_addr(addr_t va) {
+addr_t canonical_addr(addr_t va) {
     return VMI_GET_BIT(va, 47) ? (va | 0xffff000000000000) : va;
 }
 

--- a/libvmi/rekall.c
+++ b/libvmi/rekall.c
@@ -1,0 +1,115 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel (tamas@tklengyel.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "private.h"
+#include <stdio.h>
+#include <json-c/json.h>
+
+status_t
+rekall_profile_symbol_to_rva(
+    const char *rekall_profile,
+    const char *symbol,
+    const char *subsymbol,
+    addr_t *rva)
+{
+    status_t ret = VMI_FAILURE;
+    addr_t mask = 0;
+    if(!rekall_profile || !symbol) {
+        return ret;
+    }
+
+    json_object *root = json_object_from_file(rekall_profile);
+    if(!root) {
+        errprint("Rekall profile couldn't be opened!\n");
+        return ret;
+    }
+
+    if(!subsymbol) {
+        json_object *constants = NULL, *jsymbol = NULL;
+        if (!json_object_object_get_ex(root, "$CONSTANTS", &constants)) {
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: no $CONSTANTS section found\n", symbol);
+            goto exit;
+        }
+
+        if (!json_object_object_get_ex(constants, symbol, &jsymbol)){
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: symbol '%s' not found\n", symbol);
+            json_object_put(constants);
+            goto exit;
+        }
+
+        *rva = json_object_get_int64(jsymbol);
+
+        ret = VMI_SUCCESS;
+
+        json_object_put(jsymbol);
+        json_object_put(constants);
+    } else {
+        json_object *structs = NULL, *jstruct = NULL, *jstruct2 = NULL, *jmember = NULL, *jvalue = NULL;
+        if (!json_object_object_get_ex(root, "$STRUCTS", &structs)) {
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: no $STRUCTS section found\n", symbol);
+            goto exit;
+        }
+        if (!json_object_object_get_ex(structs, symbol, &jstruct)) {
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: no %s found\n", symbol);
+            json_object_put(structs);
+            goto exit;
+        }
+
+        jstruct2 = json_object_array_get_idx(jstruct, 1);
+        if (!jstruct2) {
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: struct %s has no second element\n", symbol);
+            json_object_put(jstruct);
+            json_object_put(structs);
+            goto exit;
+        }
+
+        if (!json_object_object_get_ex(jstruct2, subsymbol, &jmember)) {
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: %s has no %s member\n", symbol, subsymbol);
+            json_object_put(jstruct2);
+            json_object_put(jstruct);
+            json_object_put(structs);
+            goto exit;
+        }
+
+        jvalue = json_object_array_get_idx(jmember, 0);
+        if (!jvalue) {
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: %s.%s has no RVA defined\n", symbol, subsymbol);
+            json_object_put(jmember);
+            json_object_put(jstruct2);
+            json_object_put(jstruct);
+            json_object_put(structs);
+            goto exit;
+        }
+
+        *rva = json_object_get_int64(jvalue);
+        ret = VMI_SUCCESS;
+
+        json_object_put(jmember);
+        json_object_put(jstruct2);
+        json_object_put(jstruct);
+        json_object_put(structs);
+    }
+
+exit:
+    json_object_put(root);
+    return ret;
+}

--- a/libvmi/rekall.h
+++ b/libvmi/rekall.h
@@ -1,0 +1,47 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBVMI_REKALL_H
+#define LIBVMI_REKALL_H
+
+#ifdef REKALL_PROFILES
+
+status_t
+rekall_profile_symbol_to_rva(
+    const char *rekall_profile,
+    const char *symbol,
+    const char *subsymbol,
+    addr_t *rva);
+
+#else
+
+static inline status_t
+rekall_profile_symbol_to_rva(
+    const char *rekall_profile,
+    const char *symbol,
+    const char *subsymbol,
+    addr_t *rva)
+{
+    return VMI_FAILURE;
+}
+
+#endif
+
+#endif /* LIBVMI_REKALL_H */


### PR DESCRIPTION
In this patch we move the Rekall profile component from the Windows driver to common and convert the JSON parsing from JANSSON to JSON-C, as JANSSON is unable to handle large VAs stored in the Linux profile. The Rekall profile for Linux needs to be generated with Rekall after patch 7668d50b129b4cc38048819e38ee0b0cee794f75 (https://github.com/google/rekall/pull/113).