### PR TITLE
Add new events from Xen 4.8

### DIFF
--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -129,6 +129,15 @@ typedef struct driver_interface {
         uint32_t);
     status_t (*shutdown_single_step_ptr)(
         vmi_instance_t);
+    status_t (*set_guest_requested_ptr)(
+        vmi_instance_t,
+        bool enabled);
+    status_t (*set_cpuid_event_ptr)(
+        vmi_instance_t,
+        bool enabled);
+    status_t (*set_debug_event_ptr)(
+        vmi_instance_t,
+        bool enabled);
 
     /* Driver-specific data storage. */
     void* driver_data;

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -454,5 +454,47 @@ driver_shutdown_single_step(
     }
 }
 
+static inline status_t
+driver_set_guest_requested_event(
+    vmi_instance_t vmi,
+    bool enabled)
+{
+    if (vmi->driver.initialized && vmi->driver.set_guest_requested_ptr)
+        return vmi->driver.set_guest_requested_ptr(vmi, enabled);
+    else
+    {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_guest_requested function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_set_cpuid_event(
+    vmi_instance_t vmi,
+    bool enabled)
+{
+    if (vmi->driver.initialized && vmi->driver.set_cpuid_event_ptr)
+        return vmi->driver.set_cpuid_event_ptr(vmi, enabled);
+    else
+    {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_cpuid_event function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_set_debug_event(
+    vmi_instance_t vmi,
+    bool enabled)
+{
+    if (vmi->driver.initialized && vmi->driver.set_debug_event_ptr)
+        return vmi->driver.set_debug_event_ptr(vmi, enabled);
+    else
+    {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_debug_event function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
 #endif /* DRIVER_WRAPPER_H */
 

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -33,6 +33,9 @@
 #define HVM_PARAM_ACCESS_RING_PFN 28
 #endif
 
+#define X86_TRAP_DEBUG  1
+#define X86_TRAP_INT3   3
+
 #ifdef HAVE_XENMEM_ACCESS_T
 #include <xen/memory.h>
 

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -138,6 +138,9 @@ status_t xen_set_mem_access(vmi_instance_t vmi,
                             mem_access_event_t *event,
                             vmi_mem_access_t page_access_flag,
                             uint16_t vmm_pagetable_id);
+status_t xen_set_guest_requested_event(vmi_instance_t vmi, bool enabled);
+status_t xen_set_debug_event(vmi_instance_t vmi, bool enabled);
+status_t xen_set_cpuid_event(vmi_instance_t vmi, bool enabled);
 status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event);
 status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu);
 status_t xen_shutdown_single_step(vmi_instance_t vmi);

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -319,6 +319,48 @@ done:
     return rc;
 }
 
+status_t register_guest_requested_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( !vmi->guest_requested_event )
+    {
+        rc = driver_set_guest_requested_event(vmi, 1);
+        if ( VMI_SUCCESS == rc )
+            vmi->guest_requested_event = event;
+    };
+
+    return rc;
+}
+
+status_t register_cpuid_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( !vmi->cpuid_event )
+    {
+        rc = driver_set_cpuid_event(vmi, 1);
+        if ( VMI_SUCCESS == rc )
+            vmi->cpuid_event = event;
+    };
+
+    return rc;
+}
+
+status_t register_debug_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( !vmi->debug_event )
+    {
+        rc = driver_set_cpuid_event(vmi, 1);
+        if ( VMI_SUCCESS == rc )
+            vmi->debug_event = event;
+    };
+
+    return rc;
+}
+
 status_t clear_interrupt_event(vmi_instance_t vmi, vmi_event_t *event)
 {
 
@@ -410,6 +452,48 @@ status_t clear_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
     return rc;
 }
 
+status_t clear_guest_requested_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( vmi->guest_requested_event ) {
+        rc = driver_set_guest_requested_event(vmi, 0);
+
+        if ( VMI_SUCCESS == rc )
+            vmi->guest_requested_event = NULL;
+    }
+
+    return rc;
+}
+
+status_t clear_cpuid_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( vmi->cpuid_event ) {
+        rc = driver_set_cpuid_event(vmi, 0);
+
+        if ( VMI_SUCCESS == rc)
+            vmi->cpuid_event = NULL;
+    }
+
+    return rc;
+}
+
+status_t clear_debug_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( vmi->debug_event ) {
+        rc = driver_set_debug_event(vmi, 0);
+
+        if ( VMI_SUCCESS == rc )
+            vmi->debug_event = NULL;
+    }
+
+    return rc;
+}
+
 //----------------------------------------------------------------------------
 // Public event functions.
 
@@ -458,6 +542,15 @@ status_t vmi_register_event(vmi_instance_t vmi, vmi_event_t* event)
         break;
     case VMI_EVENT_INTERRUPT:
         rc = register_interrupt_event(vmi, event);
+        break;
+    case VMI_EVENT_GUEST_REQUEST:
+        rc = register_guest_requested_event(vmi, event);
+        break;
+    case VMI_EVENT_CPUID:
+        rc = register_cpuid_event(vmi, event);
+        break;
+    case VMI_EVENT_DEBUG_EXCEPTION:
+        rc = register_debug_event(vmi, event);
         break;
     default:
         dbprint(VMI_DEBUG_EVENTS, "Unknown event type: %d\n", event->type);

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -150,6 +150,12 @@ struct vmi_instance {
 
     int event_listener_required; /**< Non-zero if event listener is required for the domain to run */
 
+    vmi_event_t *guest_requested_event; /**< Handler of guest-requested events */
+
+    vmi_event_t *cpuid_event; /**< Handler of CPUID events */
+
+    vmi_event_t *debug_event; /**< Handler of debug exception events */
+
     GHashTable *interrupt_events; /**< interrupt event to function mapping (key: interrupt) */
 
     GHashTable *mem_events; /**< mem event to functions mapping (key: physical address) */
@@ -162,11 +168,12 @@ struct vmi_instance {
 
     uint32_t step_vcpus[MAX_SINGLESTEP_VCPUS]; /**< counter of events on vcpus for which we have internal singlestep enabled */
 
-    gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
-
     gboolean event_callback; /**< flag indicating that libvmi is currently issuing an event callback */
 
     GHashTable *clear_events; /**< table to save vmi_clear_event requests when event_callback is set */
+
+    gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
+
 };
 
 /** Event singlestep reregister wrapper */


### PR DESCRIPTION
New types of events:
 - Guest-requested event (available on Xen via HVMOP Hypercall since 4.6).
 - Debug exception events
 - CPUID events