### PR TITLE
Added support for specifying win_ntoskrnl_va in the libvmi.conf.

### DIFF
--- a/libvmi/config/grammar.y
+++ b/libvmi/config/grammar.y
@@ -275,6 +275,7 @@ int vmi_parse_config (const char *target_name)
 %token<str>    LINUX_PGD
 %token<str>    LINUX_ADDR
 %token<str>    WIN_NTOSKRNL
+%token<str>    WIN_NTOSKRNL_VA
 %token<str>    WIN_TASKS
 %token<str>    WIN_PDBASE
 %token<str>    WIN_PID
@@ -336,6 +337,8 @@ assignment:
         linux_addr_assignment
         |
         win_ntoskrnl_assignment
+        |
+        win_ntoskrnl_va_assignment
         |
         win_tasks_assignment
         |
@@ -418,6 +421,17 @@ linux_addr_assignment:
 
 win_ntoskrnl_assignment:
         WIN_NTOSKRNL EQUALS NUM
+        {
+            uint64_t tmp = strtoull($3, NULL, 0);
+            uint64_t *tmp_ptr = malloc(sizeof(uint64_t));
+            (*tmp_ptr) = tmp;
+            g_hash_table_insert(tmp_entry, $1, tmp_ptr);
+            free($3);
+        }
+        ;
+
+win_ntoskrnl_va_assignment:
+        WIN_NTOSKRNL_VA EQUALS NUM
         {
             uint64_t tmp = strtoull($3, NULL, 0);
             uint64_t *tmp_ptr = malloc(sizeof(uint64_t));

--- a/libvmi/config/lexicon.l
+++ b/libvmi/config/lexicon.l
@@ -49,6 +49,7 @@ linux_pid               { BeginToken(yytext); yylval.str = strndup(yytext, CONFI
 linux_pgd               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PGD; }
 linux_addr              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_ADDR; }
 win_ntoskrnl            { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL; }
+win_ntoskrnl_va         { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL_VA; }
 win_tasks               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_TASKS; }
 win_pdbase              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PDBASE; }
 win_pid                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PID; }

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -457,6 +457,11 @@ void windows_read_config_ghashtable_entries(char* key, gpointer value,
         goto _done;
     }
 
+    if (strncmp(key, "win_ntoskrnl_va", CONFIG_STR_LENGTH) == 0) {
+        windows_instance->ntoskrnl_va = *(addr_t *)value;
+        goto _done;
+    }
+
     if (strncmp(key, "win_tasks", CONFIG_STR_LENGTH) == 0) {
         windows_instance->tasks_offset = *(int *)value;
         goto _done;
@@ -536,7 +541,8 @@ init_from_rekall_profile(vmi_instance_t vmi)
     reg_t kpcr = 0;
     addr_t kpcr_rva = 0;
 
-    if(vmi->mode != VMI_FILE) {
+    // try to find the kernel if we are not connecting to a file and the kernel pa/va were not already specified.
+    if(vmi->mode != VMI_FILE && ! ( windows->ntoskrnl && windows->ntoskrnl_va ) ) {
 
         switch ( vmi->page_mode ) {
             case VMI_PM_IA32E:

--- a/libvmi/os/windows/kdbg.c
+++ b/libvmi/os/windows/kdbg.c
@@ -1163,7 +1163,7 @@ done:
  * This functions is responsible for setting up
  * Windows specific variables:
  *  - ntoskrnl (*)
- *  - ntoskrnl_va
+ *  - ntoskrnl_va (*)
  *  - kdbg_offset (*)
  *  - kdbg_va (*)
  * The variables marked with (*) can be also specified


### PR DESCRIPTION
This is useful when restoring a virtual machine from a state file.

*grammar.y added win_ntoskrnl_va
*lexicon.l added win_ntoskrnl_va
*core.c added win_ntoskrnl_va, added sanity check to init_from_rekall_profile, try fallback initialisation if init_from_rekall_profile fails
*kdbg.c Allow initialisation with ntoskrnl + ntoskrnl_va