### PR TITLE
access_context_t work

### DIFF
--- a/examples/win-guid.c
+++ b/examples/win-guid.c
@@ -287,17 +287,21 @@ int main(int argc, char **argv) {
     /* the nice thing about the windows kernel is that it's page aligned */
     uint32_t i;
     uint32_t found = 0;
-    for(i = 0; i < MAX_SEARCH_SIZE; i += PAGE_SIZE) {
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_NONE,
+    };
+
+    for(ctx.addr = 0; ctx.addr < MAX_SEARCH_SIZE; ctx.addr += PAGE_SIZE) {
 
         uint8_t pe[MAX_HEADER_SIZE];
 
-        if(VMI_SUCCESS == peparse_get_image_phys(vmi, i, MAX_HEADER_SIZE, pe)) {
-            if(VMI_SUCCESS == is_WINDOWS_KERNEL(vmi, i, pe)) {
+        if(VMI_SUCCESS == peparse_get_image(vmi, &ctx, MAX_HEADER_SIZE, pe)) {
+            if(VMI_SUCCESS == is_WINDOWS_KERNEL(vmi, ctx.addr, pe)) {
 
-                printf("Windows Kernel found @ 0x%"PRIx32"\n", i);
-                print_os_version(vmi, i, pe);
-                print_guid(vmi, i, pe);
-                print_pe_header(vmi, i, pe);
+                printf("Windows Kernel found @ 0x%"PRIx32"\n", ctx.addr);
+                print_os_version(vmi, ctx.addr, pe);
+                print_guid(vmi, ctx.addr, pe);
+                print_pe_header(vmi, ctx.addr, pe);
                 found=1;
                 break;
             }

--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -383,7 +383,7 @@ status_t
 rva_cache_get(
     vmi_instance_t vmi,
     addr_t base_addr,
-    vmi_pid_t pid,
+    addr_t dtb,
     addr_t rva,
     char **sym)
 {
@@ -394,7 +394,7 @@ rva_cache_get(
 
     struct key_128 local_key;
     key_128_t key = &local_key;
-    key_128_init(vmi, key, (uint64_t)base_addr, (uint64_t)pid);
+    key_128_init(vmi, key, (uint64_t)base_addr, (uint64_t)dtb);
 
     if ((rva_table = g_hash_table_lookup(vmi->rva_cache, key)) == NULL) {
         return ret;
@@ -403,7 +403,8 @@ rva_cache_get(
     if ((entry = g_hash_table_lookup(rva_table, GUINT_TO_POINTER(rva))) != NULL) {
         entry->last_used = time(NULL);
         *sym = entry->sym;
-        dbprint(VMI_DEBUG_RVACACHE, "--RVA cache hit %u:0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n", pid, base_addr, *sym, rva);
+        dbprint(VMI_DEBUG_RVACACHE, "--RVA cache hit 0x%.16%"PRIx64":0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n",
+                dtb, base_addr, *sym, rva);
         ret=VMI_SUCCESS;
     }
 
@@ -414,14 +415,14 @@ void
 rva_cache_set(
     vmi_instance_t vmi,
     addr_t base_addr,
-    vmi_pid_t pid,
+    addr_t dtb,
     addr_t rva,
     char *sym)
 {
     GHashTable *rva_table = NULL;
-    sym_cache_entry_t entry = sym_cache_entry_create(sym, rva, base_addr, pid);
+    sym_cache_entry_t entry = sym_cache_entry_create(sym, rva, base_addr, dtb);
 
-    key_128_t key = key_128_build(vmi, (uint64_t)base_addr, (uint64_t)pid);
+    key_128_t key = key_128_build(vmi, (uint64_t)base_addr, (uint64_t)dtb);
 
     if ((rva_table = g_hash_table_lookup(vmi->rva_cache, key)) == NULL) {
         rva_table = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL,
@@ -439,21 +440,21 @@ status_t
 rva_cache_del(
     vmi_instance_t vmi,
     addr_t base_addr,
-    vmi_pid_t pid,
+    addr_t dtb,
     addr_t rva)
 {
     status_t ret=VMI_FAILURE;
     GHashTable *rva_table=NULL;
     struct key_128 local_key;
     key_128_t key = &local_key;
-    key_128_init(vmi, key, (uint64_t)base_addr, (uint64_t)pid);
+    key_128_init(vmi, key, (uint64_t)base_addr, (uint64_t)dtb);
 
     if ((rva_table = g_hash_table_lookup(vmi->rva_cache, key)) == NULL) {
         return ret;
     }
 
-    dbprint(VMI_DEBUG_RVACACHE, "--RVA cache del %u:0x%.16"PRIx64":0x%.16"PRIx64"\n",
-            pid, base_addr, rva);
+    dbprint(VMI_DEBUG_RVACACHE, "--RVA cache del 0x%.16"PRIx64":0x%.16"PRIx64":0x%.16"PRIx64"\n",
+            dtb, base_addr, rva);
 
     if (TRUE == g_hash_table_remove(rva_table, GUINT_TO_POINTER(rva))) {
         ret=VMI_SUCCESS;
@@ -808,7 +809,7 @@ status_t
 rva_cache_get(
     vmi_instance_t vmi,
     addr_t base_addr,
-    vmi_pid_t pid,
+    addr_t dtb,
     addr_t rva,
     char **sym)
 {
@@ -819,7 +820,7 @@ void
 rva_cache_set(
     vmi_instance_t vmi,
     addr_t base_addr,
-    vmi_pid_t pid,
+    addr_t dtb,
     addr_t rva,
     char *sym)
 {
@@ -830,7 +831,7 @@ status_t
 rva_cache_del(
     vmi_instance_t vmi,
     addr_t base_addr,
-    vmi_pid_t pid,
+    addr_t dtb,
     addr_t rva)
 {
     return VMI_FAILURE;
@@ -912,7 +913,7 @@ status_t
 v2m_cache_get(
     vmi_instance_t vmi,
     addr_t va,
-    pid_t pid,
+    addr_t dtb,
     addr_t *ma,
     uint64_t *length)
 {
@@ -923,7 +924,7 @@ void
 v2m_cache_set(
     vmi_instance_t vmi,
     addr_t va,
-    pid_t pid,
+    addr_t dtb,
     addr_t ma,
     uint64_t length)
 {
@@ -934,7 +935,7 @@ status_t
 v2m_cache_del(
     vmi_instance_t vmi,
     addr_t va,
-    pid_t pid)
+    addr_t dtb)
 {
     return VMI_FAILURE;
 }

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -672,7 +672,7 @@ status_t vmi_pagetable_lookup_extended(
  */
 size_t vmi_read(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     void *buf,
     size_t count);
 
@@ -686,7 +686,7 @@ size_t vmi_read(
  */
 status_t vmi_read_8(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint8_t * value);
 
 /**
@@ -699,7 +699,7 @@ status_t vmi_read_8(
  */
 status_t vmi_read_16(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint16_t * value);
 
 /**
@@ -712,7 +712,7 @@ status_t vmi_read_16(
  */
 status_t vmi_read_32(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint32_t * value);
 
 /**
@@ -726,7 +726,7 @@ status_t vmi_read_32(
  */
 status_t vmi_read_64(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint64_t * value);
 
 /**
@@ -740,7 +740,7 @@ status_t vmi_read_64(
  */
 status_t vmi_read_addr(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     addr_t *value);
 
 /**
@@ -754,7 +754,7 @@ status_t vmi_read_addr(
  */
 char *vmi_read_str(
     vmi_instance_t vmi,
-    access_context_t *ctx);
+    const access_context_t *ctx);
 
 /**
  * Reads \a count bytes from memory located at the kernel symbol \a sym
@@ -1107,7 +1107,7 @@ char *vmi_read_str_pa(
  */
 size_t vmi_write(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     void *buf,
     size_t count);
 
@@ -1171,7 +1171,7 @@ size_t vmi_write_pa(
  */
 status_t vmi_write_8(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint8_t * value);
 
 /**
@@ -1184,7 +1184,7 @@ status_t vmi_write_8(
  */
 status_t vmi_write_16(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint16_t * value);
 
 /**
@@ -1197,7 +1197,7 @@ status_t vmi_write_16(
  */
 status_t vmi_write_32(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint32_t * value);
 
 /**
@@ -1210,7 +1210,7 @@ status_t vmi_write_32(
  */
 status_t vmi_write_64(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint64_t * value);
 
 /**
@@ -1224,7 +1224,7 @@ status_t vmi_write_64(
  */
 status_t vmi_write_addr(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     addr_t * value);
 
 /**

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -753,6 +753,20 @@ char *vmi_read_str(
     const access_context_t *ctx);
 
 /**
+ * Reads a Unicode string from the given address. If the guest is running
+ * Windows, a UNICODE_STRING struct is read. Linux is not yet
+ * supported. The returned value must be freed by the caller.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] ctx Access context
+ * @return String read from memory or NULL on error; this function
+ *         will set the encoding field.
+ */
+unicode_string_t *vmi_read_unicode_str(
+    vmi_instance_t vmi,
+    access_context_t *ctx);
+
+/**
  * Reads \a count bytes from memory located at the kernel symbol \a sym
  * and stores the output in \a buf.
  *

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -569,15 +569,13 @@ addr_t vmi_translate_ksym2v(
  * Linux is unimplemented at this time.
  *
  * @param[in] vmi LibVMI instance
- * @param[in] base_vaddr Base virtual address (beginning of PE header in Windows)
- * @param[in] pid PID
+ * @param[in] ctx Access context (beginning of PE header in Windows)
  * @param[in] symbol Desired symbol to translate
  * @return Virtual address, or zero on error
  */
 addr_t vmi_translate_sym2v(
     vmi_instance_t vmi,
-    addr_t base_vaddr,
-    vmi_pid_t pid,
+    const access_context_t *ctx,
     const char *symbol);
 
 /**
@@ -588,15 +586,13 @@ addr_t vmi_translate_sym2v(
  * ELF Headers are not supported.
  *
  * @param[in] vmi LibVMI instance
- * @param[in] base_vaddr Base virtual address (beginning of PE header in Windows)
- * @param[in] pid PID
+ * @param[in] ctx Access context (beginning of PE header in Windows)
  * @param[in] rva RVA to translate
  * @return Symbol, or NULL on error
  */
 const char* vmi_translate_v2sym(
     vmi_instance_t vmi,
-    addr_t base_vaddr,
-    vmi_pid_t pid,
+    const access_context_t *ctx,
     addr_t rva);
 
 /**

--- a/libvmi/os/linux/linux.h
+++ b/libvmi/os/linux/linux.h
@@ -46,8 +46,8 @@ uint64_t linux_get_offset(vmi_instance_t vmi, const char* offset_name);
 status_t linux_symbol_to_address(vmi_instance_t instance,
         const char *symbol, addr_t *__unused, addr_t *address);
 
-char* linux_system_map_address_to_symbol(vmi_instance_t vmi, 
-        addr_t address, addr_t base_vaddr, vmi_pid_t pid);
+char* linux_system_map_address_to_symbol(vmi_instance_t vmi,
+        addr_t address, const access_context_t *ctx);
 
 addr_t linux_pid_to_pgd(vmi_instance_t vmi, vmi_pid_t pid);
 

--- a/libvmi/os/os_interface.h
+++ b/libvmi/os/os_interface.h
@@ -42,7 +42,7 @@ typedef char* (*os_address_to_symbol_t)(vmi_instance_t vmi, addr_t address,
         const access_context_t *ctx);
 
 typedef unicode_string_t* (*os_read_unicode_struct_t)(vmi_instance_t vmi,
-        addr_t vaddr, vmi_pid_t pid);
+        const access_context_t *ctx);
 
 typedef status_t (*os_teardown_t)(vmi_instance_t vmi);
 

--- a/libvmi/os/os_interface.h
+++ b/libvmi/os/os_interface.h
@@ -36,10 +36,10 @@ typedef status_t (*os_kernel_symbol_to_address_t)(vmi_instance_t instance,
         const char *symbol, addr_t *kernel_base_vaddr, addr_t *address);
 
 typedef status_t (*os_user_symbol_to_rva_t)(vmi_instance_t instance,
-        addr_t base_vaddr, vmi_pid_t pid, const char *symbol, addr_t *rva);
+        const access_context_t *ctx, const char *symbol, addr_t *rva);
 
 typedef char* (*os_address_to_symbol_t)(vmi_instance_t vmi, addr_t address,
-        addr_t base_vaddr, vmi_pid_t pid);
+        const access_context_t *ctx);
 
 typedef unicode_string_t* (*os_read_unicode_struct_t)(vmi_instance_t vmi,
         addr_t vaddr, vmi_pid_t pid);

--- a/libvmi/os/windows/kdbg.c
+++ b/libvmi/os/windows/kdbg.c
@@ -962,14 +962,18 @@ find_kdbg_address_faster(
     // start searching at the lower part from the kpcr
     // then switch to the upper part if needed
     int step = -VMI_PS_4KB;
-    addr_t page_paddr = 0;
+    addr_t page_paddr;
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_NONE,
+    };
 
 scan:
     page_paddr = (vmi_pagetable_lookup(vmi, cr3, fsgs) >> 12) << 12;
     for(; page_paddr + step < vmi->max_physical_address; page_paddr += step) {
 
         uint8_t page[VMI_PS_4KB];
-        status_t rc = peparse_get_image_phys(vmi, page_paddr, VMI_PS_4KB, page);
+        ctx.addr = page_paddr;
+        status_t rc = peparse_get_image(vmi, &ctx, VMI_PS_4KB, page);
         if(VMI_FAILURE == rc) {
             continue;
         }

--- a/libvmi/os/windows/memory.c
+++ b/libvmi/os/windows/memory.c
@@ -69,7 +69,13 @@ windows_kernel_symbol_to_address(
     dbprint(VMI_DEBUG_MISC, "--trying kernel PE export table\n");
 
     /* check exports */
-    if (VMI_SUCCESS == windows_export_to_rva(vmi, windows->ntoskrnl_va, 0, symbol, &rva)) {
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_PROCESS_PID,
+        .addr = windows->ntoskrnl_va,
+        .pid = 0
+    };
+
+    if (VMI_SUCCESS == windows_export_to_rva(vmi, &ctx, symbol, &rva)) {
         *address = windows->ntoskrnl_va + rva;
         dbprint(VMI_DEBUG_MISC, "--got symbol from PE export table (%s --> 0x%.16"PRIx64").\n",
              symbol, *address);

--- a/libvmi/os/windows/unicode.c
+++ b/libvmi/os/windows/unicode.c
@@ -34,9 +34,9 @@
 unicode_string_t *
 windows_read_unicode_struct(
     vmi_instance_t vmi,
-    addr_t vaddr,
-    vmi_pid_t pid)
+    const access_context_t *ctx)
 {
+    access_context_t _ctx = *ctx;
     unicode_string_t *us = 0;   // return val
     size_t struct_size = 0;
     size_t read = 0;
@@ -47,7 +47,7 @@ windows_read_unicode_struct(
         win64_unicode_string_t us64 = { 0 };
         struct_size = sizeof(us64);
         // read the UNICODE_STRING struct
-        read = vmi_read_va(vmi, vaddr, pid, &us64, struct_size);
+        read = vmi_read(vmi, ctx, &us64, struct_size);
         if (read != struct_size) {
             dbprint(VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING\n",__FUNCTION__);
             goto out_error;
@@ -59,7 +59,7 @@ windows_read_unicode_struct(
         win32_unicode_string_t us32 = { 0 };
         struct_size = sizeof(us32);
         // read the UNICODE_STRING struct
-        read = vmi_read_va(vmi, vaddr, pid, &us32, struct_size);
+        read = vmi_read(vmi, ctx, &us32, struct_size);
         if (read != struct_size) {
             dbprint(VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING\n",__FUNCTION__);
             goto out_error;
@@ -74,7 +74,8 @@ windows_read_unicode_struct(
     us->length = buffer_len;
     us->contents = safe_malloc(sizeof(uint8_t) * (buffer_len + 2));
 
-    read = vmi_read_va(vmi, buffer_va, pid, us->contents, us->length);
+    _ctx.addr = buffer_va;
+    read = vmi_read(vmi, &_ctx, us->contents, us->length);
     if (read != us->length) {
         dbprint
             (VMI_DEBUG_READ, "--%s: failed to read UNICODE_STRING buffer\n",__FUNCTION__);

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -77,6 +77,6 @@ addr_t windows_find_eprocess_list_pgd(vmi_instance_t vmi, addr_t pgd);
 status_t init_from_kdbg(vmi_instance_t vmi);
 status_t windows_kdbg_lookup(vmi_instance_t vmi, const char *symbol, addr_t *address);
 
-unicode_string_t *windows_read_unicode_struct(vmi_instance_t vmi, addr_t vaddr, vmi_pid_t pid);
+unicode_string_t *windows_read_unicode_struct(vmi_instance_t vmi, const access_context_t *ctx);
 
 #endif /* OS_WINDOWS_H_ */

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -60,11 +60,10 @@ status_t
 windows_kernel_symbol_to_address(vmi_instance_t vmi, const char *symbol,
         addr_t *kernel_base_address, addr_t *address);
 status_t
-windows_export_to_rva(vmi_instance_t vmi, addr_t base_vaddr, vmi_pid_t pid,
+windows_export_to_rva(vmi_instance_t vmi, const access_context_t *ctx,
         const char *symbol, addr_t *rva);
 char*
-windows_rva_to_export(vmi_instance_t vmi, addr_t rva, addr_t base_vaddr,
-        vmi_pid_t pid);
+windows_rva_to_export(vmi_instance_t vmi, addr_t rva, const access_context_t *ctx);
 
 status_t windows_teardown(vmi_instance_t vmi);
 

--- a/libvmi/peparse.h
+++ b/libvmi/peparse.h
@@ -203,38 +203,19 @@ peparse_validate_pe_image(
     size_t len);
 
 /**
- * Read a physical address and return a valid PE image if one was found
- * continuously allocated at the address.
+ * Return a valid PE image if one was found
+ * at the provided context.
  *
  * @param[in] vmi, the vmi instance
- * @param[in] base_paddr, the physicall address to read from
+ * @param[in] ctx, Access context to get image from
  * @param[in] len, length to read
  * @param[out] image, address to store the data at
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t
-peparse_get_image_phys(
+peparse_get_image(
     vmi_instance_t vmi,
-    addr_t base_paddr,
-    size_t len,
-    const uint8_t * const image);
-
-/**
- * Read a virtual address and return a valid PE image if one was found
- * at the address.
- *
- * @param[in] vmi, the vmi instance
- * @param[in] base_vaddr, the virtual address to read from
- * @param[in] pid, PID of the process
- * @param[in] len, length to read
- * @param[out] image, address to store the data at
- * @return VMI_SUCCESS or VMI_FAILURE
- */
-status_t
-peparse_get_image_virt(
-    vmi_instance_t vmi,
-    addr_t base_vaddr,
-    vmi_pid_t pid,
+    const access_context_t *ctx,
     size_t len,
     const uint8_t * const image);
 
@@ -303,8 +284,7 @@ peparse_get_idd_size(
  * Get the export table from a PE image.
  *
  * @param[in] vmi, the libvmi instance
- * @param[in] base_vaddr, the base virtual address of the PE image
- * @param[in] pid, the PID of the program (or 0 for kernel)
+ * @param[in] ctx, Access context for the PE image base
  * @param[out] et, the address of the export_table to save data into
  * @param[out] (optional) export_table_rva, the rva of the export table as given in the IDD
  * @param[out] (optional) export_table_size, the size of the export table as given in the IDD
@@ -312,8 +292,7 @@ peparse_get_idd_size(
 status_t
 peparse_get_export_table(
     vmi_instance_t vmi,
-    addr_t base_vaddr,
-    vmi_pid_t pid,
+    const access_context_t *ctx,
     struct export_table *et,
     addr_t *export_table_rva,
     size_t *export_table_size);

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -296,19 +296,19 @@ status_t vmi_pagetable_lookup_cache(
     status_t rva_cache_get(
         vmi_instance_t vmi,
         addr_t base_addr,
-        vmi_pid_t pid,
+        addr_t dtb,
         addr_t rva,
         char **sym);
     void rva_cache_set(
         vmi_instance_t vmi,
         addr_t base_addr,
-        vmi_pid_t pid,
+        addr_t dtb,
         addr_t rva,
         char *sym);
     status_t rva_cache_del(
         vmi_instance_t vmi,
         addr_t base_addr,
-        vmi_pid_t pid,
+        addr_t dtb,
         addr_t rva);
 
     void v2p_cache_init(

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -36,7 +36,7 @@
 size_t
 vmi_read(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     void *buf,
     size_t count)
 {
@@ -188,7 +188,7 @@ vmi_read_ksym(
 static inline status_t
 vmi_read_X(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     void *value,
     int size)
 {
@@ -203,7 +203,7 @@ vmi_read_X(
 
 status_t
 vmi_read_8(vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint8_t * value)
 {
     return vmi_read_X(vmi, ctx, value, 1);
@@ -211,7 +211,7 @@ vmi_read_8(vmi_instance_t vmi,
 
 status_t
 vmi_read_16(vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint16_t * value)
 {
     return vmi_read_X(vmi, ctx, value, 2);
@@ -220,7 +220,7 @@ vmi_read_16(vmi_instance_t vmi,
 status_t
 vmi_read_32(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint32_t * value)
 {
     return vmi_read_X(vmi, ctx, value, 4);
@@ -229,7 +229,7 @@ vmi_read_32(
 status_t
 vmi_read_64(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint64_t * value)
 {
     return vmi_read_X(vmi, ctx, value, 8);
@@ -238,7 +238,7 @@ vmi_read_64(
 status_t
 vmi_read_addr(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     addr_t *value)
 {
     status_t ret = VMI_FAILURE;
@@ -266,7 +266,7 @@ vmi_read_addr(
 char *
 vmi_read_str(
     vmi_instance_t vmi,
-    access_context_t *ctx)
+    const access_context_t *ctx)
 {
     unsigned char *memory = NULL;
     char *rtnval = NULL;

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -351,6 +351,17 @@ vmi_read_str(
     return rtnval;
 }
 
+unicode_string_t*
+vmi_read_unicode_str(
+    vmi_instance_t vmi,
+    access_context_t *ctx)
+{
+    if (vmi->os_interface && vmi->os_interface->os_read_unicode_struct)
+        return vmi->os_interface->os_read_unicode_struct(vmi, ctx);
+
+    return NULL;
+}
+
 ///////////////////////////////////////////////////////////
 // Easy access to physical memory
 static inline status_t
@@ -557,12 +568,13 @@ vmi_read_str_va(
 
 unicode_string_t *
 vmi_read_unicode_str_va(vmi_instance_t vmi, addr_t vaddr, vmi_pid_t pid) {
-    unicode_string_t *ret = NULL;
-    if (vmi->os_interface && vmi->os_interface->os_read_unicode_struct) {
-        ret = vmi->os_interface->os_read_unicode_struct(vmi, vaddr, pid);
-    }
+    access_context_t ctx = {
+        .translate_mechanism = VMI_TM_PROCESS_PID,
+        .addr = vaddr,
+        .pid = pid
+    };
 
-    return ret;
+    return vmi_read_unicode_str(vmi, &ctx);
 }
 
 ///////////////////////////////////////////////////////////

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -32,7 +32,7 @@
 size_t
 vmi_write(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     void *buf,
     size_t count)
 {
@@ -181,7 +181,7 @@ vmi_write_ksym(
 static inline
 status_t vmi_write_X(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     void *value,
     int size)
 {
@@ -198,7 +198,7 @@ status_t vmi_write_X(
 status_t
 vmi_write_8(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint8_t * value)
 {
     return vmi_write_X(vmi, ctx, value, 1);
@@ -207,7 +207,7 @@ vmi_write_8(
 status_t
 vmi_write_16(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint16_t * value)
 {
     return vmi_write_X(vmi, ctx, value, 2);
@@ -216,7 +216,7 @@ vmi_write_16(
 status_t
 vmi_write_32(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint32_t * value)
 {
     return vmi_write_X(vmi, ctx, value, 4);
@@ -225,7 +225,7 @@ vmi_write_32(
 status_t
 vmi_write_64(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     uint64_t * value)
 {
     return vmi_write_X(vmi, ctx, value, 8);
@@ -234,7 +234,7 @@ vmi_write_64(
 status_t
 vmi_write_addr(
     vmi_instance_t vmi,
-    access_context_t *ctx,
+    const access_context_t *ctx,
     addr_t * value)
 {
     switch(vmi->page_mode) {

--- a/tests/test_peparse.c
+++ b/tests/test_peparse.c
@@ -269,8 +269,13 @@ START_TEST (test_peparse)
         kernbase = vmi_translate_ksym2v(vmi, "KernBase");
 
         uint8_t pe[MAX_HEADER_SIZE];
+        access_context_t ctx = {
+            .translate_mechanism = VMI_TM_PROCESS_PID,
+            .addr = kernbase,
+            .pid = 0
+        };
 
-        if(VMI_SUCCESS == peparse_get_image_virt(vmi, kernbase, 0, MAX_HEADER_SIZE, pe)) {
+        if(VMI_SUCCESS == peparse_get_image(vmi, &ctx, MAX_HEADER_SIZE, pe)) {
             if(VMI_SUCCESS == is_WINDOWS_KERNEL(vmi, kernbase, pe)) {
 
                 if(VMI_FAILURE == check_os_version(vmi, kernbase, pe))


### PR DESCRIPTION
This series converts some functions to use access_context_t instead of the current vaddr and PID input.  With access_context_t it these functions become more flexible as the user will be able to pass a DTB in directly. This involves changes to the public API.

As part of this change the symcache and rvachache has been updated to use the DTB as unique identifier instead of the PID.