### PR TITLE
KVM: Parse segment registers

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -58,6 +58,13 @@ struct request {
     uint64_t length;    // number of bytes to read OR write
 };
 
+enum segment_type {
+  SEGMENT_SELECTOR,
+  SEGMENT_BASE,
+  SEGMENT_LIMIT,
+  SEGMENT_ATTR
+};
+
 //----------------------------------------------------------------------------
 // Helper functions
 
@@ -173,6 +180,51 @@ parse_reg_value(
     if (NULL != ptr) {
         ptr += strlen(regname) + 1;
         return (reg_t) strtoll(ptr, (char **) NULL, 16);
+    }
+    else {
+        return 0;
+    }
+}
+
+static reg_t
+parse_seg_reg_value(
+    char *regname,
+    char *ir_output,
+    int type)
+{
+    int offset;
+    int size;
+
+    if (NULL == ir_output || NULL == regname) {
+        return 0;
+    }
+
+    switch(type) {
+        case SEGMENT_SELECTOR:
+        offset = 4;
+        size = 4;
+        break;
+        case SEGMENT_BASE:
+        offset = 9;
+        size = 16;
+        break;
+        case SEGMENT_LIMIT:
+        offset = 26;
+        size = 8;
+        break;
+        case SEGMENT_ATTR:
+        offset = 35;
+        size = 8;
+        break;
+        default:
+        return 0;
+    }
+
+    char *ptr = strcasestr(ir_output, regname);
+
+    if (NULL != ptr) {
+        ptr += offset;
+        return (reg_t) strtoll(ptr, (char **) NULL, size);
     }
     else {
         return 0;
@@ -1582,6 +1634,114 @@ kvm_get_vcpureg(
             break;
         case DR7:
             *value = parse_reg_value("DR7", regs);
+            break;
+        case CS_SEL:
+            *value = parse_seg_reg_value("CS", regs, SEGMENT_SELECTOR);
+            break;
+        case DS_SEL:
+            *value = parse_seg_reg_value("DS", regs, SEGMENT_SELECTOR);
+            break;
+        case ES_SEL:
+            *value = parse_seg_reg_value("ES", regs, SEGMENT_SELECTOR);
+            break;
+        case FS_SEL:
+            *value = parse_seg_reg_value("FS", regs, SEGMENT_SELECTOR);
+            break;
+        case GS_SEL:
+            *value = parse_seg_reg_value("GS", regs, SEGMENT_SELECTOR);
+            break;
+        case SS_SEL:
+            *value = parse_seg_reg_value("SS", regs, SEGMENT_SELECTOR);
+            break;
+        case TR_SEL:
+            *value = parse_seg_reg_value("TR", regs, SEGMENT_SELECTOR);
+            break;
+        case LDTR_SEL:
+            *value = parse_seg_reg_value("LDT", regs, SEGMENT_SELECTOR);
+            break;
+        case CS_LIMIT:
+            *value = parse_seg_reg_value("CS", regs, SEGMENT_LIMIT);
+            break;
+        case DS_LIMIT:
+            *value = parse_seg_reg_value("DS", regs, SEGMENT_LIMIT);
+            break;
+        case ES_LIMIT:
+            *value = parse_seg_reg_value("ES", regs, SEGMENT_LIMIT);
+            break;
+        case FS_LIMIT:
+            *value = parse_seg_reg_value("FS", regs, SEGMENT_LIMIT);
+            break;
+        case GS_LIMIT:
+            *value = parse_seg_reg_value("GS", regs, SEGMENT_LIMIT);
+            break;
+        case SS_LIMIT:
+            *value = parse_seg_reg_value("SS", regs, SEGMENT_LIMIT);
+            break;
+        case TR_LIMIT:
+            *value = parse_seg_reg_value("TR", regs, SEGMENT_LIMIT);
+            break;
+        case LDTR_LIMIT:
+            *value = parse_seg_reg_value("LDT", regs, SEGMENT_LIMIT);
+            break;
+        case IDTR_LIMIT:
+            *value = parse_seg_reg_value("IDT", regs, SEGMENT_LIMIT);
+            break;
+        case GDTR_LIMIT:
+            *value = parse_seg_reg_value("GDT", regs, SEGMENT_LIMIT);
+            break;
+        case CS_BASE:
+            *value = parse_seg_reg_value("CS", regs, SEGMENT_BASE);
+            break;
+        case DS_BASE:
+            *value = parse_seg_reg_value("DS", regs, SEGMENT_BASE);
+            break;
+        case ES_BASE:
+            *value = parse_seg_reg_value("ES", regs, SEGMENT_BASE);
+            break;
+        case FS_BASE:
+            *value = parse_seg_reg_value("FS", regs, SEGMENT_BASE);
+            break;
+        case GS_BASE:
+            *value = parse_seg_reg_value("GS", regs, SEGMENT_BASE);
+            break;
+        case SS_BASE:
+            *value = parse_seg_reg_value("SS", regs, SEGMENT_BASE);
+            break;
+        case TR_BASE:
+            *value = parse_seg_reg_value("TR", regs, SEGMENT_BASE);
+            break;
+        case LDTR_BASE:
+            *value = parse_seg_reg_value("LDT", regs, SEGMENT_BASE);
+            break;
+        case IDTR_BASE:
+            *value = parse_seg_reg_value("IDT", regs, SEGMENT_BASE);
+            break;
+        case GDTR_BASE:
+            *value = parse_seg_reg_value("GDT", regs, SEGMENT_BASE);
+            break;
+        case CS_ARBYTES:
+            *value = parse_seg_reg_value("CS", regs, SEGMENT_ATTR);
+            break;
+        case DS_ARBYTES:
+            *value = parse_seg_reg_value("DS", regs, SEGMENT_ATTR);
+            break;
+        case ES_ARBYTES:
+            *value = parse_seg_reg_value("ES", regs, SEGMENT_ATTR);
+            break;
+        case FS_ARBYTES:
+            *value = parse_seg_reg_value("FS", regs, SEGMENT_ATTR);
+            break;
+        case GS_ARBYTES:
+            *value = parse_seg_reg_value("GS", regs, SEGMENT_ATTR);
+            break;
+        case SS_ARBYTES:
+            *value = parse_seg_reg_value("SS", regs, SEGMENT_ATTR);
+            break;
+        case TR_ARBYTES:
+            *value = parse_seg_reg_value("TR", regs, SEGMENT_ATTR);
+            break;
+        case LDTR_ARBYTES:
+            *value = parse_seg_reg_value("LDT", regs, SEGMENT_ATTR);
             break;
         case MSR_EFER:
             *value = parse_reg_value("EFER", regs);


### PR DESCRIPTION
Parse the segment registers for KVM.

Without this, vmi_init will fail for Windows-based guests coupled with a Rekall profile under KVM. (#344)

I'm unsure about the validity of the ARBYTES, [since QEMU ANDs it with 0x00ffff00 in the output.](https://github.com/qemu/qemu/blob/287db79df8af8e31f18e262feb5e05103a09e4d4/target-i386/helper.c#L133)

However, the process-list and module-list examples will at least be functional.

```
Process listing for VM W10 (id=1)
[    4] System (struct addr:ffffe001fd66a840)
[  276] smss.exe (struct addr:ffffe001febb1840)
[  360] csrss.exe (struct addr:ffffe001fea41080)
[  448] wininit.exe (struct addr:ffffe001ffdc4080)
[  464] csrss.exe (struct addr:ffffe001ffdd5080)
[  512] services.exe (struct addr:ffffe001fead2840)
[  520] lsass.exe (struct addr:ffffe001ffe50080)
[  608] winlogon.exe (struct addr:ffffe001ffeb3380)
[  648] svchost.exe (struct addr:ffffe001ffe3d840)
[  708] svchost.exe (struct addr:ffffe001ffeeb6c0)
[  812] LogonUI.exe (struct addr:ffffe001fff3a080)
[  820] dwm.exe (struct addr:ffffe001fff39080)
[  876] svchost.exe (struct addr:ffffe001fff4d840)
[  920] svchost.exe (struct addr:ffffe001feefa6c0)
[  984] nvSCPAPISvr.ex (struct addr:ffffe001ffed6240)
[  992] nvvsvc.exe (struct addr:ffffe001fffb3840)
...
```