### PR TITLE
LibVMI Xen backwards compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,13 +73,6 @@ AC_ARG_ENABLE([xen],
       [enable_xen=yes])
 AM_CONDITIONAL([XEN], [test x"$enable_xen" = xyes])
 
-AC_ARG_ENABLE([xen_events],
-      [AS_HELP_STRING([--enable-xen-events],
-         [Support use of Xen memory events (default is no)])],
-      [enable_xen_events=$enableval],
-      [enable_xen_events=yes])
-AM_CONDITIONAL([XEN_EVENTS], [test x"$enable_xen_events" = xyes])
-
 AC_ARG_WITH([xenstore],
       [AS_HELP_STRING([--without-xenstore],
          [Build LibVMI without Xenstore])],
@@ -161,12 +154,10 @@ PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.16])
 AC_SUBST([GLIB_CFLAGS])
 AC_SUBST([GLIB_LIBS])
 AC_CHECK_LIB(m, ceil)
+AC_CHECK_LIB(dl, dlopen)
 
 have_xen='no'
 xen_space='      '
-have_xen_events='no'
-have_xen_events_legacy='no'
-xen_event_space=' '
 [if test "$enable_xen" = "yes"]
 [then]
 
@@ -184,7 +175,6 @@ xen_event_space=' '
         enable_xen='no'
         have_xen='missing xenstore'
     [else]
-        AC_CHECK_LIB(xenctrl, xc_domain_maximum_gpfn, [AC_DEFINE([HAVE_XC_DOMAIN_MAXIMUM_GPFN],[1],"xenctrl has xc_domain_maximum_gpfn")],[missing="no"])
         AC_CHECK_LIB(xenctrl, xc_interface_open, [], [missing="yes"])
         [if test "$missing" = "yes"]
         [then]
@@ -197,143 +187,23 @@ xen_event_space=' '
             have_xen='yes'
             xen_space='     '
 
