### PR TITLE
ARM64 paging support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,8 +33,12 @@ x86?64*)
     AC_DEFINE([X86_64], 1, [Define for the AMD x86-64 architecture.])
     ;;
 arm*)
-    arch=arm
-    AC_DEFINE([ARM], 1, [Define for the ARM architecture.])
+    arch=arm32
+    AC_DEFINE([ARM32], 1, [Define for the ARM32 architecture.])
+    ;;
+aarch64*)
+    arch=arm64
+    AC_DEFINE([ARM64], 1, [Define for the ARM64 architecture.])
     ;;
 esac
 AC_MSG_RESULT($arch)

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -13,6 +13,7 @@ h_private = \
     arch/intel.h \
     arch/amd64.h \
     arch/arm_aarch32.h \
+    arch/arm_aarch64.h \
     os/os_interface.h \
     driver/driver_interface.h \
     driver/driver_wrapper.h \
@@ -34,6 +35,7 @@ c_sources = \
     arch/intel.c \
     arch/amd64.c \
     arch/arm_aarch32.c \
+    arch/arm_aarch64.c \
     driver/driver_interface.c \
     driver/memory_cache.c \
     os/os_interface.c

--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -25,6 +25,7 @@
 #include "arch/intel.h"
 #include "arch/amd64.h"
 #include "arch/arm_aarch32.h"
