### PR TITLE
vmi_swap_events

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -1374,27 +1374,37 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
     vrc = process_requests(vmi, &req, &rsp);
 
     /*
-     * The only way to gracefully handle vmi_clear_event requests
+     * The only way to gracefully handle vmi_swap_events and vmi_clear_event requests
      * that were issued in a callback is to ensure no more requests
      * are in the ringpage. We do this by pausing the domain (all vCPUs)
      * and process all reamining events on the ring. Once no more requests
      * are on the ring we can remove the events.
      */
-    if ( g_hash_table_size(vmi->clear_events) ) {
+    if ( vmi->swap_events || g_hash_table_size(vmi->clear_events) ) {
         vmi_pause_vm(vmi); // Pause all vCPUs
+
         vrc = process_requests(vmi, &req, &rsp);
+
+        GSList *loop = vmi->swap_events;
+        while(loop) {
+            swap_wrapper_t *swap_wrapper = loop->data;
+            swap_events(vmi, swap_wrapper->swap_from, swap_wrapper->swap_to,
+                        swap_wrapper->free_routine);
+            loop = loop->next;
+        }
 
         GHashTableIter i;
         vmi_event_t **key = NULL;
         vmi_event_free_t cb;
-
-        ghashtable_foreach(vmi->clear_events, i, &key, &cb) {
+        ghashtable_foreach(vmi->clear_events, i, &key, &cb)
             vmi_clear_event(vmi, *key, cb);
-        }
 
+        g_slist_free(vmi->swap_events);
         g_hash_table_destroy(vmi->clear_events);
+
+        vmi->swap_events = NULL;
         vmi->clear_events =
-            g_hash_table_new_full(g_int64_hash, g_int64_equal, free, NULL);
+            g_hash_table_new_full(g_int64_hash, g_int64_equal, g_free, NULL);
 
         vmi_resume_vm(vmi);
     }

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -53,6 +53,13 @@ vmi_mem_access_t combine_mem_access(vmi_mem_access_t base, vmi_mem_access_t add)
 
 }
 
+gint swap_search_from(gconstpointer a, gconstpointer b)
+{
+    swap_wrapper_t *w1 = (swap_wrapper_t*)a;
+    swap_wrapper_t *w2 = (swap_wrapper_t*)a;
+    return (w1->swap_from == w2->swap_from);
+}
+
 //----------------------------------------------------------------------------
 //  General event callback management.
 
@@ -137,6 +144,7 @@ void events_destroy(vmi_instance_t vmi)
         g_hash_table_destroy(vmi->interrupt_events);
     }
 
+    g_slist_free(vmi->swap_events);
     g_hash_table_destroy(vmi->clear_events);
 }
 
@@ -494,6 +502,29 @@ status_t clear_debug_event(vmi_instance_t vmi, vmi_event_t *event)
     return rc;
 }
 
+status_t swap_events(vmi_instance_t vmi, vmi_event_t *swap_from, vmi_event_t *swap_to,
+                     vmi_event_free_t free_routine)
+{
+    status_t rc;
+    if(swap_from->vmm_pagetable_id != swap_to->vmm_pagetable_id) {
+        rc = driver_set_mem_access(vmi, &swap_from->mem_event, VMI_MEMACCESS_N, swap_from->vmm_pagetable_id);
+        if(rc == VMI_FAILURE)
+            return rc;
+    }
+
+    rc = driver_set_mem_access(vmi, &swap_to->mem_event, swap_to->mem_event.in_access, swap_to->vmm_pagetable_id);
+    if(rc == VMI_FAILURE)
+        return rc;
+
+    addr_t page_key = swap_from->mem_event.physical_address >> 12;
+    g_hash_table_replace(vmi->mem_events, g_memdup(&page_key, sizeof(addr_t)), swap_to);
+
+    if ( free_routine )
+        free_routine(swap_from, rc);
+
+    return VMI_SUCCESS;
+}
+
 //----------------------------------------------------------------------------
 // Public event functions.
 
