### PR TITLE
Added vmi_get_linux_sysmap function

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -474,8 +474,9 @@ vmi_get_linux_sysmap(
 {
     linux_instance_t linux_instance = NULL;
 
-    if(VMI_OS_LINUX != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode))
+    if(VMI_OS_LINUX != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode)){
 	return NULL;
+    }
 
     if(!vmi->os_data){
 	return NULL;

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -467,3 +467,22 @@ addr_t vmi_translate_uv2p (vmi_instance_t vmi, addr_t virt_address, vmi_pid_t pi
     }
     return paddr;
 }
+
+const char *
+vmi_get_linux_sysmap(
+	vmi_instance_t vmi)
+{
+    linux_instance_t linux_instance = NULL;
+
+    if(VMI_OS_LINUX != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode))
+	return NULL;
+
+    if(!vmi->os_data){
+	return NULL;
+    }
+
+    linux_instance = vmi->os_data;
+
+    return linux_instance->sysmap;
+
+}

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1819,6 +1819,14 @@ void vmi_pidcache_add(
     vmi_pid_t pid,
     addr_t dtb);
 
+/**
+ * Returns the path of the Linux system map file for the given vmi instance
+ *
+ * @param[in] vmi LibVMI instance
+ * @return String file path location of the Linux system map
+ */
+const char * vmi_get_linux_sysmap(vmi_instance_t vmi);
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus


### PR DESCRIPTION
the new accessor function will return the value that a particular linux vmi instance has for the location of the system map file or NULL if otherwise. This should require the libvmi public api reference site to be updated as well as it is a new addition