+#include "arch/arm_aarch64.h"
 
 status_t arch_init(vmi_instance_t vmi) {
 
@@ -51,6 +52,9 @@ status_t arch_init(vmi_instance_t vmi) {
             break;
         case VMI_PM_AARCH32:
             ret = aarch32_init(vmi);
+            break;
+        case VMI_PM_AARCH64:
+            ret = aarch64_init(vmi);
             break;
         case VMI_PM_UNKNOWN: /* fallthrough */
         default:

--- a/libvmi/arch/arm_aarch64.c
+++ b/libvmi/arch/arm_aarch64.c
@@ -1,0 +1,323 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel (tamas@tklengyel.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+#include "private.h"
+#include "driver/driver_wrapper.h"
+#include "arch/arm_aarch64.h"
+
+// 0th Level Page Table Index (4kb Pages)
+static inline
+uint64_t zero_level_4kb_table_index(uint64_t vaddr) {
+    return (vaddr >> 39) & VMI_BIT_MASK(0,8);
+}
+
+// 0th Level Descriptor (4kb Pages)
+static inline
+void get_zero_level_4kb_descriptor(vmi_instance_t vmi, uint64_t dtb, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.zld_location = (dtb & VMI_BIT_MASK(12,47)) | (zero_level_4kb_table_index(vaddr) << 3);
+    uint64_t zld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.zld_location, &zld_v)) {
+        printf("Got zld_v: 0x%lx\n", zld_v);
+        info->arm_aarch64.zld_value = zld_v;
+    }
+}
+
+// 1st Level Page Table Index (4kb Pages)
+static inline
+uint64_t first_level_4kb_table_index(uint64_t vaddr) {
+    return (vaddr >> 30) & VMI_BIT_MASK(0,8);
+}
+
+// 1st Level Descriptor (4kb Pages)
+static inline
+void get_first_level_4kb_descriptor(vmi_instance_t vmi, uint64_t dtb, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.fld_location = (dtb & VMI_BIT_MASK(12,47)) | (first_level_4kb_table_index(vaddr) << 3);
+    uint64_t fld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.fld_location, &fld_v)) {
+        info->arm_aarch64.fld_value = fld_v;
+    }
+}
+
+// 1st Level Page Table Index (64kb Pages)
+static inline
+uint64_t first_level_64kb_table_index(uint64_t vaddr) {
+    return (vaddr >> 42) & VMI_BIT_MASK(0,5);
+}
+
+// 1st Level Descriptor (64kb Pages)
+static inline
+void get_first_level_64kb_descriptor(vmi_instance_t vmi, uint64_t dtb, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.fld_location = (dtb & VMI_BIT_MASK(9,47)) | (first_level_64kb_table_index(vaddr) << 3);
+    uint64_t fld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.fld_location, &fld_v)) {
+        info->arm_aarch64.fld_value = fld_v;
+    }
+
+    printf("64kb fld location: 0x%lx 0x%lx\n", info->arm_aarch64.fld_location, fld_v);
+}
+
+// 2nd Level Page Table Index (4kb Pages)
+static inline
+uint64_t second_level_4kb_table_index(uint64_t vaddr) {
+    return (vaddr>>21) & VMI_BIT_MASK(0,8);
+}
+
+// 2nd Level Page Table Descriptor (4kb Pages)
+static inline
+void get_second_level_4kb_descriptor(vmi_instance_t vmi, uint64_t dtb, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.sld_location = (dtb & VMI_BIT_MASK(12,47)) | (second_level_4kb_table_index(vaddr) << 3);
+    uint64_t sld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.sld_location, &sld_v)) {
+        info->arm_aarch64.sld_value = sld_v;
+    }
+}
+
+// 2nd Level Page Table Index (64kb Pages)
+static inline
+uint64_t second_level_64kb_table_index(uint64_t vaddr) {
+    return (vaddr>>29) & VMI_BIT_MASK(0,12);
+}
+
+// 2nd Level Page Table Descriptor (64kb Pages)
+static inline
+void get_second_level_64kb_descriptor(vmi_instance_t vmi, uint64_t dtb, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.sld_location = (dtb & VMI_BIT_MASK(16,47)) | (second_level_64kb_table_index(vaddr) << 3);
+    uint64_t sld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.sld_location, &sld_v)) {
+        info->arm_aarch64.sld_value = sld_v;
+    }
+}
+
+// 3rd Level Page Table Index (4kb Pages)
+static inline
+uint64_t third_level_4kb_table_index(uint64_t vaddr) {
+    return (vaddr>>12) & VMI_BIT_MASK(0,8);
+}
+
+// 3rd Level Page Table Descriptor (4kb Pages)
+static inline
+void get_third_level_4kb_descriptor(vmi_instance_t vmi, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.tld_location = (info->arm_aarch64.sld_value & VMI_BIT_MASK(12,47)) | (third_level_4kb_table_index(vaddr) << 3);
+    uint64_t tld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.tld_location, &tld_v)) {
+        info->arm_aarch64.tld_value = tld_v;
+    }
+}
+
+// 3rd Level Page Table Index (64kb Pages)
+static inline
+uint64_t third_level_64kb_table_index(uint64_t vaddr) {
+    return (vaddr>>16) & VMI_BIT_MASK(0,12);
+}
+
+// 3rd Level Page Table Descriptor (64kb Pages)
+static inline
+void get_third_level_64kb_descriptor(vmi_instance_t vmi, uint64_t vaddr, page_info_t *info) {
+    info->arm_aarch64.tld_location = (info->arm_aarch64.sld_value & VMI_BIT_MASK(16,47)) | (third_level_64kb_table_index(vaddr) << 3);
+    uint64_t tld_v;
+    if(VMI_SUCCESS == vmi_read_64_pa(vmi, info->arm_aarch64.tld_location, &tld_v)) {
+        info->arm_aarch64.tld_value = tld_v;
+    }
+}
+
+// Based on ARM Reference Manual
+// D4.3 ARM ARMv8-A VMSAv8-64 translation table format descriptors
+// K7.1.2 ARM ARMv8-A Full translation flows for VMSAv8-64 address translation
+status_t v2p_aarch64 (vmi_instance_t vmi,
+    addr_t dtb,
+    addr_t vaddr,
+    page_info_t *info)
+{
+    status_t status = VMI_FAILURE;
+
+    dbprint(VMI_DEBUG_PTLOOKUP, "--ARM AArch64 PTLookup: vaddr = 0x%.16"PRIx64", dtb = 0x%.16"PRIx64"\n", vaddr, dtb);
+
+    /*
+     * TODO: Fixme
+     * We need to know if we are using TTBR0 or TTBR1 here so we know table type.
+     * Right now we can deduce this for Linux by comparing to vmi->kpgd which is
+     * TTBR1. However, this means V2P translation only works with complete init.
+     * To make this OS neutral we will likely have to extend the API so the user
+     * can specify the dtb type.
+     */
+
+    bool is_dtb_ttbr1 = false;
+    page_size_t ps;
+    uint8_t levels;
+    uint8_t va_width;
+
+    if(dtb == vmi->kpgd)
+        is_dtb_ttbr1 = true;
+
+    if ( is_dtb_ttbr1 ) {
+        ps = vmi->arm64.tg1;
+        va_width = 64 - vmi->arm64.t1sz;
+    } else {
+        ps = vmi->arm64.tg0;
+        va_width = 64 - vmi->arm64.t0sz;
+    }
+
+    if ( ps == VMI_PS_4KB )
+        levels = va_width == 39 ? 3 : 4;
+    else if ( ps == VMI_PS_64KB )
+        levels = va_width == 42 ? 2 : 3;
+    else {
+        errprint("16KB granule size ARM64 lookups are not yet implemented\n");
+        goto done;
+    }
+
+    if ( levels == 4 ) {
+        if ( ps == VMI_PS_4KB ) {
+            get_zero_level_4kb_descriptor(vmi, dtb, vaddr, info);
+            dbprint(VMI_DEBUG_PTLOOKUP,
+                "--ARM AArch64 PTLookup: zld_value = 0x%"PRIx64"\n",
+                info->arm_aarch64.zld_value);
+
+            if(info->arm_aarch64.zld_value & VMI_BIT_MASK(0,1) != 0b11)
+                goto done;
+
+            dtb = info->arm_aarch64.zld_value & VMI_BIT_MASK(12,47);
+            --levels;
+        } else
+            goto done;
+    }
+
+    if ( levels == 3 ) {
+        if ( ps == VMI_PS_4KB ) {
+            get_first_level_4kb_descriptor(vmi, dtb, vaddr, info);
+            dbprint(VMI_DEBUG_PTLOOKUP,
+                "--ARM AArch64 4kb PTLookup: fld_value = 0x%"PRIx64"\n",
+                info->arm_aarch64.fld_value);
+
+            switch(info->arm_aarch64.fld_value & VMI_BIT_MASK(0,1)) {
+                case 0b11:
+                    dtb = info->arm_aarch64.fld_value & VMI_BIT_MASK(12,47);
+                    --levels;
+                    break;
+                case 0b01:
+                    info->size = VMI_PS_1GB;
+                    info->paddr = (info->arm_aarch64.fld_value & VMI_BIT_MASK(30,47)) | (vaddr & VMI_BIT_MASK(0,29));
+                    status = VMI_SUCCESS;
+                    goto done;
+                default:
+                    goto done;
+            }
+
+        }
+        if ( ps == VMI_PS_64KB ) {
+            get_first_level_64kb_descriptor(vmi, dtb, vaddr, info);
+            dbprint(VMI_DEBUG_PTLOOKUP,
+                "--ARM AArch64 64kb PTLookup: fld_value = 0x%"PRIx64"\n",
+                info->arm_aarch64.fld_value);
+
+            switch(info->arm_aarch64.fld_value & VMI_BIT_MASK(0,1)) {
+                case 0b11:
+                    dtb = info->arm_aarch64.fld_value & VMI_BIT_MASK(16,47);
+                    --levels;
+                    break;
+                default:
+                    goto done;
+            }
+        }
+    }
+
+    if ( levels == 2 ) {
+        if ( ps == VMI_PS_4KB ) {
+            get_second_level_4kb_descriptor(vmi, dtb, vaddr, info);
+            dbprint(VMI_DEBUG_PTLOOKUP,
+                "--ARM AArch64 4kb PTLookup: sld_value = 0x%"PRIx64"\n",
+                info->arm_aarch64.sld_value);
+
+            switch(info->arm_aarch64.sld_value & VMI_BIT_MASK(0,1)) {
+                case 0b11:
+                    get_third_level_4kb_descriptor(vmi, vaddr, info);
+                    dbprint(VMI_DEBUG_PTLOOKUP,
+                        "--ARM AArch64 4kb PTLookup: tld_value = 0x%"PRIx64"\n",
+                        info->arm_aarch64.tld_value);
+
+                    info->size = VMI_PS_4KB;
+                    info->paddr = (info->arm_aarch64.tld_value & VMI_BIT_MASK(12,47)) | (vaddr & VMI_BIT_MASK(0,11));
+                    status = VMI_SUCCESS;
+                    break;
+                case 0b01:
+                    info->size = VMI_PS_2MB;
+                    info->paddr = (info->arm_aarch64.sld_value & VMI_BIT_MASK(21,47)) | (vaddr & VMI_BIT_MASK(0,20));
+                    status = VMI_SUCCESS;
+                    goto done;
+                default:
+                    goto done;
+            }
+        }
+        if ( ps == VMI_PS_64KB ) {
+            get_second_level_64kb_descriptor(vmi, dtb, vaddr, info);
+            dbprint(VMI_DEBUG_PTLOOKUP,
+                "--ARM AArch64 64kb PTLookup: sld_value = 0x%"PRIx64"\n",
+                info->arm_aarch64.sld_value);
+
+            switch(info->arm_aarch64.sld_value & VMI_BIT_MASK(0,1)) {
+                case 0b11:
+                    get_third_level_64kb_descriptor(vmi, vaddr, info);
+                    dbprint(VMI_DEBUG_PTLOOKUP,
+                        "--ARM AArch64 64kb PTLookup: tld_value = 0x%"PRIx64"\n",
+                        info->arm_aarch64.tld_value);
+
+                    info->size = VMI_PS_4KB;
+                    info->paddr = (info->arm_aarch64.tld_value & VMI_BIT_MASK(16,47)) | (vaddr & VMI_BIT_MASK(0,15));
+                    status = VMI_SUCCESS;
+                    goto done;
+                case 0b01:
+                    info->size = VMI_PS_512MB;
+                    info->paddr = (info->arm_aarch64.sld_value & VMI_BIT_MASK(29,47)) | (vaddr & VMI_BIT_MASK(0,28));
+                    status = VMI_SUCCESS;
+                    goto done;
+                default:
+                    goto done;
+            }
+        }
+    }
+
+done:
+    dbprint(VMI_DEBUG_PTLOOKUP, "--ARM PTLookup: PA = 0x%"PRIx64"\n", info->paddr);
+    return status;
+}
+
+GSList* get_va_pages_aarch64(vmi_instance_t vmi, addr_t dtb) {
+    //TODO: investigate best method to loop over all tables
+    return NULL;
+}
+
+status_t aarch64_init(vmi_instance_t vmi) {
+
+    if(!vmi->arch_interface) {
+        vmi->arch_interface = safe_malloc(sizeof(struct arch_interface));
+        bzero(vmi->arch_interface, sizeof(struct arch_interface));
+    }
+
+    vmi->arch_interface->v2p = v2p_aarch64;
+    vmi->arch_interface->get_va_pages = get_va_pages_aarch64;
+
+    return VMI_SUCCESS;
+}

