### PR TITLE
Don't redefine xc_domain_maximum_gpfn

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,7 @@ xen_event_space=' '
         enable_xen='no'
         have_xen='missing xenstore'
     [else]
+        AC_CHECK_LIB(xenctrl, xc_domain_maximum_gpfn, [AC_DEFINE([HAVE_XC_DOMAIN_MAXIMUM_GPFN],[1],"xenctrl has xc_domain_maximum_gpfn")],[missing="no"])
         AC_CHECK_LIB(xenctrl, xc_interface_open, [], [missing="yes"])
         [if test "$missing" = "yes"]
         [then]

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -54,10 +54,12 @@
 
 #define xen_pfn_to_cr3_x86_32(pfn) (((unsigned)(pfn) << 12) | ((unsigned)(pfn) >> 20))
 #define xen_cr3_to_pfn_x86_32(cr3) (((unsigned)(cr3) >> 12) | ((unsigned)(cr3) << 20))
+#endif /* xen_cr3_to_pfn_x86_32 */
 
+#ifndef HAVE_XC_DOMAIN_MAXIMUM_GPFN
 #include <xen/memory.h>
 #define xc_domain_maximum_gpfn(xch, domid) xc_memory_op(xch, XENMEM_maximum_gpfn, &domid)
-#endif /* xen_cr3_to_pfn_x86_32 */
+#endif
 
 #ifdef XENCTRL_HAS_XC_INTERFACE // Xen >= 4.1
 typedef xc_interface *libvmi_xenctrl_handle_t;


### PR DESCRIPTION
On Xen 4.6 ARM builds we end up erroneously defining our own xc_domain_maximum_gpfn because the xen_cr3_to_pfn_x86_32 guard is not present and __XEN_INTERFACE_VERSION__ is >= 40600.

Thanks to @kittel for the bug-report.