### PR TITLE
Deprecate byte-granularity memaccess events

### DIFF
--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -334,19 +334,16 @@ int main (int argc, char **argv)
     msr_syscall_sysenter_event.type = VMI_EVENT_MEMORY;
     msr_syscall_sysenter_event.mem_event.physical_address = phys_sysenter_ip;
     msr_syscall_sysenter_event.mem_event.npages = 1;
-    msr_syscall_sysenter_event.mem_event.granularity=VMI_MEMEVENT_PAGE;
 
     memset(&kernel_sysenter_target_event, 0, sizeof(vmi_event_t));
     kernel_sysenter_target_event.type = VMI_EVENT_MEMORY;
     kernel_sysenter_target_event.mem_event.physical_address = phys_ia32_sysenter_target;
     kernel_sysenter_target_event.mem_event.npages = 1;
-    kernel_sysenter_target_event.mem_event.granularity=VMI_MEMEVENT_PAGE;
 
     memset(&kernel_vsyscall_event, 0, sizeof(vmi_event_t));
     kernel_vsyscall_event.type = VMI_EVENT_MEMORY;
     kernel_vsyscall_event.mem_event.physical_address = phys_vsyscall;
     kernel_vsyscall_event.mem_event.npages = 1;
-    kernel_vsyscall_event.mem_event.granularity=VMI_MEMEVENT_PAGE;
 
     while(!interrupted){
         printf("Waiting for events...\n");

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -176,7 +176,7 @@ int main (int argc, char **argv)
 
     printf("Preparing memory event to catch next RIP 0x%lx, PA 0x%lx, page 0x%lx for PID %u\n",
             rip, rip_pa, rip_pa >> 12, pid);
-    SETUP_MEM_EVENT(&mm_event, rip_pa, VMI_MEMEVENT_PAGE, VMI_MEMACCESS_X, mm_callback);
+    SETUP_MEM_EVENT(&mm_event, rip_pa, VMI_MEMACCESS_X, mm_callback);
 
     vmi_resume_vm(vmi);
 

--- a/libvmi/driver/xen/xen_events_legacy.c
+++ b/libvmi/driver/xen/xen_events_legacy.c
@@ -388,47 +388,6 @@ status_t process_register(vmi_instance_t vmi,
     return VMI_FAILURE;
 }
 
-
-/*
- * This function clears up the page access flags and queues each event
- * registered on that page for re-registration using vmi_step_event.
- */
-status_t process_unhandled_mem(vmi_instance_t vmi, memevent_page_t *page,
-        mem_event_request_t *req)
-{
-
-    // Clear the page's access flags
-    mem_access_event_t event = { 0 };
-    event.physical_address = page->key << 12;
-    event.npages = 1;
-    xen_set_mem_access(vmi, &event, VMI_MEMACCESS_N, 0);
-
-    // Queue the VMI_MEMEVENT_PAGE
-    if (page->event) {
-        vmi_step_event(vmi, page->event, req->vcpu_id, 1, NULL);
-    }
-
-    // Queue each VMI_MEMEVENT_BYTE
-    if (page->byte_events)
-    {
-        GHashTableIter i;
-        addr_t *pa;
-        vmi_event_t *loop;
-        ghashtable_foreach(page->byte_events, i, &pa, &loop)
-        {
-            vmi_step_event(vmi, loop, req->vcpu_id, 1, NULL);
-        }
-
-        // Free up memory of byte events GHashTable
-        g_hash_table_destroy(page->byte_events);
-    }
-
-    // Clear page from LibVMI GhashTable
-    g_hash_table_remove(vmi->mem_events, &page->key);
-
-    return VMI_SUCCESS;
-}
-
 void issue_mem_cb(vmi_instance_t vmi, vmi_event_t *event,
         mem_event_request_t *req, vmi_mem_access_t out_access) {
     event->mem_event.gla = req->gla;
@@ -461,60 +420,14 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
     xc_domain_hvm_getcontext_partial(xch, dom,
             HVM_SAVE_CODE(CPU), req.vcpu_id, &ctx, sizeof(ctx));
 
-    memevent_page_t * page = g_hash_table_lookup(vmi->mem_events, &req.gfn);
+    vmi_event_t *event = g_hash_table_lookup(vmi->mem_events, &req.gfn);
     vmi_mem_access_t out_access = VMI_MEMACCESS_INVALID;
     if(req.access_r) out_access |= VMI_MEMACCESS_R;
     if(req.access_w) out_access |= VMI_MEMACCESS_W;
     if(req.access_x) out_access |= VMI_MEMACCESS_X;
 
-    if (page)
-    {
-        uint8_t cb_issued = 0;
-        // To prevent use-after-free of 'page' in case it is freed after the first cb
-        GHashTable *byte_events = page->byte_events;
-
-        if (page->event && (page->event->mem_event.in_access & out_access))
-        {
-            issue_mem_cb(vmi, page->event, &req, out_access);
-            cb_issued = 1;
-        }
-
-        if (byte_events)
-        {
-            // Check if the offset has a byte-event registered
-            addr_t pa = (req.gfn<<12) + req.offset;
-            vmi_event_t *byte_event = (vmi_event_t *)g_hash_table_lookup(byte_events, &pa);
-
-            if(byte_event && (byte_event->mem_event.in_access & out_access))
-            {
-                issue_mem_cb(vmi, byte_event, &req, out_access);
-                cb_issued = 1;
-            }
-        }
-
-        /*
-         * When using VMI_MEMEVENT_BYTE the page-fault may be triggered
-         * at an offset that doesn't trigger a callback to the user. If these
-         * events are not catched and cleared the VM will halt. On the other hand
-         * if these events are cleared the user won't get the callback when the
-         * target offset is hit, therefore the events need to be re-registered
-         * after the fault has been cleared.
-         */
-        if(!cb_issued)
-        {
-            if(VMI_FAILURE == process_unhandled_mem(vmi, page, &req))
-            {
-                goto errdone;
-            }
-        }
-
-        /* TODO MARESCA: decide whether it's worthwhile to emulate xen-access here and call the following
-         *    note: the 'access' variable is basically discarded in that spot. perhaps it's really only called
-         *    to validate that the event is accessible (maybe that it's not consumed elsewhere??)
-         * hvmmem_access_t access;
-         * rc = xc_hvm_get_mem_access(xch, domain_id, event.mem_event.gfn, &access);
-         */
-
+    if (event && event->mem_event.in_access & out_access) {
+        issue_mem_cb(vmi, event, &req, out_access);
         return VMI_SUCCESS;
     }
 
@@ -524,11 +437,8 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
      *       The event in that case would be already removed from the GHashTable so
      *       the second violation on the other vCPU would not get delivered..
      */
-
     errprint("Caught a memory event that had no handler registered in LibVMI @ GFN %"PRIu32" (0x%"PRIx64"), access: %u\n",
-        req.gfn, (req.gfn<<12) + req.offset, out_access);
-
-errdone:
+             req.gfn, (req.gfn<<12) + req.offset, out_access);
     return VMI_FAILURE;
 }
 

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -102,21 +102,6 @@ typedef enum {
     __VMI_MEMACCESS_MAX
 } vmi_mem_access_t;
 
-/**
- * The level of granularity used in the configuration of a memory event.
- *  VMI_MEMEVENT_PAGE granularity delivers an event for any operation
- *   matching the access permission on the relevant page.
- *  VMI_MEMEVENT_BYTE granularity is more specific, deliving an event
- *   if an operation occurs involving the specific byte within a page
- */
-typedef enum {
-    VMI_MEMEVENT_INVALID,
-    VMI_MEMEVENT_BYTE,
-    VMI_MEMEVENT_PAGE,
-
-    __VMI_MEMEVENT_MAX
-} vmi_memevent_granularity_t;
-
 typedef struct x86_regs {
     uint64_t rax;
     uint64_t rcx;
@@ -234,15 +219,7 @@ typedef struct {
 
 typedef struct {
     /**
-     * IN: Specify if using VMI_MEMEVENT_BYTE/PAGE
-     */
-    vmi_memevent_granularity_t granularity;
-
-    /**
      * IN: Physical address to set event on.
-     * With granularity of
-     *  VMI_MEMEVENT_PAGE, this can any
-     *  byte on the target page.
      */
     addr_t physical_address;
 
@@ -434,11 +411,10 @@ struct vmi_event {
 /**
  * Convenience macro to setup a memory event
  */
-#define SETUP_MEM_EVENT(_event, _addr, _granularity, _access, _callback) \
+#define SETUP_MEM_EVENT(_event, _addr, _access, _callback) \
         do { \
             (_event)->type = VMI_EVENT_MEMORY; \
             (_event)->mem_event.physical_address = _addr; \
-            (_event)->mem_event.granularity = _granularity; \
             (_event)->mem_event.in_access = _access; \
             (_event)->mem_event.npages = 1; \
             (_event)->callback = _callback; \
@@ -533,8 +509,7 @@ vmi_event_t *vmi_get_reg_event(
  */
 vmi_event_t *vmi_get_mem_event(
     vmi_instance_t vmi,
-    addr_t physical_address,
-    vmi_memevent_granularity_t granularity);
+    addr_t physical_address);
 
 /**
  * Setup single-stepping to register the given event

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -155,17 +155,6 @@ struct vmi_instance {
     GHashTable *clear_events; /**< table to save vmi_clear_event requests when event_callback is set */
 };
 
-/** Page-level memevent struct to also hold byte-level events in the embedded hashtable */
-typedef struct memevent_page {
-
-    vmi_mem_access_t access_flag; /**< combined page access flag */
-    vmi_event_t *event; /**< page event registered */
-    addr_t key; /**< page # */
-
-    GHashTable  *byte_events; /**< byte events */
-
-} memevent_page_t;
-
 /** Event singlestep reregister wrapper */
 typedef struct step_and_reg_event_wrapper {
     vmi_event_t *event;


### PR DESCRIPTION
Byte-granularity events have a particular weakness in that events triggered up to 8-bytes prior to the actual byte where the event is registered would not trigger a callback. Thus, the API as it is right now may encourage the development of insecure applications. As only the user is aware if such events are permissible or not depending on the use-case, it is better to leave it up to the user to determine what to do.