--- a/libvmi/arch/arm_aarch64.h
+++ b/libvmi/arch/arm_aarch64.h
@@ -2,6 +2,8 @@
  * memory in a target virtual machine or in a file containing a dump of
  * a system's physical memory.  LibVMI is based on the XenAccess Library.
  *
+ * Author: Tamas K Lengyel (tamas@tklengyel.com)
+ *
  * This file is part of LibVMI.
  *
  * LibVMI is free software: you can redistribute it and/or modify it under
@@ -18,26 +20,11 @@
  * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef ARCH_INTERFACE_H_
-#define ARCH_INTERFACE_H_
+#ifndef ARM64_H
+#define ARM64_H
 
 #include "private.h"
 
-typedef status_t (*arch_v2p_t)
-    (vmi_instance_t vmi,
-     addr_t dtb,
-     addr_t vaddr,
-     page_info_t *info);
-typedef GSList* (*arch_get_va_pages_t)
-    (vmi_instance_t vmi,
-     addr_t dtb);
+status_t aarch64_init(vmi_instance_t vmi);
 
-struct arch_interface {
-    arch_v2p_t v2p;
-    arch_get_va_pages_t get_va_pages;
-};
-typedef struct arch_interface *arch_interface_t;
-
-status_t arch_init(vmi_instance_t vmi);
-
-#endif /* ARCH_INTERFACE_H_ */
+#endif

