### PR TITLE
Update PyVMI example to support linux

### DIFF
--- a/tools/pyvmi/examples/process-list.py
+++ b/tools/pyvmi/examples/process-list.py
@@ -28,48 +28,41 @@ along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
 import pyvmi
 import sys
 
-def get_processes_iterator(vmi):
+def get_os_params(vmi):
     ostype = vmi.get_ostype()
     if ostype.lower() == "windows":
-        return get_processes_windows
+        return get_windows_params(vmi)
     elif ostype.lower() == "linux":
-        return get_processes_linux
+        return get_linux_params(vmi)
     else:
         print("Sorry, {} ostype is not supported in this example yet.".format(
             ostype))
         exit(1)
 
-def get_processes_linux(vmi):
+
+def get_linux_params(vmi):
     tasks_offset = vmi.get_offset("linux_tasks")
     name_offset = vmi.get_offset("linux_name") - tasks_offset
     pid_offset = vmi.get_offset("linux_pid") - tasks_offset
 
-    if vmi.get_access_mode() == 'file':
-        print("Process listing for file {}".format(vmi.get_name()))
-    else:
-        print("Process listing for VM {}".format(vmi.get_name()))
-
     list_head = vmi.translate_ksym2v("init_task")
-    next_process = vmi.read_addr_va(list_head + tasks_offset, 0)
-    list_head = next_process
 
-    while True:
-        procname = vmi.read_str_va(next_process + name_offset, 0)
-        pid = vmi.read_32_va(next_process + pid_offset, 0)
-        next_process = vmi.read_addr_va(next_process, 0)
-
-        if (pid < 1<<16):
-            yield pid, procname
-        if list_head == next_process:
-            break
+    return (tasks_offset, name_offset, pid_offset, list_head)
 
 
-def get_processes_windows(vmi):
+def get_windows_params(vmi):
     tasks_offset = vmi.get_offset("win_tasks")
     name_offset = vmi.get_offset("win_pname") - tasks_offset
     pid_offset = vmi.get_offset("win_pid") - tasks_offset
 
     list_head = vmi.read_addr_ksym("PsInitialSystemProcess")
+
+    return (tasks_offset, name_offset, pid_offset, list_head)
+
+
+def processes(vmi):
+    tasks_offset, name_offset, pid_offset, list_head = get_os_params(vmi)
+
     next_process = vmi.read_addr_va(list_head + tasks_offset, 0)
     list_head = next_process
 
@@ -83,10 +76,14 @@ def get_processes_windows(vmi):
         if (list_head == next_process):
             break
 
-
 def main(argv):
     vmi = pyvmi.init(argv[1], "complete")
-    processes = get_processes_iterator(vmi)
+
+    if vmi.get_access_mode() == 'file':
+        print("Process listing for File {}".format(vmi.get_name()))
+    else:
+        print("Process listing for VM {}".format(vmi.get_name()))
+
     for pid, procname in processes(vmi):
         print "[%5d] %s" % (pid, procname)
 


### PR DESCRIPTION
This updates the pyvmi example to check for ostype and then get offsets specific to the os. Currently there is no check for the os type and the example errors out when calling `vmi.get_offset("win_tasks")` .