### PR TITLE
paddr + length may equal to max_physical_address

### DIFF
--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -128,7 +128,7 @@ static memory_cache_entry_t create_new_entry (vmi_instance_t vmi, addr_t paddr,
     //
     // TODO: perform other reasonable checks
 
-    if (vmi->hvm && (paddr + length >= vmi->max_physical_address)) {
+    if (vmi->hvm && (paddr + length > vmi->max_physical_address)) {
         errprint("--requesting PA [0x%"PRIx64"] beyond max physical address [0x%"PRIx64"]\n",
                 paddr + length, vmi->max_physical_address);
         errprint("\tpaddr: %"PRIx64", length %"PRIx32", vmi->max_physical_address %"PRIx64"\n", paddr, length,


### PR DESCRIPTION
If the "paddr + length" equals to max_physical_address, the program may cause VMI_ERROR
\# ./examples/process-list windows732
VMI_ERROR: --requesting PA [0x3e800000] beyond max physical address [0x3e800000]
VMI_ERROR: 	paddr: 3e7ff000, length 1000, vmi->max_physical_address 3e800000
VMI_ERROR: create_new_entry failed
LibVMI Suggestion: set win_ntoskrnl=0x3c1f000 in libvmi.conf for faster startup.
LibVMI Suggestion: set win_kdbg=0x121c28 in libvmi.conf for faster startup.
LibVMI Suggestion: set win_kdvb=0x83d40c28 in libvmi.conf for faster startup.

This commit changes "paddr + length >= vmi->max_physical_address" to "paddr + length > vmi->max_physical_address"