@@ -506,6 +537,53 @@ vmi_event_t *vmi_get_mem_event(vmi_instance_t vmi, addr_t physical_address)
 {
     addr_t page_key = physical_address >> 12;
     return g_hash_table_lookup(vmi->mem_events, &page_key);
+}
+
+status_t vmi_swap_events(vmi_instance_t vmi, vmi_event_t* swap_from, vmi_event_t *swap_to,
+                         vmi_event_free_t free_routine)
+{
+    if(swap_from->type == swap_to->type && swap_from->type == VMI_EVENT_MEMORY)
+    {
+        addr_t page_key = swap_from->mem_event.physical_address >> 12;
+
+        if(!g_hash_table_lookup(vmi->mem_events, &page_key)) {
+            dbprint(VMI_DEBUG_EVENTS, "The event to be swapped is not registered.\n");
+            return VMI_FAILURE;
+        }
+
+        /*
+         * We can't swap events when in an event callback rigt away
+         * because there may be more events in the queue already
+         * that were triggered by the event we would be clearing now.
+         * The driver needs to process this list when it can safely.
+         * The user may request a callback when the struct can be safely
+         * freed.
+         */
+        if ( vmi->event_callback ) {
+            if (!g_slist_find_custom(vmi->swap_events, &swap_from, swap_search_from)) {
+
+                swap_wrapper_t *wrapper = g_malloc0(sizeof(swap_wrapper_t));
+                wrapper->swap_from = swap_from;
+                wrapper->swap_to = swap_to;
+                wrapper->free_routine = free_routine;
+
+                /* We need to use append here to ensure the swaps
+                 * are processed in the order the user issued them. */
+                vmi->swap_events = g_slist_append(vmi->swap_events, wrapper);
+
+                return VMI_SUCCESS;
+            }
+
+            dbprint(VMI_DEBUG_EVENTS, "Event was already queued for swapping.\n");
+            return VMI_FAILURE;
+        }
+
+        return swap_events(vmi, swap_from, swap_to, free_routine);
+
+    }
+
+    dbprint(VMI_DEBUG_EVENTS, "Swapping events is only implemented for VMI_EVENT_MEMORY type!\n");
+    return VMI_FAILURE;
 }
 
 status_t vmi_register_event(vmi_instance_t vmi, vmi_event_t* event)
@@ -579,6 +657,14 @@ status_t vmi_clear_event(vmi_instance_t vmi, vmi_event_t* event,
      * freed.
      */
     if ( vmi->event_callback ) {
+
+        /* If this event was requested to be swapped from calling
+         * vmi_clear_event will cause issues for the new event. */
+        if (g_slist_find_custom(vmi->swap_events, &event, swap_search_from)) {
+            dbprint(VMI_DEBUG_EVENTS, "Event was already queued for swapping.\n");
+            return VMI_FAILURE;
+        }
+
         if (!g_hash_table_lookup(vmi->clear_events, &event)) {
             g_hash_table_insert(vmi->clear_events,
                                 g_memdup(&event, sizeof(void*)),

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -491,12 +491,34 @@ struct vmi_event {
  *
  * @param[in] vmi LibVMI instance
  * @param[in] event Definition of event to monitor
- * @param[in] callback Function to call when the event occurs
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t vmi_register_event(
     vmi_instance_t vmi,
     vmi_event_t *event);
+
+/**
+ * Swap a registered event to another.
+ *
+ * This function is intended to be used when changing the MEMACCESS
+ * page permissions on a page that already has been registered. This
+ * function is safe to be called from event callbacks, as no pending
+ * event will be left without a registered handler.
+ *
+ * Memory management of the vmi_event_t being registered remains the
+ *  responsibility of the caller.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] swap_from A currently registered event
+ * @param[in] swap_to The event to replace the currently registered one with
+ * @param[in] free_routine Function to call when it is safe to free old event (swap_from).
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_swap_events(
+    vmi_instance_t vmi,
+    vmi_event_t *swap_from,
+    vmi_event_t *swap_to,
+    vmi_event_free_t free_routine);
 
 /**
  * Clear the event specified by the vmi_event_t object.

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -174,6 +174,7 @@ struct vmi_instance {
 
     gboolean shutting_down; /**< flag indicating that libvmi is shutting down */
 
+    GSList *swap_events; /**< list to save vmi_swap_events requests when event_callback is set */
 };
 
 /** Event singlestep reregister wrapper */
@@ -183,6 +184,13 @@ typedef struct step_and_reg_event_wrapper {
     uint64_t steps;
     event_callback_t cb;
 } step_and_reg_event_wrapper_t;
+
+/** Event swap wrapper */
+typedef struct swap_wrapper {
+    vmi_event_t *swap_from;
+    vmi_event_t *swap_to;
+    vmi_event_free_t free_routine;
+} swap_wrapper_t;
 
 /** Windows' UNICODE_STRING structure (x86) */
 typedef struct _windows_unicode_string32 {
@@ -414,6 +422,12 @@ status_t vmi_pagetable_lookup_cache(
         gpointer key,
         gpointer value,
         gpointer data);
+    status_t swap_events(
+        vmi_instance_t vmi,
+        vmi_event_t *swap_from,
+        vmi_event_t *swap_to,
+        vmi_event_free_t free_routine);
+
     #define ghashtable_foreach(table, iter, key, val) \
         g_hash_table_iter_init(&iter, table); \
         while(g_hash_table_iter_next(&iter,(void**)key,(void**)val))


### PR DESCRIPTION
When a user needs to change mem_access permissions from a callback it can result in unpredictable behavior if there are other events already queued on the ring from Xen reporting other vCPU violations.  Thus, the only safe point when the user can swap the mem_access permissions is when the ring is empty and the vm is paused, ensuring we don't run into any old events. By introducing vmi_swap_events LibVMI can safely handle such situations with multi-vCPU guests.