-            [if test "$enable_xen_events" = "yes"]
-            [then]
-
-                have_xc_mem_event_enable='no'
-                have_xc_mem_access_enable='no'
-                have_xc_monitor_enable='no'
-                have_hvmmem_access_t='no'
-                have_xenmem_access_t='no'
-
-                # Check for xen events capability (only relevant if Xen is enabled).
-                AC_CHECK_LIB(xenctrl,
-                    [xc_monitor_enable],
-                    [
-                        have_xc_monitor_enable='yes'
-                        AC_DEFINE([HAVE_XC_MONITOR_ENABLE], [1], "xenctrl has xc_monitor_enable")
-                    ]
-                )
-
-                [if test "$have_xc_monitor_enable" = "no"]
-                [then]
-                    AC_CHECK_LIB(xenctrl,
-                        [xc_mem_event_enable],
-                        [
-                            have_xc_mem_event_enable='yes'
-                            AC_DEFINE([HAVE_XC_MEM_EVENT_ENABLE], [1], "xenctrl has xc_mem_event_enable")
-                        ]
-                    )
-                [fi]
-
-                [if test "$have_xc_monitor_enable" = "no" && test "$have_xc_mem_event_enable" = "no"]
-                [then]
-                    AC_CHECK_LIB(xenctrl,
-                        [xc_mem_access_enable],
-                        [
-                            have_xc_mem_access_enable='yes'
-                            AC_DEFINE([HAVE_XC_MEM_ACCESS_ENABLE], [1], "xenctrl has xc_mem_access_enable")
-                        ]
-                    )
-                [fi]
-
-
-                # MSR events are only available in Xen 4.3+
-                [if test "$have_xc_monitor_enable" = "no"]
-                [then]
-                    AC_CHECK_HEADERS([xen/mem_event.h],
-                        [
-                            AC_DEFINE([HAVE_MEM_EVENT_H], [1], "Xen provides mem_event.h")
-                            AC_CHECK_DEFINE(MEM_EVENT_REASON_MSR, xen/mem_event.h)
-                        ]
-                    )
-                [else]
-                    AC_CHECK_HEADERS([xen/vm_event.h],
-                        [
-                            AC_DEFINE([HAVE_VM_EVENT_H], [1], "Xen provides vm_event.h")
-                            AC_CHECK_DEFINE(VM_EVENT_INTERFACE_VERSION, xen/vm_event.h)
-                        ]
-                    )
-                [fi]
-
-                AC_CHECK_DEFINE(XENCTRL_HAS_XC_INTERFACE, xenctrl.h) 
-
-                AC_CHECK_TYPE(
+            AC_CHECK_TYPE(
                     [hvmmem_access_t],
                     [
                         have_hvmmem_access_t='yes'
-                        AC_DEFINE([HAVE_HVMMEM_ACCESS_T], [1], [xenctrl defines hvmmem_access_t])],
+                        AC_DEFINE([HAVE_HVMMEM_ACCESS_T], [1], [xen headers define hvmmem_access_t])],
                     [],
                     [#include <xenctrl.h> #include <xen/hvm/save.h>]
                 )
 
-                AC_CHECK_TYPE(
+            AC_CHECK_TYPE(
                     [xenmem_access_t],
                     [
                         have_xenmem_access_t='yes'
-                        AC_DEFINE([HAVE_XENMEM_ACCESS_T], [1], [xenctrl defines xenmem_access_t])],
+                        AC_DEFINE([HAVE_XENMEM_ACCESS_T], [1], [xen headers define xenmem_access_t])],
                     [],
                     [#include <xenctrl.h> #include <xen/memory.h>]
                 )
-
-                #validate that Xen events are in fact possible
-                [if test "$have_XENCTRL_HAS_XC_INTERFACE" != "yes"]
-                [then]
-                    AC_MSG_WARN([XENCTRL_HAS_XC_INTERFACE undefined, event support disabled.])
-                    have_xen_events='missing event support'
-                    enable_xen_events='no'
-                [else] 
-                    [if test "$have_xc_mem_event_enable" = "yes" && test "$have_hvmmem_access_t" = "yes"]
-                    [then]
-                        have_xen_events='yes'
-                        have_xen_events_legacy='yes'
-                        xen_event_space=''
-                        AC_DEFINE([ENABLE_XEN_EVENTS], [1], [Define to 1 to enable Xen mem events support.])
-                        AC_DEFINE([XEN_EVENTS_VERSION], [410], [Define the xen events version.])
-                        AC_MSG_NOTICE([4.1 style events enabled.])
-                    [else]
-                        [if test "$have_xc_mem_access_enable" = "yes"]
-                        [then]
-                            [if test "$have_hvmmem_access_t" = "yes"]
-                            [then]
-                                have_xen_events='yes'
-                                have_xen_events_legacy='yes'
-                                xen_event_space=''
-                                AC_DEFINE([ENABLE_XEN_EVENTS], [1], [Define to 1 to enable Xen mem events support.])
-                                AC_DEFINE([XEN_EVENTS_VERSION], [420], [Define the xen events version.])
-                                AC_MSG_NOTICE([4.2 style events enabled.])
-                            [else]
-                                [if test "$have_xenmem_access_t" = "yes"]
-                                [then]
-                                    have_xen_events='yes'
-                                    have_xen_events_legacy='yes'
-                                    xen_event_space=''
-                                    AC_DEFINE([ENABLE_XEN_EVENTS], [1], [Define to 1 to enable Xen mem events support.])
-                                    AC_DEFINE([XEN_EVENTS_VERSION], [450], [Define the xen events version.])
-                                    AC_MSG_NOTICE([4.5 style events enabled.])
-                                [else]
-                                    AC_MSG_WARN([Xen event support missing.])
-                                    have_xen_events='missing event support'
-                                    enable_xen_events='no'
-                                [fi]
-                            [fi]
-                        [else]
-                            [if test "$have_xc_monitor_enable" = "yes"]
-                            [then]
-                                    have_xen_events='yes'
-                                    xen_event_space=''
-                                    AC_DEFINE([ENABLE_XEN_EVENTS], [1], [Define to 1 to enable Xen mem events support.])
-                                    AC_DEFINE([XEN_EVENTS_VERSION], [460], [Define the xen events version.])
-                                    AC_MSG_NOTICE([4.6 style events enabled.])
-                            [else]
-                                AC_MSG_WARN([Xen event support missing.])
-                                have_xen_events='missing event support'
-                                enable_xen_events='no'
-                            [fi]
-                        [fi]    
-                    [fi]
-                [fi]
-            [fi]
         [fi]
     [fi]
 
@@ -344,8 +214,6 @@ xen_event_space=' '
         [#include "xenctrl.h"])
 [fi]
 AM_CONDITIONAL([HAVE_XEN], [test x"$have_xen" = "xyes"])
-AM_CONDITIONAL([HAVE_XEN_EVENTS], [test x"$have_xen_events" = "xyes"])
-AM_CONDITIONAL([HAVE_XEN_EVENTS_LEGACY], [test x"$have_xen_events_legacy" = "xyes"])
 
 have_kvm='no'
 kvm_space='      '
@@ -511,13 +379,12 @@ Installation prefix: $prefix
 Feature      | Option                    | Reason
 -------------|---------------------------|----------------------------
 Xen Support  | --enable-xen=$enable_xen$xen_space     | $have_xen
-Xen Events   | --enable-xen-events=$enable_xen_events$xen_event_space   | $have_xen_events
 KVM Support  | --enable-kvm=$enable_kvm$kvm_space     | $have_kvm
 File Support | --enable-file=$enable_file$file_space    | $have_file
 Shm-snapshot | --enable-shm-snapshot=$enable_shm_snapshot$shm_snapshot_space | $have_shm_snapshot
 -------------|---------------------------|----------------------------
 
-OS           | Option                    
+OS           | Option
 -------------|--------------------------------------------------------
 Windows      | --enable-windows=$enable_windows
 Linux        | --enable-linux=$enable_linux

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -65,22 +65,15 @@ endif
 endif
 
 if HAVE_XEN
+h_public    += events.h
 drivers     += driver/xen/xen.h \
                driver/xen/xen_private.h \
-               driver/xen/xen.c
-
-if HAVE_XEN_EVENTS
-h_public    += events.h
-drivers     += driver/xen/xen_events.h \
-               driver/xen/xen_events_private.h
-
-if HAVE_XEN_EVENTS_LEGACY
-drivers     += driver/xen/xen_events_legacy.c
-else
-drivers     += driver/xen/xen_events.c
-endif
-
-endif
+               driver/xen/xen.c \
+               driver/xen/xen_events.h \
+               driver/xen/xen_events_private.h \
+               driver/xen/xen_events.c \
+               driver/xen/xen_events_legacy.c \
+               driver/xen/libxc_wrapper.c
 endif
 
 os =

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -525,13 +525,8 @@ vmi_init_private(
     }
 
     if(init_mode & VMI_INIT_EVENTS) {
-#if ENABLE_XEN_EVENTS == 1
         /* Enable event handlers */
         events_init(*vmi);
-#else
-        errprint("LibVMI wasn't compiled with events support!\n");
-        status = VMI_FAILURE;
-#endif
     }
 
 error_exit:

--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -1,0 +1,129 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel <tamas.lengyel@zentific.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "xen_private.h"
+
+static inline status_t sanity_check(xen_instance_t *xen)
+{
+    status_t ret = VMI_FAILURE;
+    libxc_wrapper_t *w = &xen->libxcw;
+
+    if ( xen->major_version != 4 )
+        return ret;
+
+    switch ( xen->minor_version )
+    {
+        case 1:
+            if ( !w->xc_domain_maximum_gpfn )
+                break;
+
+            ret = VMI_SUCCESS;
+            break;
+        case 2:
+        case 3:
+        case 4:
+            if ( !w->xc_domain_maximum_gpfn || !w->xc_map_foreign_batch ||
+                 !w->xc_mem_access_enable || !w->xc_mem_access_disable ||
+                 !w->xc_mem_access_resume || !w->xc_hvm_set_mem_access ||
+                 !w->xc_hvm_get_mem_access )
+                break;
+
+            ret = VMI_SUCCESS;
+            break;
+
+        case 5:
+            if ( !w->xc_domain_maximum_gpfn || !w->xc_set_mem_access ||
+                 !w->xc_get_mem_access || !w->xc_mem_access_enable2 ||
+                 !w->xc_mem_access_disable || !w->xc_mem_access_disable )
+                break;
+
+            ret = VMI_SUCCESS;
+            break;
+
+        /* Things start to be a bit saner from 4.6 */
+        case 8:
+            if ( !w->xc_monitor_debug_exceptions || !w->xc_monitor_cpuid )
+                break;
+            /* Fall-through */
+        case 7:
+            /* Fall-through */
+        case 6:
+            if ( !w->xc_domain_maximum_gpfn2 || !w->xc_set_mem_access ||
+                 !w->xc_get_mem_access || !w->xc_monitor_enable ||
+                 !w->xc_monitor_disable || !w->xc_monitor_resume ||
+                 !w->xc_monitor_get_capabilities || !w->xc_monitor_write_ctrlreg ||
+                 !w->xc_monitor_mov_to_msr || !w->xc_monitor_singlestep ||
+                 !w->xc_monitor_software_breakpoint || !w->xc_monitor_guest_request ||
+                 !w->xc_altp2m_set_mem_access )
+                break;
+
+            ret = VMI_SUCCESS;
+            break;
+        default:
+            break;
+    };
+
+    return ret;
+}
+
+status_t create_libxc_wrapper(xen_instance_t *xen)
+{
+    libxc_wrapper_t *wrapper = &xen->libxcw;
+
+    memset ( wrapper, 0, sizeof(libxc_wrapper_t) );
+
+    wrapper->handle = dlopen ("libxenctrl.so", RTLD_NOW | RTLD_GLOBAL);
+
+    if ( !wrapper->handle )
+    {
+        fprintf(stderr, "Failed to find a suitable libxenctrl.so at any of the standard paths!\n");
+        return VMI_FAILURE;
+    }
+
+    wrapper->xc_domain_maximum_gpfn = dlsym(wrapper->handle, "xc_domain_maximum_gpfn");
+    wrapper->xc_domain_maximum_gpfn2 = dlsym(wrapper->handle, "xc_domain_maximum_gpfn");
+    wrapper->xc_map_foreign_batch = dlsym(wrapper->handle, "xc_map_foreign_batch");
+    wrapper->xc_hvm_set_mem_access = dlsym(wrapper->handle, "xc_hvm_set_mem_access");
+    wrapper->xc_hvm_get_mem_access = dlsym(wrapper->handle, "xc_hvm_get_mem_access");
+    wrapper->xc_set_mem_access = dlsym(wrapper->handle, "xc_set_mem_access");
+    wrapper->xc_get_mem_access = dlsym(wrapper->handle, "xc_get_mem_access");
+    wrapper->xc_mem_access_enable = dlsym(wrapper->handle, "xc_mem_access_enable");
+    wrapper->xc_mem_access_enable2 = dlsym(wrapper->handle, "xc_mem_access_enable");
+    wrapper->xc_mem_access_disable = dlsym(wrapper->handle, "xc_mem_access_disable");
+    wrapper->xc_mem_access_resume = dlsym(wrapper->handle, "xc_mem_access_resume");
+    wrapper->xc_monitor_enable = dlsym(wrapper->handle, "xc_monitor_enable");
+    wrapper->xc_monitor_disable = dlsym(wrapper->handle, "xc_monitor_disable");
+    wrapper->xc_monitor_resume = dlsym(wrapper->handle, "xc_monitor_resume");
+    wrapper->xc_monitor_get_capabilities = dlsym(wrapper->handle, "xc_monitor_get_capabilities");
+    wrapper->xc_monitor_write_ctrlreg = dlsym(wrapper->handle, "xc_monitor_write_ctrlreg");
+    wrapper->xc_monitor_mov_to_msr = dlsym(wrapper->handle, "xc_monitor_mov_to_msr");
+    wrapper->xc_monitor_singlestep = dlsym(wrapper->handle, "xc_monitor_singlestep");
+    wrapper->xc_monitor_software_breakpoint = dlsym(wrapper->handle, "xc_monitor_software_breakpoint");
+    wrapper->xc_monitor_guest_request = dlsym(wrapper->handle, "xc_monitor_guest_request");
+    wrapper->xc_altp2m_set_mem_access = dlsym(wrapper->handle, "xc_altp2m_set_mem_access");
+    wrapper->xc_monitor_debug_exceptions = dlsym(wrapper->handle, "xc_monitor_debug_exceptions");
+    wrapper->xc_monitor_cpuid = dlsym(wrapper->handle, "xc_monitor_cpuid");
+
+    return sanity_check(xen);
+}

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -1,0 +1,117 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel <tamas.lengyel@zentific.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <xenctrl.h>
+#include <dlfcn.h>
+
+#include "libvmi.h"
+#include "xen_events_abi.h"
+
+struct xen_instance;
+typedef struct xen_instance xen_instance_t;
+
+typedef struct {
+    void *handle;
+
+    /* Xen 4.1 - Xen 4.5 */
+    int (*xc_domain_maximum_gpfn)
+            (xc_interface *xch, domid_t domid);
+
+    /* Xen 4.6+ */
+    int (*xc_domain_maximum_gpfn2)
+            (xc_interface *xch, domid_t domid, xen_pfn_t *gpfns);
+
+    /* Xen 4.1 - Xen 4.4 */
+    void* (*xc_map_foreign_batch)
+            (xc_interface *xch, uint32_t dom, int prot, xen_pfn_t *arr, int num);
+
+    /* Xen 4.1 - 4.4 */
+    int (*xc_hvm_set_mem_access)
+            (xc_interface *xch, domid_t dom, hvmmem_access_t memaccess, uint64_t first_pfn, uint64_t nr);
+
+    int (*xc_hvm_get_mem_access)
+            (xc_interface *xch, domid_t dom, uint64_t pfn, hvmmem_access_t* memaccess);
+
+    /* Xen 4.5+ */
+    int (*xc_set_mem_access)
+            (xc_interface *xch, domid_t domain_id, xenmem_access_t access, uint64_t first_pfn, uint32_t nr);
+
+    int (*xc_get_mem_access)
+            (xc_interface *xch, domid_t domain_id, uint64_t pfn, xenmem_access_t *access);
+
+    /* Xen 4.1 - Xen 4.4 */
+    int (*xc_mem_access_enable)
+            (xc_interface *xch, domid_t domain_id, uint32_t *port);
+
+    /* Xen 4.5 */
+    void* (*xc_mem_access_enable2)
+            (xc_interface *xch, domid_t domain_id, uint32_t *port);
+
+    /* Xen 4.1+ */
+    int (*xc_mem_access_disable)
+            (xc_interface *xch, domid_t domain_id);
+
+    int (*xc_mem_access_resume)
+            (xc_interface *xch, domid_t domain_id);
+
+    /* Xen 4.6+ */
+    void* (*xc_monitor_enable)
+            (xc_interface *xch, domid_t domain_id, uint32_t *port);
+
+    int (*xc_monitor_disable)
+            (xc_interface *xch, domid_t domain_id);
+
+    int (*xc_monitor_resume)
+            (xc_interface *xch, domid_t domain_id);
+
+    int (*xc_monitor_get_capabilities)
+            (xc_interface *xch, domid_t domain_id, uint32_t *capabilities);
+
+    int (*xc_monitor_write_ctrlreg)
+            (xc_interface *xch, domid_t domain_id, uint16_t index, bool enable, bool sync, bool onchangeonly);
+
+    int (*xc_monitor_mov_to_msr)
+            (xc_interface *xch, domid_t domain_id, uint32_t msr, bool enable);
+
+    int (*xc_monitor_singlestep)
+            (xc_interface *xch, domid_t domain_id, bool enable);
+
+    int (*xc_monitor_software_breakpoint)
+            (xc_interface *xch, domid_t domain_id, bool enable);
+
+    int (*xc_monitor_guest_request)
+            (xc_interface *xch, domid_t domain_id, bool enable, bool sync);
+
+    int (*xc_altp2m_set_mem_access)
+        (xc_interface *handle, domid_t domid, uint16_t view_id, xen_pfn_t gfn, xenmem_access_t access);
+
+    /* Xen 4.8+ */
+    int (*xc_monitor_debug_exceptions)
+            (xc_interface *xch, domid_t domain_id, bool enable, bool sync);
+
+    int (*xc_monitor_cpuid)
+            (xc_interface *xch, domid_t domain_id, bool enable);
+
+} libxc_wrapper_t;
+
+status_t create_libxc_wrapper(xen_instance_t *xen);

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -539,7 +539,7 @@ xen_get_domainid_from_name(
     uint64_t domainid = VMI_INVALID_DOMID;
     char *tmp;
 
-    struct xs_handle *xsh = OPEN_XS_DAEMON();
+    struct xs_handle *xsh = xs_open(0);
 
     if (!xsh)
         goto _bail;
@@ -572,7 +572,7 @@ _bail:
     if (domains)
         free(domains);
     if (xsh)
-        CLOSE_XS_DAEMON(xsh);
+        xs_close(xsh);
     return domainid;
 #endif
 }
@@ -599,7 +599,7 @@ xen_get_name_from_domainid(
     int i = 0;
     xs_transaction_t xth = XBT_NULL;
 
-    struct xs_handle *xsh = OPEN_XS_DAEMON();
+    struct xs_handle *xsh = xs_open(0);
 
     if (!xsh)
         goto _bail;
@@ -616,7 +616,7 @@ xen_get_name_from_domainid(
 
 _bail:
     if (xsh)
-        CLOSE_XS_DAEMON(xsh);
+        xs_close(xsh);
     return ret;
 #endif
 }
@@ -795,7 +795,7 @@ xen_init(
     /* initialize other xen-specific values */
 
 #ifdef HAVE_LIBXENSTORE
-    xen->xshandle = OPEN_XS_DAEMON();
+    xen->xshandle = xs_open(0);
     if (!xen->xshandle) {
         errprint("xs_domain_open failed\n");
         xc_interface_close(xchandle);
@@ -959,7 +959,7 @@ xen_destroy(
 
 #ifdef HAVE_LIBXENSTORE
     if(xen->xshandle) {
-        CLOSE_XS_DAEMON(xen->xshandle);
+        xs_close(xen->xshandle);
     }
 #endif
 

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -137,16 +137,6 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.destroy_shm_snapshot_ptr = &xen_destroy_shm_snapshot;
     driver.get_dgpma_ptr = &xen_get_dgpma;
 #endif
-#if ENABLE_XEN_EVENTS == 1
-    driver.events_listen_ptr = &xen_events_listen;
-    driver.are_events_pending_ptr = &xen_are_events_pending;
-    driver.set_reg_access_ptr = &xen_set_reg_access;
-    driver.set_intr_access_ptr = &xen_set_intr_access;
-    driver.set_mem_access_ptr = &xen_set_mem_access;
-    driver.start_single_step_ptr = &xen_start_single_step;
-    driver.stop_single_step_ptr = &xen_stop_single_step;
-    driver.shutdown_single_step_ptr = &xen_shutdown_single_step;
-#endif
     vmi->driver = driver;
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -66,6 +66,7 @@ xen_events_t *xen_get_events(vmi_instance_t vmi)
     return xen_get_instance(vmi)->events;
 }
 
+static
 int wait_for_event_or_timeout(xc_interface *xch,
                               xc_evtchn *xce,
                               unsigned long ms)
@@ -113,12 +114,12 @@ int wait_for_event_or_timeout(xc_interface *xch,
 
 static inline
 void get_request(xen_vm_event_t *mem_event,
-                 vm_event_request_t *req)
+                 vm_event_46_request_t *req)
 {
-    vm_event_back_ring_t *back_ring;
+    vm_event_46_back_ring_t *back_ring;
     RING_IDX req_cons;
 
-    back_ring = &mem_event->back_ring;
+    back_ring = &mem_event->back_ring_46;
     req_cons = back_ring->req_cons;
 
     // Copy request
@@ -132,12 +133,12 @@ void get_request(xen_vm_event_t *mem_event,
 
 static inline
 void put_response(xen_vm_event_t *mem_event,
-                  vm_event_response_t *rsp)
+                  vm_event_46_response_t *rsp)
 {
-    vm_event_back_ring_t *back_ring;
+    vm_event_46_back_ring_t *back_ring;
     RING_IDX rsp_prod;
 
-    back_ring = &mem_event->back_ring;
+    back_ring = &mem_event->back_ring_46;
     rsp_prod = back_ring->rsp_prod_pvt;
 
     // Copy response
@@ -176,7 +177,7 @@ static int resume_domain(vmi_instance_t vmi)
  * that allows triggering Xen vm_event response flags.
  */
 static inline
-void process_response ( event_response_t response, vmi_event_t* event, vm_event_request_t *rsp )
+void process_response ( event_response_t response, vmi_event_t* event, vm_event_46_request_t *rsp )
 {
     if ( response && event ) {
         uint32_t i = VMI_EVENT_RESPONSE_NONE+1;
@@ -217,10 +218,11 @@ void process_response ( event_response_t response, vmi_event_t* event, vm_event_
     }
 }
 
+static
 status_t process_interrupt_event(vmi_instance_t vmi,
                                  interrupts_t intr,
-                                 vm_event_request_t *req,
-                                 vm_event_request_t *rsp)
+                                 vm_event_46_request_t *req,
+                                 vm_event_46_request_t *rsp)
 {
     int rc              = -1;
     status_t status     = VMI_FAILURE;
@@ -343,8 +345,8 @@ status_t process_interrupt_event(vmi_instance_t vmi,
 static inline
 status_t process_register(vmi_instance_t vmi,
                           registers_t reg,
-                          vm_event_request_t *req,
-                          vm_event_request_t *rsp)
+                          vm_event_46_request_t *req,
+                          vm_event_46_request_t *rsp)
 {
     vmi_event_t * event = g_hash_table_lookup(vmi->reg_events, &reg);
 
@@ -389,7 +391,7 @@ status_t process_register(vmi_instance_t vmi,
 static inline
 event_response_t issue_mem_cb(vmi_instance_t vmi,
                   vmi_event_t *event,
-                  vm_event_request_t *req,
+                  vm_event_46_request_t *req,
                   vmi_mem_access_t out_access)
 {
     event->mem_event.gla = req->u.mem_access.gla;
@@ -400,9 +402,10 @@ event_response_t issue_mem_cb(vmi_instance_t vmi,
     return event->callback(vmi, event);
 }
 
+static
 status_t process_mem(vmi_instance_t vmi,
-                     vm_event_request_t *req,
-                     vm_event_response_t *rsp)
+                     vm_event_46_request_t *req,
+                     vm_event_46_response_t *rsp)
 {
 
     xc_interface * xch = xen_get_xchandle(vmi);
@@ -447,9 +450,10 @@ errdone:
     return VMI_FAILURE;
 }
 
+static
 status_t process_single_step_event(vmi_instance_t vmi,
-                                   vm_event_request_t *req,
-                                   vm_event_response_t *rsp)
+                                   vm_event_46_request_t *req,
+                                   vm_event_46_response_t *rsp)
 {
     xc_interface * xch = xen_get_xchandle(vmi);
     domid_t dom = xen_get_domainid(vmi);
@@ -488,7 +492,7 @@ status_t process_single_step_event(vmi_instance_t vmi,
 //----------------------------------------------------------------------------
 // Driver functions
 
-void xen_events_destroy(vmi_instance_t vmi)
+void xen_events_destroy_new(vmi_instance_t vmi)
 {
     int rc, resume = 0;
     xc_interface * xch = xen_get_xchandle(vmi);
@@ -520,20 +524,20 @@ void xen_events_destroy(vmi_instance_t vmi)
     //A precaution to not leave vcpus stuck in single step
     xen_shutdown_single_step(vmi);
 
-    rc = xc_set_mem_access(xch, dom, (mem_access_t)COMPAT_MEMACCESS_RWX, ~0ull, 0);
-    rc = xc_set_mem_access(xch, dom, (mem_access_t)COMPAT_MEMACCESS_RWX, 0, xen->max_gpfn);
-    rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR0, false, false, false);
-    rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR3, false, false, false);
-    rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR4, false, false, false);
-    rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_XCR0, false, false, false);
-    rc = xc_monitor_software_breakpoint(xch, dom, false);
+    rc = xen->libxcw.xc_set_mem_access(xch, dom, XENMEM_access_rwx, ~0ull, 0);
+    rc = xen->libxcw.xc_set_mem_access(xch, dom, XENMEM_access_rwx, 0, xen->max_gpfn);
+    rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR0, false, false, false);
+    rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR3, false, false, false);
+    rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR4, false, false, false);
+    rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_XCR0, false, false, false);
+    rc = xen->libxcw.xc_monitor_software_breakpoint(xch, dom, false);
 
     if ( xe->vm_event.ring_page ) {
         xen_events_listen(vmi, 0);
         munmap(xe->vm_event.ring_page, getpagesize());
     }
 
-    if ( xc_monitor_disable(xch, dom) )
+    if ( xen->libxcw.xc_monitor_disable(xch, dom) )
         errprint("Error disabling monitor vm_event ring.\n");
 
     // Unbind VIRQ
@@ -553,7 +557,7 @@ void xen_events_destroy(vmi_instance_t vmi)
         vmi_resume_vm(vmi);
 }
 
-status_t xen_events_init(vmi_instance_t vmi)
+status_t xen_init_events_new(vmi_instance_t vmi)
 {
     xen_events_t * xe = NULL;
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -574,6 +578,16 @@ status_t xen_events_init(vmi_instance_t vmi)
         return VMI_FAILURE;
     }
 
+    // Wire up the functions
+    vmi->driver.events_listen_ptr = &xen_events_listen;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending;
+    vmi->driver.set_reg_access_ptr = &xen_set_reg_access;
+    vmi->driver.set_intr_access_ptr = &xen_set_intr_access;
+    vmi->driver.set_mem_access_ptr = &xen_set_mem_access;
+    vmi->driver.start_single_step_ptr = &xen_start_single_step;
+    vmi->driver.stop_single_step_ptr = &xen_stop_single_step;
+    vmi->driver.shutdown_single_step_ptr = &xen_shutdown_single_step;
+
     // Allocate memory
     xe = g_malloc0(sizeof(xen_events_t));
     if ( !xe ) {
@@ -584,7 +598,7 @@ status_t xen_events_init(vmi_instance_t vmi)
     xen_get_instance(vmi)->events = xe;
 
     /* Enable monitor page */
-    xe->vm_event.ring_page = xc_monitor_enable(xch, dom, &xe->vm_event.evtchn_port);
+    xe->vm_event.ring_page = xen->libxcw.xc_monitor_enable(xch, dom, &xe->vm_event.evtchn_port);
     if ( !xe->vm_event.ring_page )
     {
         switch ( errno ) {
@@ -620,14 +634,14 @@ status_t xen_events_init(vmi_instance_t vmi)
 
     xe->vm_event.port = rc;
 
-    SHARED_RING_INIT((vm_event_sring_t *)xe->vm_event.ring_page);
-    BACK_RING_INIT(&xe->vm_event.back_ring,
-                   (vm_event_sring_t *)xe->vm_event.ring_page,
+    SHARED_RING_INIT((vm_event_46_sring_t *)xe->vm_event.ring_page);
+    BACK_RING_INIT(&xe->vm_event.back_ring_46,
+                   (vm_event_46_sring_t *)xe->vm_event.ring_page,
                    XC_PAGE_SIZE);
 
     /* Mem access events are always delivered via this ring */
     xe->vm_event.monitor_mem_access_on = 1;
-    xc_monitor_get_capabilities(xch, dom, &xe->vm_event.monitor_capabilities);
+    xen->libxcw.xc_monitor_get_capabilities(xch, dom, &xe->vm_event.monitor_capabilities);
 
     return VMI_SUCCESS;
 
@@ -642,6 +656,7 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
     xc_interface * xch = xen_get_xchandle(vmi);
     domid_t dom = xen_get_domainid(vmi);
     xen_events_t * xe = xen_get_events(vmi);
+    xen_instance_t * xen = xen_get_instance(vmi);
     bool sync = !event->async;
 
     if ( !xch ) {
@@ -699,8 +714,8 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
             if ( enable == xe->vm_event.monitor_cr0_on )
                 goto done;
 
-            rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR0,
-                                          enable, sync, event->onchange);
+            rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR0,
+                                                      enable, sync, event->onchange);
             if ( rc )
                 goto done;
 
@@ -710,8 +725,8 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
             if ( enable == xe->vm_event.monitor_cr3_on )
                 goto done;
 
-            rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR3,
-                                          enable, sync, event->onchange);
+            rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR3,
+                                                      enable, sync, event->onchange);
             if ( rc )
                 goto done;
 
@@ -721,8 +736,8 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
             if ( enable == xe->vm_event.monitor_cr4_on )
                 goto done;
 
-            rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR4,
-                                          enable, sync, event->onchange);
+            rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR4,
+                                                      enable, sync, event->onchange);
             if ( rc )
                 goto done;
 
@@ -731,8 +746,8 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
             if ( enable == xe->vm_event.monitor_xcr0_on )
                 goto done;
 
-            rc = xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_XCR0,
-                                          enable, sync, event->onchange);
+            rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_XCR0,
+                                                      enable, sync, event->onchange);
             if ( rc )
                 goto done;
 
@@ -742,7 +757,7 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
             if ( enable == xe->vm_event.monitor_msr_on )
                 goto done;
 
-            rc = xc_monitor_mov_to_msr(xch, dom, enable, event->extended_msr);
+            rc = xen->libxcw.xc_monitor_mov_to_msr(xch, dom, enable, event->extended_msr);
             if ( rc )
                 goto done;
 
@@ -763,7 +778,7 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
                             vmi_mem_access_t page_access_flag, uint16_t altp2m_idx)
 {
     int rc;
-    mem_access_t access;
+    xenmem_access_t access;
     xen_instance_t *xen = xen_get_instance(vmi);
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
@@ -807,15 +822,27 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
 
     // Convert betwen vmi_mem_access_t and mem_access_t
     // Xen does them backwards....
-    access = compat_memaccess_conversion[page_access_flag];
+    static const xenmem_access_t memaccess_conversion[] = {
+        [VMI_MEMACCESS_RWX] = XENMEM_access_n,
+        [VMI_MEMACCESS_WX] = XENMEM_access_r,
+        [VMI_MEMACCESS_RX] = XENMEM_access_w,
+        [VMI_MEMACCESS_X] = XENMEM_access_rw,
+        [VMI_MEMACCESS_W] = XENMEM_access_rx,
+        [VMI_MEMACCESS_R] = XENMEM_access_wx,
+        [VMI_MEMACCESS_N] = XENMEM_access_rwx,
+        [VMI_MEMACCESS_W2X] = XENMEM_access_rx2rw,
+        [VMI_MEMACCESS_RWX2N] = XENMEM_access_n2rwx,
+    };
+
+    access = memaccess_conversion[page_access_flag];
 
     dbprint(VMI_DEBUG_XEN, "--Setting memaccess for domain %"PRIu64" on physical address: %"PRIu64" npages: %"PRIu64"\n",
         dom, event->physical_address, npages);
 
     if ( !altp2m_idx )
-        rc = xc_set_mem_access(xch, dom, access, page_key, npages);
+        rc = xen->libxcw.xc_set_mem_access(xch, dom, access, page_key, npages);
     else
-        rc = xc_altp2m_set_mem_access(xch, dom, altp2m_idx, page_key, access);
+        rc = xen->libxcw.xc_altp2m_set_mem_access(xch, dom, altp2m_idx, page_key, access);
 
     if(rc) {
         errprint("xc_hvm_set_mem_access failed with code: %d\n", rc);
@@ -846,6 +873,7 @@ status_t xen_set_int3_access(vmi_instance_t vmi, bool enable)
     xc_interface * xch = xen_get_xchandle(vmi);
     domid_t dom = xen_get_domainid(vmi);
     xen_events_t *xe = xen_get_events(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
 
     if ( !xch )
     {
@@ -868,7 +896,7 @@ status_t xen_set_int3_access(vmi_instance_t vmi, bool enable)
     if ( enable == xe->vm_event.monitor_intr_on )
         return VMI_FAILURE;
 
-    if ( xc_monitor_software_breakpoint(xch, dom, enable) )
+    if ( xen->libxcw.xc_monitor_software_breakpoint(xch, dom, enable) )
         return VMI_FAILURE;
 
     xe->vm_event.monitor_intr_on = enable;
@@ -879,6 +907,7 @@ status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event)
 {
     domid_t dom = xen_get_domainid(vmi);
     xen_events_t *xe = xen_get_events(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
     int rc;
     uint32_t i;
 
@@ -892,7 +921,7 @@ status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event)
 
     if ( !xe->vm_event.monitor_singlestep_on )
     {
-        rc = xc_monitor_singlestep(xen_get_xchandle(vmi), dom, true);
+        rc = xen->libxcw.xc_monitor_singlestep(xen_get_xchandle(vmi), dom, true);
         if ( rc<0 )
         {
             errprint("Error %d setting HVM single step\n", rc);
@@ -949,6 +978,7 @@ status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu)
 status_t xen_shutdown_single_step(vmi_instance_t vmi) {
     domid_t dom = xen_get_domainid(vmi);
     xen_events_t *xe = xen_get_events(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
     int rc = -1;
     uint32_t i=0;
 
@@ -960,7 +990,7 @@ status_t xen_shutdown_single_step(vmi_instance_t vmi) {
 
     if ( xe->vm_event.monitor_singlestep_on )
     {
-        rc = xc_monitor_singlestep(xen_get_xchandle(vmi), dom,false);
+        rc = xen->libxcw.xc_monitor_singlestep(xen_get_xchandle(vmi), dom,false);
 
         if (rc<0) {
             errprint("Error %d disabling single step\n", rc);
@@ -982,30 +1012,30 @@ int xen_are_events_pending(vmi_instance_t vmi)
         return -1;
     }
 
-    return RING_HAS_UNCONSUMED_REQUESTS(&xe->vm_event.back_ring);
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->vm_event.back_ring_46);
 
 }
 
 static inline
-status_t process_requests(vmi_instance_t vmi, vm_event_request_t *req,
-                          vm_event_response_t *rsp)
+status_t process_requests(vmi_instance_t vmi, vm_event_46_request_t *req,
+                          vm_event_46_response_t *rsp)
 {
     xen_events_t * xe = xen_get_events(vmi);
     status_t vrc = VMI_SUCCESS;
 
-    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->vm_event.back_ring) ) {
-        memset( req, 0, sizeof (vm_event_request_t) );
-        memset( rsp, 0, sizeof (vm_event_response_t) );
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->vm_event.back_ring_46) ) {
+        memset( req, 0, sizeof (vm_event_46_request_t) );
+        memset( rsp, 0, sizeof (vm_event_46_response_t) );
 
         get_request(&xe->vm_event, req);
 
-        if ( req->version != VM_EVENT_INTERFACE_VERSION )
+        if ( req->version > MAX_SUPPORTED_VM_EVENT_INTERFACE_VERSION )
         {
-            errprint("Error, Xen reports a different VM_EVENT_INTERFACE_VERSION!\n");
+            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION we don't (yet) support!\n");
             return VMI_FAILURE;
         }
 
-        rsp->version = VM_EVENT_INTERFACE_VERSION;
+        rsp->version = req->version;
         rsp->vcpu_id = req->vcpu_id;
         rsp->flags = (req->flags & VM_EVENT_FLAG_VCPU_PAUSED);
         rsp->reason = req->reason;
@@ -1088,8 +1118,8 @@ status_t process_requests(vmi_instance_t vmi, vm_event_request_t *req,
 
 status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
 {
-    vm_event_request_t req;
-    vm_event_response_t rsp;
+    vm_event_46_request_t req;
+    vm_event_46_response_t rsp;
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
     domid_t dom = xen_get_domainid(vmi);

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -195,7 +195,7 @@ void process_response ( event_response_t response, vmi_event_t* event, vm_event_
                     break;
                 case VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA:
                     if ( event->emul_data ) {
-                        rsp->flags |= VMI_EVENT_RESPONSE_EMULATE;
+                        rsp->flags |= event_response_conversion[VMI_EVENT_RESPONSE_EMULATE];
 
                         if ( event->emul_data->size < sizeof(rsp->data.emul_read_data.data) )
                             rsp->data.emul_read_data.size = event->emul_data->size;

--- a/libvmi/driver/xen/xen_events.h
+++ b/libvmi/driver/xen/xen_events.h
@@ -56,18 +56,9 @@
 #ifndef XEN_EVENTS_H
 #define XEN_EVENTS_H
 
-status_t xen_events_init(vmi_instance_t vmi);
-void xen_events_destroy(vmi_instance_t vmi);
-int xen_are_events_pending(vmi_instance_t vmi);
-status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
-status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event);
-status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t *event, bool enabled);
-status_t xen_set_mem_access(vmi_instance_t vmi,
-                            mem_access_event_t *event,
-                            vmi_mem_access_t page_access_flag,
-                            uint16_t vmm_pagetable_id);
-status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event);
-status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu);
-status_t xen_shutdown_single_step(vmi_instance_t vmi);
+status_t xen_init_events_new(vmi_instance_t vmi);
+status_t xen_init_events_legacy(vmi_instance_t vmi);
+void xen_events_destroy_new(vmi_instance_t vmi);
+void xen_events_destroy_legacy(vmi_instance_t vmi);
 
 #endif

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -1,0 +1,281 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XEN_EVENTS_ABI_H
+#define XEN_EVENTS_ABI_H
+
+#include <config.h>
+#include <xen/io/ring.h>
+
+#define MAX_SUPPORTED_VM_EVENT_INTERFACE_VERSION 0x00000002
+
+#ifndef HVM_PARAM_MONITOR_RING_PFN
+#define HVM_PARAM_MONITOR_RING_PFN 28
+#endif
+#ifndef HVM_PARAM_ACCESS_RING_PFN
+#define HVM_PARAM_ACCESS_RING_PFN 28
+#endif
+
+#ifdef HAVE_XENMEM_ACCESS_T
+#include <xen/memory.h>
+
+typedef enum {
+    HVMMEM_access_n,
+    HVMMEM_access_r,
+    HVMMEM_access_w,
+    HVMMEM_access_rw,
+    HVMMEM_access_x,
+    HVMMEM_access_rx,
+    HVMMEM_access_wx,
+    HVMMEM_access_rwx,
+    HVMMEM_access_rx2rw,
+    HVMMEM_access_n2rwx,
+    HVMMEM_access_default
+} hvmmem_access_t;
+#endif
+
+#ifdef HAVE_HVMMEM_ACCESS_T
+#include <xen/hvm/hvm_op.h>
+
+typedef enum {
+    XENMEM_access_n,
+    XENMEM_access_r,
+    XENMEM_access_w,
+    XENMEM_access_rw,
+    XENMEM_access_x,
+    XENMEM_access_rx,
+    XENMEM_access_wx,
+    XENMEM_access_rwx,
+    XENMEM_access_rx2rw,
+    XENMEM_access_n2rwx,
+    XENMEM_access_default
+} xenmem_access_t;
+#endif
+
+#define HVMPME_mode_disabled   0
+#define HVMPME_mode_async      1
+#define HVMPME_mode_sync       2
+#define HVMPME_onchangeonly    (1 << 2)
+
+#define MEM_EVENT_FLAG_VCPU_PAUSED     (1 << 0)
+#define MEM_EVENT_FLAG_DROP_PAGE       (1 << 1)
+#define MEM_EVENT_FLAG_EVICT_FAIL      (1 << 2)
+#define MEM_EVENT_FLAG_FOREIGN         (1 << 3)
+#define MEM_EVENT_FLAG_DUMMY           (1 << 4)
+#define MEM_EVENT_FLAG_EMULATE         (1 << 5)
+#define MEM_EVENT_FLAG_EMULATE_NOWRITE (1 << 6)
+
+#define MEM_EVENT_REASON_UNKNOWN     0
+#define MEM_EVENT_REASON_VIOLATION   1
+#define MEM_EVENT_REASON_CR0         2
+#define MEM_EVENT_REASON_CR3         3
+#define MEM_EVENT_REASON_CR4         4
+#define MEM_EVENT_REASON_INT3        5
+#define MEM_EVENT_REASON_SINGLESTEP  6
+#define MEM_EVENT_REASON_MSR         7
+
+#define VM_EVENT_FLAG_VCPU_PAUSED        (1 << 0)
+#define VM_EVENT_FLAG_FOREIGN            (1 << 1)
+#define VM_EVENT_FLAG_EMULATE            (1 << 2)
+#define VM_EVENT_FLAG_EMULATE_NOWRITE    (1 << 3)
+#define VM_EVENT_FLAG_TOGGLE_SINGLESTEP  (1 << 4)
+#define VM_EVENT_FLAG_SET_EMUL_READ_DATA (1 << 5)
+#define VM_EVENT_FLAG_DENY               (1 << 6)
+#define VM_EVENT_FLAG_ALTERNATE_P2M      (1 << 7)
+#define VM_EVENT_FLAG_SET_REGISTERS      (1 << 8)
+
+#define VM_EVENT_REASON_UNKNOWN                 0
+#define VM_EVENT_REASON_MEM_ACCESS              1
+#define VM_EVENT_REASON_MEM_SHARING             2
+#define VM_EVENT_REASON_MEM_PAGING              3
+#define VM_EVENT_REASON_WRITE_CTRLREG           4
+#define VM_EVENT_REASON_MOV_TO_MSR              5
+#define VM_EVENT_REASON_SOFTWARE_BREAKPOINT     6
+#define VM_EVENT_REASON_SINGLESTEP              7
+#define VM_EVENT_REASON_GUEST_REQUEST           8
+#define VM_EVENT_REASON_DEBUG_EXCEPTION         9
+#define VM_EVENT_REASON_CPUID                   10
+
+#define VM_EVENT_X86_CR0    0
+#define VM_EVENT_X86_CR3    1
+#define VM_EVENT_X86_CR4    2
+#define VM_EVENT_X86_XCR0   3
+
+#define MEM_ACCESS_R                (1 << 0)
+#define MEM_ACCESS_W                (1 << 1)
+#define MEM_ACCESS_X                (1 << 2)
+#define MEM_ACCESS_RWX              (MEM_ACCESS_R | MEM_ACCESS_W | MEM_ACCESS_X)
+#define MEM_ACCESS_RW               (MEM_ACCESS_R | MEM_ACCESS_W)
+#define MEM_ACCESS_RX               (MEM_ACCESS_R | MEM_ACCESS_X)
+#define MEM_ACCESS_WX               (MEM_ACCESS_W | MEM_ACCESS_X)
+#define MEM_ACCESS_GLA_VALID        (1 << 3)
+#define MEM_ACCESS_FAULT_WITH_GLA   (1 << 4)
+#define MEM_ACCESS_FAULT_IN_GPT     (1 << 5)
+
+#define XEN_DOMCTL_MONITOR_EVENT_WRITE_CTRLREG         0
+#define XEN_DOMCTL_MONITOR_EVENT_MOV_TO_MSR            1
+#define XEN_DOMCTL_MONITOR_EVENT_SINGLESTEP            2
+#define XEN_DOMCTL_MONITOR_EVENT_SOFTWARE_BREAKPOINT   3
+#define XEN_DOMCTL_MONITOR_EVENT_GUEST_REQUEST         4
+#define XEN_DOMCTL_MONITOR_EVENT_DEBUG_EXCEPTION       5
+#define XEN_DOMCTL_MONITOR_EVENT_CPUID                 6
+
+typedef struct mem_event_st_42 {
+    uint32_t flags;
+    uint32_t vcpu_id;
+    uint64_t gfn;
+    uint64_t offset;
+    uint64_t gla;
+    uint32_t p2mt;
+    uint16_t access_r:1;
+    uint16_t access_w:1;
+    uint16_t access_x:1;
+    uint16_t gla_valid:1;
+    uint16_t available:12;
+    uint16_t reason;
+} mem_event_42_request_t, mem_event_42_response_t;
+
+struct regs_x86 {
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rbx;
+    uint64_t rsp;
+    uint64_t rbp;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t r8;
+    uint64_t r9;
+    uint64_t r10;
+    uint64_t r11;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t rflags;
+    uint64_t dr7;
+    uint64_t rip;
+    uint64_t cr0;
+    uint64_t cr2;
+    uint64_t cr3;
+    uint64_t cr4;
+    uint64_t sysenter_cs;
+    uint64_t sysenter_esp;
+    uint64_t sysenter_eip;
+    uint64_t msr_efer;
+    uint64_t msr_star;
+    uint64_t msr_lstar;
+    uint64_t fs_base;
+    uint64_t gs_base;
+    uint32_t cs_arbytes;
+    uint32_t _pad;
+};
+
+typedef struct mem_event_st_45 {
+    uint32_t flags;
+    uint32_t vcpu_id;
+    uint64_t gfn;
+    uint64_t offset;
+    uint64_t gla;
+    uint32_t p2mt;
+    uint16_t access_r:1;
+    uint16_t access_w:1;
+    uint16_t access_x:1;
+    uint16_t gla_valid:1;
+    uint16_t fault_with_gla:1;
+    uint16_t fault_in_gpt:1;
+    uint16_t available:10;
+    uint16_t reason;
+    struct regs_x86 x86_regs;
+} mem_event_45_request_t, mem_event_45_response_t;
+
+struct vm_event_mem_access {
+    uint64_t gfn;
+    uint64_t offset;
+    uint64_t gla;
+    uint32_t flags;
+    uint32_t _pad;
+};
+
+struct vm_event_write_ctrlreg {
+    uint32_t index;
+    uint32_t _pad;
+    uint64_t new_value;
+    uint64_t old_value;
+};
+
+struct vm_event_singlestep {
+    uint64_t gfn;
+};
+
+struct vm_event_debug {
+    uint64_t gfn;
+    uint32_t insn_length;
+    uint8_t type;
+    uint8_t _pad[3];
+};
+
+struct vm_event_mov_to_msr {
+    uint64_t msr;
+    uint64_t value;
+};
+
+struct vm_event_cpuid {
+    uint32_t insn_length;
+    uint32_t _pad;
+};
+
+struct vm_event_emul_read_data {
+    uint32_t size;
+    uint8_t  data[sizeof(struct regs_x86) - sizeof(uint32_t)];
+};
+
+typedef struct vm_event_st_46 {
+    uint32_t version;
+    uint32_t flags;
+    uint32_t reason;
+    uint32_t vcpu_id;
+    uint16_t altp2m_idx;
+    uint16_t _pad[3];
+
+    union {
+        struct vm_event_mem_access            mem_access;
+        struct vm_event_write_ctrlreg         write_ctrlreg;
+        struct vm_event_mov_to_msr            mov_to_msr;
+        struct vm_event_singlestep            singlestep;
+        struct vm_event_debug                 software_breakpoint;
+        struct vm_event_debug                 debug_exception;
+        struct vm_event_cpuid                 cpuid;
+    } u;
+
+    union {
+        union {
+            struct regs_x86 x86;
+        } regs;
+
+        struct vm_event_emul_read_data emul_read_data;
+    } data;
+} vm_event_46_request_t, vm_event_46_response_t;
+
+DEFINE_RING_TYPES(mem_event_42, mem_event_42_request_t, mem_event_42_response_t);
+DEFINE_RING_TYPES(mem_event_45, mem_event_45_request_t, mem_event_42_response_t);
+DEFINE_RING_TYPES(vm_event_46, vm_event_46_request_t, vm_event_46_response_t);
+
+#endif

--- a/libvmi/driver/xen/xen_events_legacy.c
+++ b/libvmi/driver/xen/xen_events_legacy.c
@@ -68,39 +68,7 @@ static inline xen_events_t *xen_get_events(vmi_instance_t vmi)
     return xen_get_instance(vmi)->events;
 }
 
-#define ADDR (*(volatile long *) addr)
-static inline int test_and_set_bit(int nr, volatile void *addr)
-{
-    int oldbit;
-    asm volatile (
-        "btsl %2,%1\n\tsbbl %0,%0"
-        : "=r" (oldbit), "=m" (ADDR)
-        : "Ir" (nr), "m" (ADDR) : "memory");
-    return oldbit;
-}
-
-/* Spinlock and mem event definitions */
-#define SPIN_LOCK_UNLOCKED 0
-
-static inline void spin_lock(spinlock_t *lock)
-{
-    while ( test_and_set_bit(1, lock) );
-}
-
-static inline void spin_lock_init(spinlock_t *lock)
-{
-    *lock = SPIN_LOCK_UNLOCKED;
-}
-
-static inline void spin_unlock(spinlock_t *lock)
-{
-    *lock = SPIN_LOCK_UNLOCKED;
-}
-
-#define xen_event_ring_lock_init(_m)  spin_lock_init(&(_m)->ring_lock)
-#define xen_event_ring_lock(_m)       spin_lock(&(_m)->ring_lock)
-#define xen_event_ring_unlock(_m)     spin_unlock(&(_m)->ring_lock)
-
+static
 int wait_for_event_or_timeout(xc_interface *xch, xc_evtchn *xce, unsigned long ms)
 {
     struct pollfd fd = { .fd = xc_evtchn_fd(xce), .events = POLLIN | POLLERR };
@@ -142,14 +110,12 @@ int wait_for_event_or_timeout(xc_interface *xch, xc_evtchn *xce, unsigned long m
     return -errno;
 }
 
-int get_mem_event(xen_mem_event_t *mem_event, mem_event_request_t *req)
+static inline int get_mem_event_42(xen_mem_event_t *mem_event, mem_event_42_request_t *req)
 {
-    mem_event_back_ring_t *back_ring;
+    mem_event_42_back_ring_t *back_ring;
     RING_IDX req_cons;
 
-    xen_event_ring_lock(mem_event);
-
-    back_ring = &mem_event->back_ring;
+    back_ring = &mem_event->back_ring_42;
     req_cons = back_ring->req_cons;
 
     // Copy request
@@ -160,19 +126,15 @@ int get_mem_event(xen_mem_event_t *mem_event, mem_event_request_t *req)
     back_ring->req_cons = req_cons;
     back_ring->sring->req_event = req_cons + 1;
 
-    xen_event_ring_unlock(mem_event);
-
     return 0;
 }
 
-static int put_mem_response(xen_mem_event_t *mem_event, mem_event_response_t *rsp)
+static inline int put_mem_response_42(xen_mem_event_t *mem_event, mem_event_42_response_t *rsp)
 {
-    mem_event_back_ring_t *back_ring;
+    mem_event_42_back_ring_t *back_ring;
     RING_IDX rsp_prod;
 
-    xen_event_ring_lock(mem_event);
-
-    back_ring = &mem_event->back_ring;
+    back_ring = &mem_event->back_ring_42;
     rsp_prod = back_ring->rsp_prod_pvt;
 
     // Copy response
@@ -183,7 +145,43 @@ static int put_mem_response(xen_mem_event_t *mem_event, mem_event_response_t *rs
     back_ring->rsp_prod_pvt = rsp_prod;
     RING_PUSH_RESPONSES(back_ring);
 
-    xen_event_ring_unlock(mem_event);
+    return 0;
+}
+
+static inline int get_mem_event_45(xen_mem_event_t *mem_event, mem_event_45_request_t *req)
+{
+    mem_event_45_back_ring_t *back_ring;
+    RING_IDX req_cons;
+
+    back_ring = &mem_event->back_ring_45;
+    req_cons = back_ring->req_cons;
+
+    // Copy request
+    memcpy(req, RING_GET_REQUEST(back_ring, req_cons), sizeof(*req));
+    req_cons++;
+
+    // Update ring
+    back_ring->req_cons = req_cons;
+    back_ring->sring->req_event = req_cons + 1;
+
+    return 0;
+}
+
+static inline int put_mem_response_45(xen_mem_event_t *mem_event, mem_event_45_response_t *rsp)
+{
+    mem_event_45_back_ring_t *back_ring;
+    RING_IDX rsp_prod;
+
+    back_ring = &mem_event->back_ring_45;
+    rsp_prod = back_ring->rsp_prod_pvt;
+
+    // Copy response
+    memcpy(RING_GET_RESPONSE(back_ring, rsp_prod), rsp, sizeof(*rsp));
+    rsp_prod++;
+
+    // Update ring
+    back_ring->rsp_prod_pvt = rsp_prod;
+    RING_PUSH_RESPONSES(back_ring);
 
     return 0;
 }
@@ -213,21 +211,13 @@ static int resume_domain(vmi_instance_t vmi)
         return -1;
     }
 
-    // Tell Xen we have finished processing the requests
-#if XEN_EVENTS_VERSION < 450
-    // The last argument is actually ignored by Xen.
-    ret = xc_mem_access_resume(xch, dom, 0);
-#else
-    // The last (unused) argument is now removed.
-    ret = xc_mem_access_resume(xch, dom);
-#endif
     ret = xc_evtchn_notify(xe->mem_event.xce_handle, xe->mem_event.port);
     return ret;
 }
 
-status_t process_interrupt_event(vmi_instance_t vmi,
-                          interrupts_t intr,
-                          mem_event_request_t req)
+static
+status_t process_interrupt_event(vmi_instance_t vmi, interrupts_t intr,
+                                 uint64_t gfn, uint64_t offset, uint64_t gla, uint32_t vcpu_id)
 {
 
     int rc                      = -1;
@@ -235,6 +225,8 @@ status_t process_interrupt_event(vmi_instance_t vmi,
     vmi_event_t * event         = g_hash_table_lookup(vmi->interrupt_events, &intr);
     xc_interface * xch          = xen_get_xchandle(vmi);
     unsigned long domain_id     = xen_get_domainid(vmi);
+    xen_instance_t *xen         = xen_get_instance(vmi);
+
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -246,12 +238,12 @@ status_t process_interrupt_event(vmi_instance_t vmi,
     }
 
     if(event) {
-        event->interrupt_event.gfn = req.gfn;
-        event->interrupt_event.offset = req.offset;
-        event->interrupt_event.gla = req.gla;
+        event->interrupt_event.gfn = gfn;
+        event->interrupt_event.offset = offset;
+        event->interrupt_event.gla = gla;
         event->interrupt_event.intr = intr;
         event->interrupt_event.reinject = -1;
-        event->vcpu_id = req.vcpu_id;
+        event->vcpu_id = vcpu_id;
 
         /* Will need to refactor if another interrupt is accessible
          *  via events, and needs differing setup before callback.
@@ -287,12 +279,12 @@ status_t process_interrupt_event(vmi_instance_t vmi,
                  *  one byte.
                  */
                 #define TRAP_int3              3
-                rc = xc_hvm_inject_trap(xch, domain_id, req.vcpu_id,
+                rc = xc_hvm_inject_trap(xch, domain_id, vcpu_id,
                         TRAP_int3,         /* Vector 3 for INT3 */
                         HVMOP_TRAP_sw_exc, /* Trap type, here a software intr */
                         ~0u, /* error code. ~0u means 'ignore' */
-                         event->interrupt_event.insn_length,
-                         0   /* cr2 need not be preserved */
+                        event->interrupt_event.insn_length,
+                        0   /* cr2 need not be preserved */
                     );
 
                 /* NOTE: Inability to re-inject constitutes a serious error.
@@ -317,20 +309,18 @@ status_t process_interrupt_event(vmi_instance_t vmi,
                  *  (XEN) Domain 449 (vcpu#1) crashed on cpu#0:
                  *
                 */
-#if __XEN_INTERFACE_VERSION__ >= 0x00040300
-                if (rc < 0) {
-                    errprint("%s : Xen event error %d re-injecting int3 (benign result for 4.1 >= Xen < 4.3)\n", __FUNCTION__, rc);
+                /*
+                 * Reinjection may return an error code when it actually worked
+                 * NOTE: 4.2.3 has the required patch
+                 *   i.e., 'fix HVMOP_inject_trap return value on success'
+                 * But this cannot be inferred via __XEN_INTERFACE_VERSION__, which is only
+                 *  updated for major versions.
+                 */
+                if ( xen->major_version == 4 && xen->minor_version > 3 && rc < 0) {
+                    errprint("%s : Xen event error %d re-injecting int3\n", __FUNCTION__, rc);
                     status = VMI_FAILURE;
                     break;
                 }
-#else
-#warning Xen version installed has interrupt reinjection with unusable return value.
-/* NOTE: 4.2.3 has the required patch
- *   i.e., 'fix HVMOP_inject_trap return value on success'
- * But this cannot be inferred via __XEN_INTERFACE_VERSION__, which is only
- *  updated for major versions.
- */
-#endif
             }
 
             status = VMI_SUCCESS;
@@ -346,32 +336,30 @@ status_t process_interrupt_event(vmi_instance_t vmi,
     return status;
 }
 
+static
 status_t process_register(vmi_instance_t vmi,
-                          registers_t reg,
-                          mem_event_request_t req)
+                          registers_t reg, uint64_t gfn, uint32_t vcpu_id, uint64_t gla)
 {
 
     vmi_event_t * event = g_hash_table_lookup(vmi->reg_events, &reg);
+    xen_instance_t *xen = xen_get_instance(vmi);
 
     if(event) {
             /* reg_event.equal allows you to set a reg event for
              *  a specific VALUE of the register (passed in req.gfn)
              */
-            if(event->reg_event.equal && event->reg_event.equal != req.gfn)
+            if(event->reg_event.equal && event->reg_event.equal != gfn)
                 return VMI_SUCCESS;
 
-            event->reg_event.value = req.gfn;
-            event->vcpu_id = req.vcpu_id;
+            event->reg_event.value = gfn;
+            event->vcpu_id = vcpu_id;
 
-#if __XEN_INTERFACE_VERSION__ >= 0x00040400
-            if(event->reg_event.reg != MSR_ALL)
-                event->reg_event.previous = req.gla;
-#endif
-#ifdef HVM_PARAM_MEMORY_EVENT_MSR
+            if(xen->major_version == 4 && xen->minor_version >=4 && event->reg_event.reg != MSR_ALL)
+                event->reg_event.previous = gla;
+
             /* Special case: indicate which MSR is being written */
-            if(event->reg_event.reg == MSR_ALL)
-                event->reg_event.context = req.gla;
-#endif
+            if(xen->major_version == 4 && xen->minor_version > 2 && event->reg_event.reg == MSR_ALL)
+                event->reg_event.context = gla;
 
             /* TODO MARESCA: note that vmi_event_t lacks a flags member
              *   so we have no req.flags equivalent. might need to add
@@ -385,20 +373,11 @@ status_t process_register(vmi_instance_t vmi,
     return VMI_FAILURE;
 }
 
-void issue_mem_cb(vmi_instance_t vmi, vmi_event_t *event,
-        mem_event_request_t *req, vmi_mem_access_t out_access) {
-    event->mem_event.gla = req->gla;
-    event->mem_event.gfn = req->gfn;
-    event->mem_event.offset = req->offset;
-    event->mem_event.out_access = out_access;
-    event->vcpu_id = req->vcpu_id;
-    event->callback(vmi, event);
-}
-
-status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
+static
+status_t process_mem(vmi_instance_t vmi, bool access_r, bool access_w, bool access_x,
+                     uint64_t gfn, uint64_t offset, uint64_t gla, uint32_t vcpu_id)
 {
 
-    struct hvm_hw_cpu ctx;
     xc_interface * xch;
     unsigned long dom;
     xch = xen_get_xchandle(vmi);
@@ -413,18 +392,19 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
         return VMI_FAILURE;
     }
 
-    /* TODO, cleanup: ctx is unused here */
-    xc_domain_hvm_getcontext_partial(xch, dom,
-            HVM_SAVE_CODE(CPU), req.vcpu_id, &ctx, sizeof(ctx));
-
-    vmi_event_t *event = g_hash_table_lookup(vmi->mem_events, &req.gfn);
+    vmi_event_t *event = g_hash_table_lookup(vmi->mem_events, &gfn);
     vmi_mem_access_t out_access = VMI_MEMACCESS_INVALID;
-    if(req.access_r) out_access |= VMI_MEMACCESS_R;
-    if(req.access_w) out_access |= VMI_MEMACCESS_W;
-    if(req.access_x) out_access |= VMI_MEMACCESS_X;
+    if(access_r) out_access |= VMI_MEMACCESS_R;
+    if(access_w) out_access |= VMI_MEMACCESS_W;
+    if(access_x) out_access |= VMI_MEMACCESS_X;
 
     if (event && event->mem_event.in_access & out_access) {
-        issue_mem_cb(vmi, event, &req, out_access);
+        event->mem_event.gla = gla;
+        event->mem_event.gfn = gfn;
+        event->mem_event.offset = offset;
+        event->mem_event.out_access = out_access;
+        event->vcpu_id = vcpu_id;
+        event->callback(vmi, event);
         return VMI_SUCCESS;
     }
 
@@ -434,12 +414,14 @@ status_t process_mem(vmi_instance_t vmi, mem_event_request_t req)
      *       The event in that case would be already removed from the GHashTable so
      *       the second violation on the other vCPU would not get delivered..
      */
-    errprint("Caught a memory event that had no handler registered in LibVMI @ GFN %"PRIu32" (0x%"PRIx64"), access: %u\n",
-             req.gfn, (req.gfn<<12) + req.offset, out_access);
+    errprint("Caught a memory event that had no handler registered in LibVMI @ GFN %"PRIu64" (0x%"PRIx64"), access: %u\n",
+             gfn, (gfn<<12) + offset, out_access);
+
     return VMI_FAILURE;
 }
 
-status_t process_single_step_event(vmi_instance_t vmi, mem_event_request_t req)
+static
+status_t process_single_step_event(vmi_instance_t vmi, uint64_t gfn, uint64_t gla, uint32_t vcpu_id)
 {
     xc_interface * xch;
     unsigned long dom;
@@ -455,13 +437,13 @@ status_t process_single_step_event(vmi_instance_t vmi, mem_event_request_t req)
         return VMI_FAILURE;
     }
 
-    vmi_event_t * event = g_hash_table_lookup(vmi->ss_events, &req.vcpu_id);
+    vmi_event_t * event = g_hash_table_lookup(vmi->ss_events, &vcpu_id);
 
     if (event)
     {
-        event->ss_event.gla = req.gla;
-        event->ss_event.gfn = req.gfn;
-        event->vcpu_id = req.vcpu_id;
+        event->ss_event.gla = gla;
+        event->ss_event.gfn = gfn;
+        event->vcpu_id = vcpu_id;
 
         event->callback(vmi, event);
         return VMI_SUCCESS;
@@ -474,17 +456,19 @@ status_t process_single_step_event(vmi_instance_t vmi, mem_event_request_t req)
 //----------------------------------------------------------------------------
 // Driver functions
 
-void xen_events_destroy(vmi_instance_t vmi)
+void xen_events_destroy_legacy(vmi_instance_t vmi)
 {
     int rc;
     xc_interface * xch;
     xen_events_t * xe;
     unsigned long dom;
+    xen_instance_t *xen;
 
     // Get xen handle and domain.
     xch = xen_get_xchandle(vmi);
     dom = xen_get_domainid(vmi);
     xe = xen_get_events(vmi);
+    xen = xen_get_instance(vmi);
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -502,44 +486,32 @@ void xen_events_destroy(vmi_instance_t vmi)
     vmi_pause_vm(vmi);
 
     //A precaution to not leave vcpus stuck in single step
-    xen_shutdown_single_step(vmi);
+    xen_shutdown_single_step_legacy(vmi);
 
     /* Unregister for all events */
-#if XEN_EVENTS_VERSION < 450
-    rc = xc_hvm_set_mem_access(xch, dom, (mem_access_t)COMPAT_MEMACCESS_RWX, ~0ull, 0);
-    rc = xc_hvm_set_mem_access(xch, dom, (mem_access_t)COMPAT_MEMACCESS_RWX, 0, xe->mem_event.max_pages);
-#else
-    rc = xc_set_mem_access(xch, dom, (mem_access_t)COMPAT_MEMACCESS_RWX, ~0ull, 0);
-    rc = xc_set_mem_access(xch, dom, (mem_access_t)COMPAT_MEMACCESS_RWX, 0, xe->mem_event.max_pages);
-#endif
+    if ( xen->major_version == 4 && xen->minor_version < 5 ) {
+        rc = xen->libxcw.xc_hvm_set_mem_access(xch, dom, HVMMEM_access_rwx, ~0ull, 0);
+        rc = xen->libxcw.xc_hvm_set_mem_access(xch, dom, HVMMEM_access_rwx, 0, xe->mem_event.max_pages);
+    } else {
+        rc = xen->libxcw.xc_set_mem_access(xch, dom, XENMEM_access_rwx, ~0ull, 0);
+        rc = xen->libxcw.xc_set_mem_access(xch, dom, XENMEM_access_rwx, 0, xe->mem_event.max_pages);
+    }
     rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_INT3, HVMPME_mode_disabled);
     rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_CR0, HVMPME_mode_disabled);
     rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_CR3, HVMPME_mode_disabled);
     rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_CR4, HVMPME_mode_disabled);
-#ifdef HVM_PARAM_MEMORY_EVENT_MSR
-    rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_MSR, HVMPME_mode_disabled);
-#endif
+    if ( xen->major_version == 4 && xen->minor_version > 2 )
+        rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_MSR, HVMPME_mode_disabled);
     rc = xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_SINGLE_STEP, HVMPME_mode_disabled);
 
-    xen_events_listen(vmi, 0);
+    if ( xen->major_version == 4 && xen->minor_version < 5 )
+        xen_events_listen_42(vmi, 0);
+    else
+        xen_events_listen_45(vmi, 0);
 
     // Turn off mem events
-#if XEN_EVENTS_VERSION == 410
-    if (xe->mem_event.ring_page != NULL) {
-        munlock(xe->mem_event.ring_page, getpagesize());
-        free(xe->mem_event.ring_page);
-    }
-
-    if (xe->mem_event.shared_page != NULL) {
-        munlock(xe->mem_event.shared_page, getpagesize());
-        free(xe->mem_event.shared_page);
-    }
-
-    rc = xc_mem_event_disable(xch, dom);
-#else
     munmap(xe->mem_event.ring_page, getpagesize());
-    rc = xc_mem_access_disable(xch, dom);
-#endif
+    rc = xen->libxcw.xc_mem_access_disable(xch, dom);
 
     if ( rc != 0 )
     {
@@ -571,11 +543,12 @@ void xen_events_destroy(vmi_instance_t vmi)
     vmi_resume_vm(vmi);
 }
 
-status_t xen_events_init(vmi_instance_t vmi)
+status_t xen_init_events_legacy(vmi_instance_t vmi)
 {
     xen_events_t * xe = NULL;
     xc_interface * xch = NULL;
     xc_domaininfo_t dom_info = {0};
+    xen_instance_t *xen = xen_get_instance(vmi);
     unsigned long dom = 0;
     unsigned long ring_pfn = 0;
     unsigned long mmap_pfn = 0;
@@ -585,10 +558,26 @@ status_t xen_events_init(vmi_instance_t vmi)
      *  This is likely to expand to PV in the future, but
      *  until such time, enforce this restriction
      */
-    if(!xen_get_instance(vmi)->hvm){
+    if(!xen->hvm){
         errprint("Xen events: only HVM domains are supported.\n");
         return VMI_FAILURE;
     }
+
+    // Wire up the functions
+    if ( xen->major_version == 4 && xen->minor_version < 5 ) {
+        vmi->driver.events_listen_ptr = &xen_events_listen_42;
+        vmi->driver.are_events_pending_ptr = &xen_are_events_pending_42;
+    } else {
+        vmi->driver.events_listen_ptr = &xen_events_listen_45;
+        vmi->driver.are_events_pending_ptr = &xen_are_events_pending_45;
+    }
+
+    vmi->driver.set_reg_access_ptr = &xen_set_reg_access_legacy;
+    vmi->driver.set_intr_access_ptr = &xen_set_intr_access_legacy;
+    vmi->driver.set_mem_access_ptr = &xen_set_mem_access_legacy;
+    vmi->driver.start_single_step_ptr = &xen_start_single_step_legacy;
+    vmi->driver.stop_single_step_ptr = &xen_stop_single_step_legacy;
+    vmi->driver.shutdown_single_step_ptr = &xen_shutdown_single_step_legacy;
 
     // Get xen handle and domain.
     xch = xen_get_xchandle(vmi);
@@ -610,7 +599,7 @@ status_t xen_events_init(vmi_instance_t vmi)
         return VMI_FAILURE;
     }
 
-    xen_get_instance(vmi)->events = xe;
+    xen->events = xe;
 
     dbprint(VMI_DEBUG_XEN, "Init xen events with xch == %llx\n", (unsigned long long)xch);
 
@@ -631,101 +620,60 @@ status_t xen_events_init(vmi_instance_t vmi)
     // There may be a better way to manage this.
     xe->mem_event.max_pages = dom_info.max_pages;
 
-    // Initialise lock
-    xen_event_ring_lock_init(&xe->mem_event);
-
     /* Initialize the shared pages and enable mem events */
     int tries = 0;
 
-#if XEN_EVENTS_VERSION == 410
-    rc = posix_memalign((void**)&xe->mem_event.ring_page, getpagesize(),
-            getpagesize());
-    if (rc != 0 ) {
-        errprint("Could not allocate the ring page!\n");
-        goto err;
-    }
+    if ( xen->major_version == 4 && xen->minor_version < 5 ) {
 
-    rc = mlock(xe->mem_event.ring_page, getpagesize());
-    if (rc != 0 ) {
-        errprint("Could not lock the ring page!\n");
-        free(xe->mem_event.ring_page);
-        xe->mem_event.ring_page = NULL;
-        goto err;
-    }
-
-    rc = posix_memalign((void**)&xe->mem_event.shared_page, getpagesize(),
-            getpagesize());
-    if (rc != 0 ) {
-        errprint("Could not allocate the shared page!\n");
-        goto err;
-    }
-
-    rc = mlock(xe->mem_event.shared_page, getpagesize());
-    if (rc != 0 ) {
-        errprint("Could not lock the shared page!\n");
-        free(xe->mem_event.shared_page);
-        xe->mem_event.shared_page = NULL;
-        goto err;
-    }
-
-enable:
-    rc = xc_mem_event_enable(xch, dom, xe->mem_event.shared_page,
-                                 xe->mem_event.ring_page);
-    goto enable_done;
-
-reinit:
-    xc_mem_event_disable(xch, dom);
-    goto enable;
-
-#elif XEN_EVENTS_VERSION < 450
-    // Initialise shared page
-    xc_get_hvm_param(xch, dom, HVM_PARAM_ACCESS_RING_PFN, &ring_pfn);
-    mmap_pfn = ring_pfn;
-    xe->mem_event.ring_page =
-        xc_map_foreign_batch(xch, dom, PROT_READ | PROT_WRITE, &mmap_pfn, 1);
-    if ( mmap_pfn & XEN_DOMCTL_PFINFO_XTAB )
-    {
-        /* Map failed, populate ring page */
-        rc = xc_domain_populate_physmap_exact(xch,
-                                              dom,
-                                              1, 0, 0, &ring_pfn);
-        if ( rc != 0 )
-        {
-            errprint("Failed to populate ring gfn\n");
-            goto err;
-        }
-
+        // Initialise shared page
+        xc_get_hvm_param(xch, dom, HVM_PARAM_ACCESS_RING_PFN, &ring_pfn);
         mmap_pfn = ring_pfn;
         xe->mem_event.ring_page =
-            xc_map_foreign_batch(xch, dom,
-                                    PROT_READ | PROT_WRITE, &mmap_pfn, 1);
+            xen->libxcw.xc_map_foreign_batch(xch, dom, PROT_READ | PROT_WRITE, &mmap_pfn, 1);
         if ( mmap_pfn & XEN_DOMCTL_PFINFO_XTAB )
         {
-            errprint("Could not map the ring page\n");
-            goto err;
+            /* Map failed, populate ring page */
+            rc = xc_domain_populate_physmap_exact(xch,
+                                                  dom,
+                                                  1, 0, 0, &ring_pfn);
+            if ( rc != 0 )
+            {
+                errprint("Failed to populate ring gfn\n");
+                goto err;
+            }
+
+            mmap_pfn = ring_pfn;
+            xe->mem_event.ring_page =
+                xen->libxcw.xc_map_foreign_batch(xch, dom,
+                                     PROT_READ | PROT_WRITE, &mmap_pfn, 1);
+            if ( mmap_pfn & XEN_DOMCTL_PFINFO_XTAB )
+            {
+                errprint("Could not map the ring page\n");
+                goto err;
+            }
         }
-    }
-enable:
-    rc = xc_mem_access_enable(xch, dom, &(xe->mem_event.evtchn_port));
-    goto enable_done;
+enable_42:
+        rc = xen->libxcw.xc_mem_access_enable(xch, dom, &(xe->mem_event.evtchn_port));
+        goto enable_done;
 
-reinit:
-    xc_mem_access_disable(xch, dom);
-    goto enable;
+reinit_42:
+        xen->libxcw.xc_mem_access_disable(xch, dom);
+        goto enable_42;
 
-#else // 4.5 style
-enable:
+    } else {
+
+enable_45:
     /* Enable mem access and map the ring page */
-    xe->mem_event.ring_page =
-            xc_mem_access_enable(xch, dom, &(xe->mem_event.evtchn_port));
+        xe->mem_event.ring_page =
+                xen->libxcw.xc_mem_access_enable2(xch, dom, &(xe->mem_event.evtchn_port));
 
-    rc = xe->mem_event.ring_page ? 0 : 1;
-    goto enable_done;
+        rc = xe->mem_event.ring_page ? 0 : 1;
+        goto enable_done;
 
-reinit:
-    xc_mem_access_disable(xch, dom);
-    goto enable;
-#endif
+reinit_45:
+        xen->libxcw.xc_mem_access_disable(xch, dom);
+        goto enable_45;
+    }
 
 enable_done:
     if ( rc != 0 )
@@ -736,7 +684,11 @@ enable_done:
                 if(!tries) {
                     errprint("trying to disable and re-enable events\n");
                     tries++;
-                    goto reinit;
+
+                    if ( xen->major_version == 4 && xen->minor_version < 5 )
+                        goto reinit_42;
+                    else
+                        goto reinit_45;
                 }
                 break;
             case ENODEV:
@@ -751,15 +703,14 @@ enable_done:
 
     /* This causes errors when going from VMI_PARTIAL->VMI_COMPLETE on Xen 4.1.2 */
     /* No longer required on Xen 4.5 */
-#if XEN_EVENTS_VERSION == 420
+
     /* Now that the ring is set, remove it from the guest's physmap */
-    if ( xc_domain_decrease_reservation_exact(xch,
-                    dom, 1, 0, &ring_pfn) )
+    if ( xen->major_version == 4 && xen->minor_version > 1 && xen->minor_version < 5 &&
+         xc_domain_decrease_reservation_exact(xch, dom, 1, 0, &ring_pfn) )
     {
         errprint("Failed to remove ring from guest physmap\n");
         goto err;
     }
-#endif
 
     // Open event channel
     xe->mem_event.xce_handle = xc_evtchn_open(NULL, 0);
@@ -770,14 +721,7 @@ enable_done:
     }
 
     // Bind event notification
-#if XEN_EVENTS_VERSION == 410
-    rc = xc_evtchn_bind_interdomain(
-          xe->mem_event.xce_handle, dom, xe->mem_event.shared_page->port);
-#else
-    rc = xc_evtchn_bind_interdomain(
-          xe->mem_event.xce_handle, dom, xe->mem_event.evtchn_port);
-#endif
-
+    rc = xc_evtchn_bind_interdomain(xe->mem_event.xce_handle, dom, xe->mem_event.evtchn_port);
     if ( rc < 0 )
     {
         errprint("Failed to bind event channel\n");
@@ -788,10 +732,15 @@ enable_done:
     dbprint(VMI_DEBUG_XEN, "Bound to event channel on port == %d\n", xe->mem_event.port);
 
     // Initialise ring
-    SHARED_RING_INIT((mem_event_sring_t *)xe->mem_event.ring_page);
-    BACK_RING_INIT(&xe->mem_event.back_ring,
-                   (mem_event_sring_t *)xe->mem_event.ring_page,
-                   getpagesize());
+    if ( xen->major_version == 4 && xen->minor_version < 5 ) {
+        BACK_RING_INIT(&xe->mem_event.back_ring_42,
+                       (mem_event_42_sring_t *)xe->mem_event.ring_page,
+                       getpagesize());
+    } else {
+        BACK_RING_INIT(&xe->mem_event.back_ring_45,
+                       (mem_event_45_sring_t *)xe->mem_event.ring_page,
+                       getpagesize());
+    }
 
     if(!(dom_info.flags & XEN_DOMINF_paused))
     {
@@ -801,7 +750,7 @@ enable_done:
 
  err:
     errprint("Failed initialize xen events.\n");
-    xen_events_destroy(vmi);
+    xen_events_destroy_legacy(vmi);
 
     if(!(dom_info.flags & XEN_DOMINF_paused))
     {
@@ -810,7 +759,7 @@ enable_done:
     return VMI_FAILURE;
 }
 
-status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
+status_t xen_set_reg_access_legacy(vmi_instance_t vmi, reg_event_t *event)
 {
     xc_interface * xch = xen_get_xchandle(vmi);
     unsigned long dom = xen_get_domainid(vmi);
@@ -877,14 +826,15 @@ status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
     return VMI_SUCCESS;
 }
 
-status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
-                            vmi_mem_access_t page_access_flag, uint16_t vmm_pagetable_id)
+status_t
+xen_set_mem_access_legacy(vmi_instance_t vmi, mem_access_event_t *event,
+                          vmi_mem_access_t page_access_flag, uint16_t vmm_pagetable_id)
 {
     int rc;
-    mem_access_t access;
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
     unsigned long dom = xen_get_domainid(vmi);
+    xen_instance_t * xen = xen_get_instance(vmi);
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -924,16 +874,42 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
 
     // Convert betwen vmi_mem_access_t and mem_access_t
     // Xen does them backwards....
-    access = compat_memaccess_conversion[page_access_flag];
+    if (xen->major_version == 4 && xen->minor_version < 5 ) {
+        static const hvmmem_access_t memaccess_conversion[] = {
+            [VMI_MEMACCESS_RWX] = HVMMEM_access_n,
+            [VMI_MEMACCESS_WX] = HVMMEM_access_r,
+            [VMI_MEMACCESS_RX] = HVMMEM_access_w,
+            [VMI_MEMACCESS_X] = HVMMEM_access_rw,
+            [VMI_MEMACCESS_W] = HVMMEM_access_rx,
+            [VMI_MEMACCESS_R] = HVMMEM_access_wx,
+            [VMI_MEMACCESS_N] = HVMMEM_access_rwx,
+            [VMI_MEMACCESS_W2X] = HVMMEM_access_rx2rw,
+            [VMI_MEMACCESS_RWX2N] = HVMMEM_access_n2rwx,
+        };
+
+        hvmmem_access_t access = memaccess_conversion[page_access_flag];
+
+        rc = xen->libxcw.xc_hvm_set_mem_access(xch, dom, access, page_key, npages);
+    } else {
+        static const hvmmem_access_t memaccess_conversion[] = {
+            [VMI_MEMACCESS_RWX] = XENMEM_access_n,
+            [VMI_MEMACCESS_WX] = XENMEM_access_r,
+            [VMI_MEMACCESS_RX] = XENMEM_access_w,
+            [VMI_MEMACCESS_X] = XENMEM_access_rw,
+            [VMI_MEMACCESS_W] = XENMEM_access_rx,
+            [VMI_MEMACCESS_R] = XENMEM_access_wx,
+            [VMI_MEMACCESS_N] = XENMEM_access_rwx,
+            [VMI_MEMACCESS_W2X] = XENMEM_access_rx2rw,
+            [VMI_MEMACCESS_RWX2N] = XENMEM_access_n2rwx,
+        };
+
+        xenmem_access_t access = memaccess_conversion[page_access_flag];
+
+        rc = xen->libxcw.xc_set_mem_access(xch, dom, access, page_key, npages);
+    }
 
     dbprint(VMI_DEBUG_XEN, "--Setting memaccess for domain %lu on physical address: %"PRIu64" npages: %"PRIu64"\n",
-        dom, event->physical_address, npages);
-
-#if XEN_EVENTS_VERSION < 450
-    rc = xc_hvm_set_mem_access(xch, dom, access, page_key, npages);
-#else
-    rc = xc_set_mem_access(xch, dom, access, page_key, npages);
-#endif
+            dom, event->physical_address, npages);
 
     if(rc) {
         errprint("xc_hvm_set_mem_access failed with code: %d\n", rc);
@@ -943,7 +919,7 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
     return VMI_SUCCESS;
 }
 
-status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t *event, bool enabled)
+status_t xen_set_intr_access_legacy(vmi_instance_t vmi, interrupt_event_t *event, bool enabled)
 {
 
     switch(event->intr){
@@ -958,7 +934,7 @@ status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t *event, bool 
     return VMI_FAILURE;
 }
 
-status_t xen_set_int3_access(vmi_instance_t vmi, bool enabled)
+status_t xen_set_int3_access_legacy(vmi_instance_t vmi, bool enabled)
 {
     xc_interface * xch = xen_get_xchandle(vmi);
     unsigned long dom = xen_get_domainid(vmi);
@@ -981,7 +957,7 @@ status_t xen_set_int3_access(vmi_instance_t vmi, bool enabled)
     return xc_set_hvm_param(xch, dom, HVM_PARAM_MEMORY_EVENT_INT3, param);
 }
 
-status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event)
+status_t xen_start_single_step_legacy(vmi_instance_t vmi, single_step_event_t *event)
 {
     unsigned long dom = xen_get_domainid(vmi);
     int rc = -1;
@@ -1012,13 +988,13 @@ status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event)
 
  rewind:
     do {
-        xen_stop_single_step(vmi, i);
+        xen_stop_single_step_legacy(vmi, i);
     }while(i--);
 
     return VMI_FAILURE;
 }
 
-status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu)
+status_t xen_stop_single_step_legacy(vmi_instance_t vmi, uint32_t vcpu)
 {
     unsigned long dom = xen_get_domainid(vmi);
     status_t ret = VMI_FAILURE;
@@ -1030,7 +1006,7 @@ status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu)
     return ret;
 }
 
-status_t xen_shutdown_single_step(vmi_instance_t vmi) {
+status_t xen_shutdown_single_step_legacy(vmi_instance_t vmi) {
     unsigned long dom = xen_get_domainid(vmi);
     int rc = -1;
     uint32_t i=0;
@@ -1038,7 +1014,7 @@ status_t xen_shutdown_single_step(vmi_instance_t vmi) {
     dbprint(VMI_DEBUG_XEN, "--Shutting down single step on domain %lu\n", dom);
 
     for(;i<vmi->num_vcpus; i++) {
-        xen_stop_single_step(vmi, i);
+        xen_stop_single_step_legacy(vmi, i);
     }
 
     rc = xc_set_hvm_param(
@@ -1053,7 +1029,7 @@ status_t xen_shutdown_single_step(vmi_instance_t vmi) {
     return VMI_SUCCESS;
 }
 
-int xen_are_events_pending(vmi_instance_t vmi)
+int xen_are_events_pending_42(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
@@ -1062,16 +1038,28 @@ int xen_are_events_pending(vmi_instance_t vmi)
         return -1;
     }
 
-    return RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring);
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring_42);
 
 }
 
-status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
+int xen_are_events_pending_45(vmi_instance_t vmi)
+{
+    xen_events_t *xe = xen_get_events(vmi);
+
+    if ( !xe ) {
+        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
+        return -1;
+    }
+
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring_45);
+}
+
+status_t xen_events_listen_42(vmi_instance_t vmi, uint32_t timeout)
 {
     xc_interface * xch;
     xen_events_t * xe;
-    mem_event_request_t req;
-    mem_event_response_t rsp;
+    mem_event_42_request_t req;
+    mem_event_42_response_t rsp;
     unsigned long dom;
 
     int rc = -1;
@@ -1118,8 +1106,8 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
         }
     }
 