--- a/libvmi/arch/intel.c
+++ b/libvmi/arch/intel.c
@@ -294,7 +294,7 @@ status_t v2p_nopae (vmi_instance_t vmi,
         goto done;
     }
 
-    if (PAGE_SIZE(info->x86_legacy.pgd_value) && (VMI_FILE == vmi->mode || vmi->pse)) {
+    if (PAGE_SIZE(info->x86_legacy.pgd_value) && (VMI_FILE == vmi->mode || vmi->x86.pse)) {
         info->paddr = get_large_paddr_nopae(vaddr, info->x86_legacy.pgd_value);
         info->size = VMI_PS_4MB;
         status = VMI_SUCCESS;
@@ -405,7 +405,7 @@ GSList* get_va_pages_nopae(vmi_instance_t vmi, addr_t dtb) {
 
         if(ENTRY_PRESENT(vmi->os_type, pgd_entry)) {
 
-            if(PAGE_SIZE(pgd_entry) && (VMI_FILE == vmi->mode || vmi->pse)) {
+            if(PAGE_SIZE(pgd_entry) && (VMI_FILE == vmi->mode || vmi->x86.pse)) {
                 page_info_t *p = g_malloc0(sizeof(page_info_t));
                 p->vaddr = pgd_base_vaddr;
                 p->paddr = get_large_paddr_nopae(p->vaddr, pgd_base_vaddr);

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -117,7 +117,9 @@ typedef enum page_mode {
 
     VMI_PM_IA32E,   /**< x86 IA-32e paging */
 
-    VMI_PM_AARCH32  /**< ARM 32-bit paging */
+    VMI_PM_AARCH32, /**< ARM 32-bit paging */
+
+    VMI_PM_AARCH64  /**< ARM 64-bit paging */
 } page_mode_t;
 
 typedef enum page_size {
@@ -127,6 +129,8 @@ typedef enum page_size {
     VMI_PS_1KB      = 0x400ULL,     /**< 1KB */
 
     VMI_PS_4KB      = 0x1000ULL,    /**< 4KB */
+
+    VMI_PS_16KB     = 0x4000ULL,    /**< 16KB */
 
     VMI_PS_64KB     = 0x10000ULL,   /**< 64KB */
 
@@ -138,7 +142,11 @@ typedef enum page_size {
 
     VMI_PS_16MB     = 0x1000000ULL, /**< 16MB */
 
-    VMI_PS_1GB      = 0x4000000ULL  /**< 1GB */
+    VMI_PS_32MB     = 0x2000000ULL, /**< 32MB */
+
+    VMI_PS_512MB    = 0x2000000ULL,  /**< 512MB */
+
+    VMI_PS_1GB      = 0x4000000ULL,  /**< 1GB */
 
 } page_size_t;
 
@@ -251,6 +259,8 @@ typedef enum registers {
     TTBR0,
     TTBR1,
 
+    CPSR,
+
     R0_USR,
     R1_USR,
     R2_USR,
@@ -296,7 +306,10 @@ typedef enum registers {
     SPSR_FIQ,
     SPSR_IRQ,
     SPSR_UND,
-    SPSR_ABT
+    SPSR_ABT,
+
+    /* ARM64 register */
+    TCR_EL1,
 } registers_t;
 
 /**
@@ -352,6 +365,17 @@ typedef struct page_info {
             uint32_t sld_location;
             uint32_t sld_value;
         } arm_aarch32;
+
+        struct {
+            uint64_t zld_location;
+            uint64_t zld_value;
+            uint64_t fld_location;
+            uint64_t fld_value;
+            uint64_t sld_location;
+            uint64_t sld_value;
+            uint64_t tld_location;
+            uint64_t tld_value;
+        } arm_aarch64;
     };
 } page_info_t;
 

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -61,9 +61,9 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     if (!VMI_GET_BIT(cr0, 31)) {
         dbprint(VMI_DEBUG_CORE, "Paging disabled for this VM, only physical addresses supported.\n");
         vmi->page_mode = VMI_PM_UNKNOWN;
-        vmi->pae = 0;
-        vmi->pse = 0;
-        vmi->lme = 0;
+        vmi->x86.pae = 0;
+        vmi->x86.pse = 0;
+        vmi->x86.lme = 0;
 
         ret = VMI_SUCCESS;
         goto _exit;
@@ -135,9 +135,9 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     }
 
     vmi->page_mode = pm;
-    vmi->pae = pae;
-    vmi->pse = pse;
-    vmi->lme = lme;
+    vmi->x86.pae = pae;
+    vmi->x86.pse = pse;
+    vmi->x86.lme = lme;
 
 _exit:
     return ret;
@@ -148,9 +148,48 @@ status_t probe_memory_layout_arm(vmi_instance_t vmi) {
     status_t ret = VMI_FAILURE;
     page_mode_t pm = VMI_PM_UNKNOWN;
 
-    reg_t ttbr1;
-    if (VMI_SUCCESS == driver_get_vcpureg(vmi, &ttbr1, TTBR1, 0)) {
-        pm = VMI_PM_AARCH32;
+    reg_t cpsr;
+    if (VMI_SUCCESS == driver_get_vcpureg(vmi, &cpsr, CPSR, 0)) {
+        if (cpsr & PSR_MODE_BIT) {
+            pm = VMI_PM_AARCH32;
+            dbprint(VMI_DEBUG_CORE, "Found ARM32 pagemode\n");
+        } else {
+            /* See ARM ARMv8-A D7.2.84 TCR_EL1, Translation Control Register (EL1) */
+            reg_t tcr_el1;
+            if (VMI_SUCCESS == driver_get_vcpureg(vmi, &tcr_el1, TCR_EL1, 0)) {
+                vmi->arm64.t0sz = tcr_el1 & VMI_BIT_MASK(0,5);
+                vmi->arm64.t1sz = (tcr_el1 & VMI_BIT_MASK(16,21)) >> 16;
+                switch((tcr_el1 & VMI_BIT_MASK(14,15)) >> 14) {
+                    case 0b00:
+                        vmi->arm64.tg0 = VMI_PS_4KB;
+                        break;
+                    case 0b01:
+                        vmi->arm64.tg0 = VMI_PS_64KB;
+                        break;
+                    case 0b10:
+                        vmi->arm64.tg0 = VMI_PS_16KB;
+                        break;
+                };
+                switch((tcr_el1 & VMI_BIT_MASK(30,31)) >> 30) {
+                    case 0b01:
+                        vmi->arm64.tg1 = VMI_PS_16KB;
+                        break;
+                    case 0b10:
+                        vmi->arm64.tg1 = VMI_PS_4KB;
+                        break;
+                    case 0b11:
+                        vmi->arm64.tg1 = VMI_PS_64KB;
+                        break;
+                };
+            }
+
+            pm = VMI_PM_AARCH64;
+            dbprint(VMI_DEBUG_CORE,
+                    "Found ARM64 pagemode. TTBR0 VA width: %u Page size: %u TTBR1 VA width:%u Page size: %u\n",
+                    64-vmi->arm64.t0sz, vmi->arm64.tg0,
+                    64-vmi->arm64.t1sz, vmi->arm64.tg1);
+        }
+
         ret = VMI_SUCCESS;
     }
 
@@ -172,7 +211,7 @@ status_t find_page_mode_live(vmi_instance_t vmi) {
     if (VMI_SUCCESS == probe_memory_layout_x86(vmi)) {
         return VMI_SUCCESS;
     }
-#elif defined(ARM)
+#elif defined(ARM32) || defined(ARM64)
     if (VMI_SUCCESS == probe_memory_layout_arm(vmi)) {
         return VMI_SUCCESS;
     }

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -72,6 +72,7 @@ static status_t linux_filemode_init(vmi_instance_t vmi)
 
     switch (vmi->page_mode)
     {
+    case VMI_PM_AARCH64:
     case VMI_PM_IA32E:
         linux_symbol_to_address(vmi, "phys_startup_64", NULL, &phys_start);
         linux_symbol_to_address(vmi, "startup_64", NULL, &virt_start);
@@ -253,7 +254,7 @@ status_t linux_init(vmi_instance_t vmi) {
 
     vmi->init_task = canonical_addr(vmi->init_task);
 
-#if defined(ARM)
+#if defined(ARM32) || defined(ARM64)
     rc = driver_get_vcpureg(vmi, &vmi->kpgd, TTBR1, 0);
 #elif defined(I386) || defined(X86_64)
     rc = driver_get_vcpureg(vmi, &vmi->kpgd, CR3, 0);

--- a/libvmi/os/linux/memory.c
+++ b/libvmi/os/linux/memory.c
@@ -191,6 +191,7 @@ linux_pid_to_pgd(
     {
         switch(vmi->page_mode)
         {
+            case VMI_PM_AARCH64:// intentional fall-through
             case VMI_PM_IA32E:
                 width = 8;
                 break;

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -84,11 +84,25 @@ struct vmi_instance {
 
     addr_t init_task;       /**< address of task struct for init */
 
-    int pae;                /**< nonzero if PAE is enabled */
+    union {
+        struct {
+            int pae;        /**< nonzero if PAE is enabled */
 
-    int pse;                /**< nonzero if PSE is enabled */
+            int pse;        /**< nonzero if PSE is enabled */
 
-    int lme;                /**< nonzero if LME is enabled */
+            int lme;        /**< nonzero if LME is enabled */
+        } x86;
+
+        struct {
+            int t0sz;           /**< TTBR0 VA size (2^(64-t0sz)) */
+
+            int t1sz;           /**< TTBR1 VA size (2^(64-t1sz)) */
+
+            page_size_t tg0;    /**< TTBR0 granule size: 4KB/16KB/64KB */
+
+            page_size_t tg1;    /**< TTBR1 granule size: 4KB/16KB/64KB */
+        } arm64;
+    };
 
     page_mode_t page_mode;  /**< paging mode in use */
 
@@ -359,6 +373,8 @@ status_t vmi_pagetable_lookup_cache(
 /*-----------------------------------------
  * memory.c
  */
+
+    #define PSR_MODE_BIT 0x10 // set on cpsr iff ARM32
 
     status_t find_page_mode_live(
     vmi_instance_t vmi);

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -244,6 +244,7 @@ vmi_read_addr(
     status_t ret = VMI_FAILURE;
 
     switch (vmi->page_mode) {
+        case VMI_PM_AARCH64:// intentional fall-through
         case VMI_PM_IA32E:
             ret = vmi_read_X(vmi, ctx, value, 8);
             break;
@@ -415,6 +416,7 @@ vmi_read_addr_pa(
     status_t ret = VMI_FAILURE;
 
     switch(vmi->page_mode) {
+        case VMI_PM_AARCH64:// intentional fall-through
         case VMI_PM_IA32E:
             ret = vmi_read_X_pa(vmi, paddr, value, 8);
             break;
@@ -519,6 +521,7 @@ vmi_read_addr_va(
     status_t ret = VMI_FAILURE;
 
     switch(vmi->page_mode) {
+        case VMI_PM_AARCH64:// intentional fall-through
         case VMI_PM_IA32E:
             ret = vmi_read_X_va(vmi, vaddr, pid, value, 8);
             break;
@@ -629,6 +632,7 @@ vmi_read_addr_ksym(
     status_t ret = VMI_FAILURE;
 
     switch(vmi->page_mode) {
+        case VMI_PM_AARCH64:// intentional fall-through
         case VMI_PM_IA32E:
             ret = vmi_read_X_ksym(vmi, sym, value, 8);
             break;

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -238,6 +238,7 @@ vmi_write_addr(
     addr_t * value)
 {
     switch(vmi->page_mode) {
+        case VMI_PM_AARCH64:// intentional fall-through
         case VMI_PM_IA32E:
             return vmi_write_X(vmi, ctx, value, 8);
         case VMI_PM_AARCH32:// intentional fall-through


### PR DESCRIPTION
ARM64 paging is very different from all other formats as the tables can have variable levels for variable VA widths and also variable page-sizes. Furthermore, TTBR0 could be operating with a different mode from TTBR1, so the translation routines need to be aware which one is being used to grab the proper configuration register values from TCR_EL1.

In this PR we implement translation for 4kb and 64kb granule sizes as these are the only ones supported by Linux at this time. Furthermore, the translation is not completely OS independent at this time as it determines if TTBR0 or TTBR1 is used by comparing to vmi->kpgd. On Linux TTBR1 statically holds the kernel page table, but for other OS's this may not hold.

# xl info
host                   : linaro-alip
release                : 4.1.15
version                : #9 SMP PREEMPT Sat Jun 4 01:32:10 UTC 2016
machine                : aarch64
nr_cpus                : 8 
max_cpu_id             : 127
nr_nodes               : 1 
cores_per_socket       : 1 
threads_per_core       : 1 
cpu_mhz                : 1 
hw_caps                : 00000000:00000000:00000000:00000000:00000000:00000000:00000000:00000000
virt_caps              :
total_memory           : 1998
free_memory            : 825
sharing_freed_memory   : 0
sharing_used_memory    : 0
outstanding_claims     : 0
free_cpus              : 0
xen_major              : 4
xen_minor              : 7
xen_extra              : .0-rc
xen_version            : 4.7.0-rc
xen_caps               : xen-3.0-aarch64 xen-3.0-armv7l 
xen_scheduler          : credit
xen_pagesize           : 4096
platform_params        : virt_start=0x200000
xen_changeset          : Thu Jun 2 16:18:40 2016 -0600 git:49b3f1e
xen_commandline        : xen console=dtuart dom0_mem=1024M dom0_max_vcpus=8 conswitch=x loglvl=all guest_loglvl=all console=dtuart dtuart=/smb/uart@f7113000
cc_compiler            : aarch64-linux-gnu-gcc (Ubuntu/Linaro 5.3.1-14ubuntu2) 5.3.1 201
cc_compile_by          : root
cc_compile_domain      : lan
cc_compile_date        : Fri Jun  3 16:40:32 UTC 2016
build_id               : 1256d74c1d4e64a51c88125da1621801681f5238
xend_config_format     : 4

# ./examples/process-list domu
Process listing for VM domu (id=1)
[    0] swapper/0 (struct addr:ffffffc000cebb40)
[    1] sh (struct addr:ffffffc00284ac80)
[    2] kthreadd (struct addr:ffffffc00284a040)
[    3] ksoftirqd/0 (struct addr:ffffffc00285ecc0)
[    4] kworker/0:0 (struct addr:ffffffc00285e080)
[    5] kworker/0:0H (struct addr:ffffffc002878d00)
[    6] kworker/u2:0 (struct addr:ffffffc0028780c0)
[    7] rcu_preempt (struct addr:ffffffc00288ad40)
[    8] rcu_sched (struct addr:ffffffc00288a100)
[    9] rcu_bh (struct addr:ffffffc002898d80)
[   10] migration/0 (struct addr:ffffffc002898140)
[   11] watchdog/0 (struct addr:ffffffc0028a4dc0)
[   12] khelper (struct addr:ffffffc0028a4180)
[   13] kdevtmpfs (struct addr:ffffffc0028b2e00)
[   14] netns (struct addr:ffffffc0028b21c0)
[   15] perf (struct addr:ffffffc0028cce40)
[   16] kworker/u2:1 (struct addr:ffffffc0028cc200)
[   31] xenwatch (struct addr:ffffffc0029463c0)
[   32] xenbus (struct addr:ffffffc002959040)
[  339] khungtaskd (struct addr:ffffffc002180dc0)
[  340] writeback (struct addr:ffffffc0021b6280)
[  342] ksmd (struct addr:ffffffc002b29000)
[  343] kworker/0:1 (struct addr:ffffffc002aac1c0)
[  344] crypto (struct addr:ffffffc002aace00)
[  345] bioset (struct addr:ffffffc002198200)
[  347] kblockd (struct addr:ffffffc002a64080)
[  354] ata_sff (struct addr:ffffffc0020dd140)
[  360] cfg80211 (struct addr:ffffffc0020e8540)
[  482] rpciod (struct addr:ffffffc002114040)
[  517] kswapd0 (struct addr:ffffffc001c17100)
[  518] fsnotify_mark (struct addr:ffffffc001c164c0)
[  519] nfsiod (struct addr:ffffffc0023a3140)
[  523] xfsalloc (struct addr:ffffffc00227b1c0)
[  525] xfs_mru_cache (struct addr:ffffffc0021f5200)
[  555] kthrotld (struct addr:ffffffc00210ce80)
[  608] khvcd (struct addr:ffffffc0022c4180)
[  725] kpsmoused (struct addr:ffffffc0020fd200)
[  744] dm_bufio_cache (struct addr:ffffffc002305140)
[  759] ipv6_addrconf (struct addr:ffffffc00208efc0)
[  760] krfcommd (struct addr:ffffffc00208e380)
[  769] bioset (struct addr:ffffffc001f172c0)
[  771] deferwq (struct addr:ffffffc001f21300)
[  772] kworker/0:1H (struct addr:ffffffc001f206c0)
[  773] jbd2/xvda-8 (struct addr:ffffffc001f16680)
[  774] ext4-rsv-conver (struct addr:ffffffc001ee71c0)

