### PR TITLE
Properly clear new events on shutdown

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -1154,6 +1154,9 @@ status_t xen_set_guest_requested_event(vmi_instance_t vmi, bool enabled) {
     if ( xen->major_version != 4 || xen->minor_version < 5 )
         return VMI_FAILURE;
 
+    if ( !enabled && !vmi->guest_requested_event )
+        return VMI_SUCCESS;
+
     rc  = xen->libxcw.xc_monitor_guest_request(xen_get_xchandle(vmi),
                                                xen_get_domainid(vmi),
                                                enabled, 1);
@@ -1174,6 +1177,9 @@ status_t xen_set_debug_event(vmi_instance_t vmi, bool enabled) {
     if ( xen->major_version != 4 || xen->minor_version < 8 )
         return VMI_FAILURE;
 
+    if ( !enabled && !vmi->debug_event )
+        return VMI_SUCCESS;
+
     rc = xen->libxcw.xc_monitor_debug_exceptions(xen_get_xchandle(vmi),
                                                  xen_get_domainid(vmi),
                                                  enabled, 1);
@@ -1193,6 +1199,9 @@ status_t xen_set_cpuid_event(vmi_instance_t vmi, bool enabled) {
 
     if ( xen->major_version != 4 || xen->minor_version < 8 )
         return VMI_FAILURE;
+
+    if ( !enabled && !vmi->cpuid_event )
+        return VMI_SUCCESS;
 
     rc = xen->libxcw.xc_monitor_cpuid(xen_get_xchandle(vmi),
                                       xen_get_domainid(vmi),

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -632,6 +632,7 @@ status_t process_debug_event(vmi_instance_t vmi,
 void xen_events_destroy_new(vmi_instance_t vmi)
 {
     int rc, resume = 0;
+    status_t rc2;
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
     xen_events_t * xe = xen_get_events(vmi);
@@ -668,6 +669,9 @@ void xen_events_destroy_new(vmi_instance_t vmi)
     rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_CR4, false, false, false);
     rc = xen->libxcw.xc_monitor_write_ctrlreg(xch, dom, VM_EVENT_X86_XCR0, false, false, false);
     rc = xen->libxcw.xc_monitor_software_breakpoint(xch, dom, false);
+    rc2 = xen_set_guest_requested_event(vmi, 0);
+    rc2 = xen_set_cpuid_event(vmi, 0);
+    rc2 = xen_set_debug_event(vmi, 0);
 
     if ( xe->vm_event.ring_page ) {
         xen_events_listen(vmi, 0);

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -606,6 +606,15 @@ status_t vmi_clear_event(vmi_instance_t vmi, vmi_event_t* event,
     case VMI_EVENT_MEMORY:
         rc = clear_mem_event(vmi, event);
         break;
+    case VMI_EVENT_GUEST_REQUEST:
+        rc = clear_guest_requested_event(vmi, event);
+        break;
+    case VMI_EVENT_CPUID:
+        rc = clear_cpuid_event(vmi, event);
+        break;
+    case VMI_EVENT_DEBUG_EXCEPTION:
+        rc = clear_debug_event(vmi, event);
+        break;
     default:
         dbprint(VMI_DEBUG_EVENTS, "Cannot clear unknown event: %d\n", event->type);
         rc = VMI_FAILURE;


### PR DESCRIPTION
PR #355 missed clearing up the events on shutdown and wiring up the clear functions to vmi_clear_event.