-    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring) ) {
-        rc = get_mem_event(&xe->mem_event, &req);
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring_42) ) {
+        rc = get_mem_event_42(&xe->mem_event, &req);
         if ( rc != 0 ) {
             errprint("Error getting event.\n");
             return VMI_FAILURE;
@@ -1136,7 +1124,8 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
                 rsp.p2mt = req.p2mt;
 
                 if(!vmi->shutting_down) {
-                    vrc = process_mem(vmi, req);
+                    vrc = process_mem(vmi, req.access_r, req.access_w, req.access_x,
+                                      req.gfn, req.offset, req.gla, req.vcpu_id);
                 }
 
                 /*MARESCA do we need logic here to reset flags on a page? see xen-access.c
@@ -1148,39 +1137,39 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
             case MEM_EVENT_REASON_CR0:
                 dbprint(VMI_DEBUG_XEN, "--Caught CR0 event!\n");
                 if(!vmi->shutting_down) {
-                    vrc = process_register(vmi, CR0, req);
+                    vrc = process_register(vmi, CR0, req.gfn, req.gla, req.vcpu_id);
                 }
                 break;
             case MEM_EVENT_REASON_CR3:
                 dbprint(VMI_DEBUG_XEN, "--Caught CR3 event!\n");
                 if(!vmi->shutting_down) {
-                    vrc = process_register(vmi, CR3, req);
+                    vrc = process_register(vmi, CR3, req.gfn, req.gla, req.vcpu_id);
                 }
                 break;
 #ifdef HVM_PARAM_MEMORY_EVENT_MSR
             case MEM_EVENT_REASON_MSR:
                 if(!vmi->shutting_down) {
                     dbprint(VMI_DEBUG_XEN, "--Caught MSR event!\n");
-                    vrc = process_register(vmi, MSR_ALL, req);
+                    vrc = process_register(vmi, MSR_ALL, req.gfn, req.gla, req.vcpu_id);
                 }
                 break;
 #endif
             case MEM_EVENT_REASON_CR4:
                 dbprint(VMI_DEBUG_XEN, "--Caught CR4 event!\n");
                 if(!vmi->shutting_down) {
-                    vrc = process_register(vmi, CR4, req);
+                    vrc = process_register(vmi, CR4, req.gfn, req.gla, req.vcpu_id);
                 }
                 break;
             case MEM_EVENT_REASON_SINGLESTEP:
                 dbprint(VMI_DEBUG_XEN, "--Caught single step event!\n");
                 if(!vmi->shutting_down) {
-                    vrc = process_single_step_event(vmi, req);
+                    vrc = process_single_step_event(vmi, req.gfn, req.gla, req.vcpu_id);
                 }
                 break;
             case MEM_EVENT_REASON_INT3:
                 if(!vmi->shutting_down) {
                     dbprint(VMI_DEBUG_XEN, "--Caught int3 interrupt event!\n");
-                    vrc = process_interrupt_event(vmi, INT3, req);
+                    vrc = process_interrupt_event(vmi, INT3, req.gfn, req.offset, req.gla, req.vcpu_id);
                 }
                 break;
             default:
@@ -1190,7 +1179,143 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
         }
 
         // Put the response on the ring
-        rc = put_mem_response(&xe->mem_event, &rsp);
+        rc = put_mem_response_42(&xe->mem_event, &rsp);
+        if ( rc != 0 ) {
+            errprint("Error putting event response on the ring.\n");
+            return VMI_FAILURE;
+        }
+
+        dbprint(VMI_DEBUG_XEN, "--Finished handling event.\n");
+    }
+
+    // We only resume the domain once all requests are processed from the ring
+    rc = resume_domain(vmi);
+    if ( rc != 0 ) {
+        errprint("Error resuming domain.\n");
+        return VMI_FAILURE;
+    }
+
+    return vrc;
+}
+
+status_t xen_events_listen_45(vmi_instance_t vmi, uint32_t timeout)
+{
+    xc_interface * xch;
+    xen_events_t * xe;
+    mem_event_45_request_t req;
+    mem_event_45_response_t rsp;
+    unsigned long dom;
+
+    int rc = -1;
+    status_t vrc = VMI_SUCCESS;
+
+    // Get xen handle and domain.
+    xch = xen_get_xchandle(vmi);
+    dom = xen_get_domainid(vmi);
+    xe = xen_get_events(vmi);
+
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( !xe ) {
+        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( dom == VMI_INVALID_DOMID ) {
+        errprint("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+
+    // Set whether the access listener is required
+    rc = xc_domain_set_access_required(xch, dom, vmi->event_listener_required);
+    if ( rc < 0 )
+        errprint("Error %d setting mem_access listener required to %d\n",
+            rc, vmi->event_listener_required);
+
+    if(!vmi->shutting_down && timeout > 0) {
+        dbprint(VMI_DEBUG_XEN, "--Waiting for xen events...(%"PRIu32" ms)\n", timeout);
+        rc = wait_for_event_or_timeout(xch, xe->mem_event.xce_handle, timeout);
+        if ( rc < -1 ) {
+            errprint("Error while waiting for event.\n");
+            return VMI_FAILURE;
+        }
+    }
+
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring_45) ) {
+        rc = get_mem_event_45(&xe->mem_event, &req);
+        if ( rc != 0 ) {
+            errprint("Error getting event.\n");
+            return VMI_FAILURE;
+        }
+
+        memset( &rsp, 0, sizeof (rsp) );
+        rsp.vcpu_id = req.vcpu_id;
+        rsp.flags = req.flags;
+
+        switch(req.reason){
+            case MEM_EVENT_REASON_VIOLATION:
+                dbprint(VMI_DEBUG_XEN, "--Caught mem event!\n");
+                rsp.gfn = req.gfn;
+                rsp.p2mt = req.p2mt;
+
+                if(!vmi->shutting_down) {
+                    vrc = process_mem(vmi, req.access_r, req.access_w, req.access_x,
+                                      req.gfn, req.offset, req.gla, req.vcpu_id);
+                }
+
+                /*MARESCA do we need logic here to reset flags on a page? see xen-access.c
+                 *    specifically regarding write/exec/int3 inspection and the code surrounding
+                 *    the variables default_access and after_first_access
+                 */
+
+                break;
+            case MEM_EVENT_REASON_CR0:
+                dbprint(VMI_DEBUG_XEN, "--Caught CR0 event!\n");
+                if(!vmi->shutting_down) {
+                    vrc = process_register(vmi, CR0, req.gfn, req.gla, req.vcpu_id);
+                }
+                break;
+            case MEM_EVENT_REASON_CR3:
+                dbprint(VMI_DEBUG_XEN, "--Caught CR3 event!\n");
+                if(!vmi->shutting_down) {
+                    vrc = process_register(vmi, CR3, req.gfn, req.gla, req.vcpu_id);
+                }
+                break;
+#ifdef HVM_PARAM_MEMORY_EVENT_MSR
+            case MEM_EVENT_REASON_MSR:
+                if(!vmi->shutting_down) {
+                    dbprint(VMI_DEBUG_XEN, "--Caught MSR event!\n");
+                    vrc = process_register(vmi, MSR_ALL, req.gfn, req.gla, req.vcpu_id);
+                }
+                break;
+#endif
+            case MEM_EVENT_REASON_CR4:
+                dbprint(VMI_DEBUG_XEN, "--Caught CR4 event!\n");
+                if(!vmi->shutting_down) {
+                    vrc = process_register(vmi, CR4, req.gfn, req.gla, req.vcpu_id);
+                }
+                break;
+            case MEM_EVENT_REASON_SINGLESTEP:
+                dbprint(VMI_DEBUG_XEN, "--Caught single step event!\n");
+                if(!vmi->shutting_down) {
+                    vrc = process_single_step_event(vmi, req.gfn, req.gla, req.vcpu_id);
+                }
+                break;
+            case MEM_EVENT_REASON_INT3:
+                if(!vmi->shutting_down) {
+                    dbprint(VMI_DEBUG_XEN, "--Caught int3 interrupt event!\n");
+                    vrc = process_interrupt_event(vmi, INT3, req.gfn, req.offset, req.gla, req.vcpu_id);
+                }
+                break;
+            default:
+                errprint("UNKNOWN REASON CODE %d\n", req.reason);
+                vrc = VMI_FAILURE;
+                break;
+        }
+
+        // Put the response on the ring
+        rc = put_mem_response_45(&xe->mem_event, &rsp);
         if ( rc != 0 ) {
             errprint("Error putting event response on the ring.\n");
             return VMI_FAILURE;

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -61,18 +61,7 @@
 #include <xenctrl.h>
 #include <libvmi/events.h>
 
-#if XEN_EVENTS_VERSION < 460
-typedef int spinlock_t;
-#include <xen/mem_event.h>
-#else
-#include <xen/vm_event.h>
-#endif
-
-#if XEN_EVENTS_VERSION < 450
-#include <xen/hvm/save.h>
-#else
-#include <xen/memory.h>
-#endif
+#include "xen_events_abi.h"
 
 #ifdef XENCTRL_HAS_XC_INTERFACE
 typedef xc_evtchn* xc_evtchn_t;
@@ -81,28 +70,23 @@ typedef int xc_evtchn_t;
 #endif
 
 typedef struct {
-#if XEN_EVENTS_VERSION < 460
     xc_evtchn_t xce_handle;
     int port;
-#if XEN_EVENTS_VERSION < 420
-    mem_event_shared_page_t *shared_page;
-#else
     uint32_t evtchn_port;
-#endif
     void *ring_page;
-    mem_event_back_ring_t back_ring;
-    spinlock_t ring_lock;
+    union {
+        mem_event_42_back_ring_t back_ring_42;
+        mem_event_45_back_ring_t back_ring_45;
+    };
     unsigned long long max_pages;
-#endif // XEN_EVENTS < 460
 } xen_mem_event_t;
 
 typedef struct {
-#if XEN_EVENTS_VERSION >= 460
     xc_evtchn_t xce_handle;
     int port;
     uint32_t evtchn_port;
     void *ring_page;
-    vm_event_back_ring_t back_ring;
+    vm_event_46_back_ring_t back_ring_46;
     xen_pfn_t max_gpfn;
     uint32_t monitor_capabilities;
     bool monitor_singlestep_on;
@@ -113,95 +97,16 @@ typedef struct {
     bool monitor_cr4_on;
     bool monitor_xcr0_on;
     bool monitor_msr_on;
-#endif
 } xen_vm_event_t;
-
-// Compatibility wrapper around mem_access versions
-#if XEN_EVENTS_VERSION < 450
-// Xen 4.0-4.4 type flags
-typedef enum {
-    COMPAT_MEMACCESS_INVALID = ~0,
-    COMPAT_MEMACCESS_N = HVMMEM_access_n,
-    COMPAT_MEMACCESS_R = HVMMEM_access_r,
-    COMPAT_MEMACCESS_W = HVMMEM_access_w,
-    COMPAT_MEMACCESS_RW = HVMMEM_access_rw,
-    COMPAT_MEMACCESS_X = HVMMEM_access_x,
-    COMPAT_MEMACCESS_RX = HVMMEM_access_rx,
-    COMPAT_MEMACCESS_WX = HVMMEM_access_wx,
-    COMPAT_MEMACCESS_RWX = HVMMEM_access_rwx,
-    /*
-     * Page starts off as r-x, but automatically
-     * change to r-w on a write
-     */
-    COMPAT_MEMACCESS_RX2RW = HVMMEM_access_rx2rw,
-
-#ifdef HVMMEM_access_n2rwx
-    /*
-     * Log access: starts off as n, automatically
-     * goes to rwx, generating an event without
-     * pausing the vcpu
-     */
-    COMPAT_MEMACCESS_N2RWX = HVMMEM_access_n2rwx
-#else
-    COMPAT_MEMACCESS_N2RWX = COMPAT_MEMACCESS_INVALID
-#endif
-} compat_COMPAT_MEMACCESS_t;
-typedef hvmmem_access_t mem_access_t;
-
-#else /* XEN_EVENTS_VERSION */
-// Xen 4.5+ type flags
-typedef enum {
-    COMPAT_MEMACCESS_INVALID = ~0,
-    COMPAT_MEMACCESS_N = XENMEM_access_n,
-    COMPAT_MEMACCESS_R = XENMEM_access_r,
-    COMPAT_MEMACCESS_W = XENMEM_access_w,
-    COMPAT_MEMACCESS_RW = XENMEM_access_rw,
-    COMPAT_MEMACCESS_X = XENMEM_access_x,
-    COMPAT_MEMACCESS_RX = XENMEM_access_rx,
-    COMPAT_MEMACCESS_WX = XENMEM_access_wx,
-    COMPAT_MEMACCESS_RWX = XENMEM_access_rwx,
-    /*
-     * Page starts off as r-x, but automatically
-     * change to r-w on a write
-     */
-    COMPAT_MEMACCESS_RX2RW = XENMEM_access_rx2rw,
-    /*
-     * Log access: starts off as n, automatically
-     * goes to rwx, generating an event without
-     * pausing the vcpu
-     */
-    COMPAT_MEMACCESS_N2RWX = XENMEM_access_n2rwx
-} compat_mem_access_t;
-typedef xenmem_access_t mem_access_t;
-
-#endif /* XEN_EVENTS_VERSION */
-
-/* Conversion matrix from LibVMI flags to Xen flags */
-static const unsigned int compat_memaccess_conversion[] = {
-    [VMI_MEMACCESS_INVALID] = COMPAT_MEMACCESS_INVALID,
-    [VMI_MEMACCESS_N] = COMPAT_MEMACCESS_RWX,
-    [VMI_MEMACCESS_R] = COMPAT_MEMACCESS_WX,
-    [VMI_MEMACCESS_W] = COMPAT_MEMACCESS_RX,
-    [VMI_MEMACCESS_X] = COMPAT_MEMACCESS_RW,
-    [VMI_MEMACCESS_RW] = COMPAT_MEMACCESS_X,
-    [VMI_MEMACCESS_RX] = COMPAT_MEMACCESS_W,
-    [VMI_MEMACCESS_WX] = COMPAT_MEMACCESS_R,
-    [VMI_MEMACCESS_RWX] = COMPAT_MEMACCESS_N,
-    [VMI_MEMACCESS_W2X] = COMPAT_MEMACCESS_RX2RW,
-    [VMI_MEMACCESS_RWX2N] = COMPAT_MEMACCESS_N2RWX
-};
 
 /* Conversion matrix from LibVMI flags to Xen vm_event flags */
 static const unsigned int event_response_conversion[] = {
-    [0 ... __VMI_EVENT_RESPONSE_MAX] = ~0, // Mark all flags invalid by default
-#if XEN_EVENTS_VERSION >= 460
     [VMI_EVENT_RESPONSE_EMULATE] = VM_EVENT_FLAG_EMULATE,
     [VMI_EVENT_RESPONSE_EMULATE_NOWRITE] = VM_EVENT_FLAG_EMULATE_NOWRITE,
     [VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP] = VM_EVENT_FLAG_TOGGLE_SINGLESTEP,
     [VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA] = VM_EVENT_FLAG_SET_EMUL_READ_DATA,
     [VMI_EVENT_RESPONSE_DENY] = VM_EVENT_FLAG_DENY,
     [VMI_EVENT_RESPONSE_VMM_PAGETABLE_ID] = VM_EVENT_FLAG_ALTERNATE_P2M,
-#endif
 };
 
 typedef struct xen_events {
@@ -212,5 +117,36 @@ typedef struct xen_events {
 } xen_events_t;
 
 status_t xen_set_int3_access(vmi_instance_t vmi, bool enable);
+
+/* Interface to Xen 4.1-4.5 events */
+int xen_are_events_pending_41(vmi_instance_t vmi);
+int xen_are_events_pending_42(vmi_instance_t vmi);
+int xen_are_events_pending_45(vmi_instance_t vmi);
+status_t xen_events_listen_41(vmi_instance_t vmi, uint32_t timeout);
+status_t xen_events_listen_42(vmi_instance_t vmi, uint32_t timeout);
+status_t xen_events_listen_45(vmi_instance_t vmi, uint32_t timeout);
+status_t xen_set_reg_access_legacy(vmi_instance_t vmi, reg_event_t *event);
+status_t xen_set_intr_access_legacy(vmi_instance_t vmi, interrupt_event_t *event, bool enabled);
+status_t xen_set_mem_access_legacy(vmi_instance_t vmi,
+                                   mem_access_event_t *event,
+                                   vmi_mem_access_t page_access_flag,
+                                   uint16_t vmm_pagetable_id);
+status_t xen_start_single_step_legacy(vmi_instance_t vmi, single_step_event_t *event);
+status_t xen_stop_single_step_legacy(vmi_instance_t vmi, uint32_t vcpu);
+status_t xen_shutdown_single_step_legacy(vmi_instance_t vmi);
+
+/* Interface to Xen 4.6+ events */
+int xen_are_events_pending(vmi_instance_t vmi);
+status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
+status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event);
+status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t *event, bool enabled);
+status_t xen_set_mem_access(vmi_instance_t vmi,
+                            mem_access_event_t *event,
+                            vmi_mem_access_t page_access_flag,
+                            uint16_t vmm_pagetable_id);
+status_t xen_start_single_step(vmi_instance_t vmi, single_step_event_t *event);
+status_t xen_stop_single_step(vmi_instance_t vmi, uint32_t vcpu);
+status_t xen_shutdown_single_step(vmi_instance_t vmi);
+
 
 #endif

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -63,14 +63,8 @@
 
 #include "xen_events_abi.h"
 
-#ifdef XENCTRL_HAS_XC_INTERFACE
-typedef xc_evtchn* xc_evtchn_t;
-#else
-typedef int xc_evtchn_t;
-#endif
-
 typedef struct {
-    xc_evtchn_t xce_handle;
+    xc_evtchn* xce_handle;
     int port;
     uint32_t evtchn_port;
     void *ring_page;
@@ -82,7 +76,7 @@ typedef struct {
 } xen_mem_event_t;
 
 typedef struct {
-    xc_evtchn_t xce_handle;
+    xc_evtchn* xce_handle;
     int port;
     uint32_t evtchn_port;
     void *ring_page;

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -47,20 +47,6 @@
 #include "libxc_wrapper.h"
 #include "driver/xen/xen_events_private.h"
 
-/* compatibility checks */
-#ifndef xen_cr3_to_pfn_x86_32
-#define xen_pfn_to_cr3_x86_64(pfn) ((__align8__ uint64_t)(pfn) << 12)
-#define xen_cr3_to_pfn_x86_64(cr3) ((__align8__ uint64_t)(cr3) >> 12)
-
-#define xen_pfn_to_cr3_x86_32(pfn) (((unsigned)(pfn) << 12) | ((unsigned)(pfn) >> 20))
-#define xen_cr3_to_pfn_x86_32(cr3) (((unsigned)(cr3) >> 12) | ((unsigned)(cr3) << 20))
-#endif /* xen_cr3_to_pfn_x86_32 */
-
-#ifdef HAVE_LIBXENSTORE
-#define OPEN_XS_DAEMON()    xs_open(0)
-#define CLOSE_XS_DAEMON(h)  xs_close(h)
-#endif
-
 typedef struct xen_instance {
 
     char *name;

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -56,9 +56,6 @@
 #define xen_cr3_to_pfn_x86_32(cr3) (((unsigned)(cr3) >> 12) | ((unsigned)(cr3) << 20))
 #endif /* xen_cr3_to_pfn_x86_32 */
 
-typedef xc_interface *libvmi_xenctrl_handle_t;
-#define XENCTRL_HANDLE_INVALID NULL
-
 #ifdef HAVE_LIBXENSTORE
 #define OPEN_XS_DAEMON()    xs_open(0)
 #define CLOSE_XS_DAEMON(h)  xs_close(h)
@@ -68,7 +65,7 @@ typedef struct xen_instance {
 
     char *name;
 
-    libvmi_xenctrl_handle_t xchandle; /**< handle to xenctrl library (libxc) */
+    xc_interface* xchandle; /**< handle to xenctrl library (libxc) */
 
     libxc_wrapper_t libxcw; /**< wrapper for libxc for backwards compatibility */
 
@@ -111,7 +108,7 @@ xen_instance_t *xen_get_instance(
 }
 
 static inline
-libvmi_xenctrl_handle_t xen_get_xchandle(
+xc_interface* xen_get_xchandle(
     vmi_instance_t vmi)
 {
     return xen_get_instance(vmi)->xchandle;


### PR DESCRIPTION
Currently LibVMI determines Xen compatibility during compile-time, requiring a user to compile a version of LibVMI for each version of Xen it needs to be deployed on. While this problem mostly affects the Xen events API which went through big changes, other libxc functions also have changed between various versions, making for example a LibVMI compiled on a Xen 4.6 incompatible with Xen 4.5 libraries and with the 4.5 events ABI.

In this PR we introduce a libxc wrapper using the dl library to load the appropriate functions for the appropriate Xen version we detect during run-time. With this we deprecate a lot of the preprocessor magic.

To properly add backwards compatibility support for Xen events we deprecate including the actual Xen event headers from the host and define the Xen events ABI locally. This allows us to compile support for all versions of Xen from Xen 4.2 upwards. However, the Xen ring API has changed substantially between Xen 4.1 and Xen 4.2, thus rather than defining a local copy of the Xen ring API as well we just deprecate support for Xen 4.1 events.

We also deprecate support for Xen 4.0 and older.

This fixes #356.