### PR TITLE
Altp2m support

### DIFF
--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -2,6 +2,7 @@ SUBDIRS = config
 
 h_public =  libvmi.h \
             libvmi_extra.h \
+            slat.h \
             x86.h
 
 h_private = \
@@ -28,6 +29,7 @@ c_sources = \
     performance.c \
     pretty_print.c \
     read.c \
+    slat.c \
     strmatch.c \
     write.c \
     memory.c \
@@ -66,7 +68,9 @@ endif
 
 if HAVE_XEN
 h_public    += events.h
-drivers     += driver/xen/xen.h \
+drivers     += driver/xen/altp2m.c \
+               driver/xen/altp2m_private.h \
+               driver/xen/xen.h \
                driver/xen/xen_private.h \
                driver/xen/xen.c \
                driver/xen/xen_events.h \

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -495,16 +495,16 @@ addr_t vmi_translate_uv2p (vmi_instance_t vmi, addr_t virt_address, vmi_pid_t pi
 
 const char *
 vmi_get_linux_sysmap(
-	vmi_instance_t vmi)
+    vmi_instance_t vmi)
 {
     linux_instance_t linux_instance = NULL;
 
     if(VMI_OS_LINUX != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode)){
-	return NULL;
+        return NULL;
     }
 
     if(!vmi->os_data){
-	return NULL;
+        return NULL;
     }
 
     linux_instance = vmi->os_data;

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -138,6 +138,26 @@ typedef struct driver_interface {
     status_t (*set_debug_event_ptr)(
         vmi_instance_t,
         bool enabled);
+    status_t (*slat_get_domain_state_ptr)(
+        vmi_instance_t vmi,
+        bool *state);
+    status_t (*slat_set_domain_state_ptr)(
+        vmi_instance_t vmi,
+        bool state);
+    status_t (*slat_create_ptr)(
+        vmi_instance_t vmi,
+        uint16_t *view);
+    status_t (*slat_destroy_ptr)(
+        vmi_instance_t vmi,
+        uint16_t view);
+    status_t (*slat_switch_ptr)(
+        vmi_instance_t vmi,
+        uint16_t view);
+    status_t (*slat_change_gfn_ptr)(
+        vmi_instance_t vmi,
+        uint16_t slat_idx,
+        addr_t old_gfn,
+        addr_t new_gfn);
 
     /* Driver-specific data storage. */
     void* driver_data;

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -496,5 +496,91 @@ driver_set_debug_event(
     }
 }
 
+static inline status_t
+driver_slat_get_domain_state (
+    vmi_instance_t vmi ,
+    bool *state )
+{
+    if (vmi->driver.initialized && vmi->driver.slat_get_domain_state_ptr ) {
+        return vmi->driver.slat_get_domain_state_ptr (vmi, state);
+    }
+    else {
+        dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_get_domain_state function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_slat_set_domain_state (
+    vmi_instance_t vmi ,
+    bool state )
+{
+    if (vmi->driver.initialized && vmi->driver.slat_set_domain_state_ptr ) {
+        return vmi->driver.slat_set_domain_state_ptr (vmi, state);
+    }
+    else {
+        dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_set_domain_state function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_slat_create (
+    vmi_instance_t vmi ,
+    uint16_t *slat_idx )
+{
+    if (vmi->driver.initialized && vmi->driver.slat_create_ptr) {
+        return vmi->driver.slat_create_ptr (vmi, slat_idx);
+    }
+    else {
+        dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_create function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_slat_destroy (
+    vmi_instance_t vmi ,
+    uint16_t slat_idx )
+{
+    if (vmi->driver.initialized && vmi->driver.slat_destroy_ptr) {
+        return vmi->driver.slat_destroy_ptr (vmi, slat_idx);
+    }
+    else {
+        dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_destroy function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_slat_switch (
+    vmi_instance_t vmi ,
+    uint16_t slat_idx )
+{
+    if (vmi->driver.initialized && vmi->driver.slat_switch_ptr) {
+        return vmi->driver.slat_switch_ptr (vmi, slat_idx);
+    }
+    else {
+        dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_switch function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
+static inline status_t
+driver_slat_change_gfn (
+    vmi_instance_t vmi ,
+    uint16_t slat_idx,
+    addr_t old_gfn,
+    addr_t new_gfn)
+{
+    if (vmi->driver.initialized && vmi->driver.slat_change_gfn_ptr) {
+        return vmi->driver.slat_change_gfn_ptr (vmi, slat_idx, old_gfn, new_gfn);
+    }
+    else {
+        dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_change_gfn function not implemented.\n");
+        return VMI_FAILURE;
+    }
+}
+
 #endif /* DRIVER_WRAPPER_H */
 

--- a/libvmi/driver/xen/altp2m.c
+++ b/libvmi/driver/xen/altp2m.c
@@ -1,0 +1,168 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+* memory in a target virtual machine or in a file containing a dump of
+* a system's physical memory.  LibVMI is based on the XenAccess Library.
+*
+* Author: Kevin Mayer (kevin.mayer@gdata.de)
+*
+* This file is part of LibVMI.
+*
+* LibVMI is free software: you can redistribute it and/or modify it under
+* the terms of the GNU Lesser General Public License as published by the
+* Free Software Foundation, either version 3 of the License, or (at your
+* option) any later version.
+*
+* LibVMI is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+* License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "private.h"
+#include "driver/xen/xen.h"
+#include "driver/xen/xen_private.h"
+
+status_t xen_altp2m_get_domain_state (vmi_instance_t vmi, bool *state)
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xc_interface * xch = xen_get_xchandle(vmi);
+    domid_t domain_id = xen_get_domainid(vmi);
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( domain_id == (domid_t)VMI_INVALID_DOMID ) {
+        errprint ("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    rc = xen->libxcw.xc_altp2m_get_domain_state (xch, domain_id, state);
+    if ( rc )
+    {
+        errprint ("xc_altp2m_get_domain_state returned rc: %i\n", rc);
+        return VMI_FAILURE;
+    }
+    return VMI_SUCCESS;
+
+}
+
+status_t xen_altp2m_set_domain_state (vmi_instance_t vmi, bool state)
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xc_interface * xch = xen_get_xchandle(vmi);
+    domid_t domain_id = xen_get_domainid(vmi);
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( domain_id == (domid_t)VMI_INVALID_DOMID ) {
+        errprint ("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    rc = xen->libxcw.xc_altp2m_set_domain_state (xch, domain_id, state);
+    if ( rc )
+    {
+        errprint ("xc_altp2m_set_domain_state returned rc: %i\n", rc);
+        return VMI_FAILURE;
+    }
+    return VMI_SUCCESS;
+
+}
+
+status_t xen_altp2m_create_p2m ( vmi_instance_t vmi, uint16_t *altp2m_idx )
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xc_interface * xch = xen_get_xchandle(vmi);
+    domid_t domain_id = xen_get_domainid(vmi);
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( domain_id == (domid_t)VMI_INVALID_DOMID ) {
+        errprint ("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    rc = xen->libxcw.xc_altp2m_create_view (xch, domain_id, VMI_MEMACCESS_N, altp2m_idx );
+    if ( rc )
+    {
+        errprint ("xc_altp2m_create_view returned rc: %i\n", rc);
+        return VMI_FAILURE;
+    }
+    return VMI_SUCCESS;
+
+}
+
+status_t xen_altp2m_destroy_p2m ( vmi_instance_t vmi, uint16_t altp2m_idx )
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xc_interface * xch = xen_get_xchandle(vmi);
+    domid_t domain_id = xen_get_domainid(vmi);
+
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( domain_id == (domid_t)VMI_INVALID_DOMID ) {
+        errprint ("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    rc = xen->libxcw.xc_altp2m_destroy_view (xch, domain_id, altp2m_idx );
+    if ( rc )
+    {
+        errprint ("xc_altp2m_destroy_view returned rc: %i\n", rc);
+        return VMI_FAILURE;
+    }
+    return VMI_SUCCESS;
+
+}
+
+status_t xen_altp2m_switch_p2m ( vmi_instance_t vmi, uint16_t altp2m_idx )
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xc_interface * xch = xen_get_xchandle(vmi);
+    domid_t domain_id = xen_get_domainid(vmi);
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( domain_id == (domid_t)VMI_INVALID_DOMID ) {
+        errprint ("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    rc = xen->libxcw.xc_altp2m_switch_to_view (xch, domain_id, altp2m_idx );
+    if ( rc )
+    {
+        errprint ("xc_altp2m_switch_to_view returned rc: %i\n", rc);
+        return VMI_FAILURE;
+    }
+    return VMI_SUCCESS;
+}
+
+status_t xen_altp2m_change_gfn ( vmi_instance_t vmi, uint16_t altp2m_idx, addr_t old_gfn, addr_t new_gfn )
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xc_interface * xch = xen_get_xchandle(vmi);
+    domid_t domain_id = xen_get_domainid(vmi);
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( domain_id == (domid_t)VMI_INVALID_DOMID ) {
+        errprint ("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    rc = xen->libxcw.xc_altp2m_change_gfn (xch, domain_id, altp2m_idx, old_gfn, new_gfn );
+    if ( rc )
+    {
+        errprint ("xc_altp2m_change_gfn returned rc: %i\n", rc);
+        return VMI_FAILURE;
+    }
+    return VMI_SUCCESS;
+}

--- a/libvmi/driver/xen/altp2m_private.h
+++ b/libvmi/driver/xen/altp2m_private.h
@@ -1,0 +1,62 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+* memory in a target virtual machine or in a file containing a dump of
+* a system's physical memory.  LibVMI is based on the XenAccess Library.
+*
+* Author: Kevin Mayer (kevin.mayer@gdata.de)
+*
+* This file is part of LibVMI.
+*
+* LibVMI is free software: you can redistribute it and/or modify it under
+* the terms of the GNU Lesser General Public License as published by the
+* Free Software Foundation, either version 3 of the License, or (at your
+* option) any later version.
+*
+* LibVMI is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+* License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file altp2m_private.h
+* @brief The functions concerning themself with the control of xens altp2m 
+* are defined here.
+*
+*/
+
+#ifndef ALTP2M_PRIVATE_H
+#define ALTP2M_PRIVATE_H
+
+#include "private.h"
+
+status_t xen_altp2m_get_domain_state (vmi_instance_t vmi, bool *state);
+status_t xen_altp2m_set_domain_state (vmi_instance_t vmi, bool state);
+status_t xen_altp2m_create_p2m (vmi_instance_t vmi, uint16_t *altp2m_idx);
+status_t xen_altp2m_destroy_p2m (vmi_instance_t vmi, uint16_t altp2m_idx);
+status_t xen_altp2m_switch_p2m (vmi_instance_t vmi, uint16_t altp2m_idx);
+status_t xen_altp2m_change_gfn (vmi_instance_t vmi,
+    uint16_t altp2m_idx,
+    addr_t old_gfn,
+    addr_t new_gfn);
+
+static inline void
+xen_init_altp2m (
+    vmi_instance_t vmi )
+{
+    xen_instance_t *xen = xen_get_instance ( vmi );
+
+    if ( xen->major_version > 4 || ( xen->major_version == 4 && xen->minor_version >= 6 ) )
+    {
+        vmi->driver.slat_get_domain_state_ptr = &xen_altp2m_get_domain_state;
+        vmi->driver.slat_set_domain_state_ptr = &xen_altp2m_set_domain_state;
+        vmi->driver.slat_create_ptr = &xen_altp2m_create_p2m;
+        vmi->driver.slat_destroy_ptr = &xen_altp2m_destroy_p2m;
+        vmi->driver.slat_switch_ptr = &xen_altp2m_switch_p2m;
+        vmi->driver.slat_change_gfn_ptr = &xen_altp2m_change_gfn;
+    }
+}
+
+#endif

--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -75,7 +75,10 @@ static inline status_t sanity_check(xen_instance_t *xen)
                  !w->xc_monitor_get_capabilities || !w->xc_monitor_write_ctrlreg ||
                  !w->xc_monitor_mov_to_msr || !w->xc_monitor_singlestep ||
                  !w->xc_monitor_software_breakpoint || !w->xc_monitor_guest_request ||
-                 !w->xc_altp2m_set_mem_access )
+                 !w->xc_altp2m_get_domain_state || !w->xc_altp2m_set_domain_state ||
+                 !w->xc_altp2m_set_vcpu_enable_notify || !w->xc_altp2m_create_view ||
+                 !w->xc_altp2m_destroy_view || !w->xc_altp2m_switch_to_view ||
+                 !w->xc_altp2m_set_mem_access || !w->xc_altp2m_change_gfn )
                 break;
 
             ret = VMI_SUCCESS;
@@ -121,7 +124,14 @@ status_t create_libxc_wrapper(xen_instance_t *xen)
     wrapper->xc_monitor_singlestep = dlsym(wrapper->handle, "xc_monitor_singlestep");
     wrapper->xc_monitor_software_breakpoint = dlsym(wrapper->handle, "xc_monitor_software_breakpoint");
     wrapper->xc_monitor_guest_request = dlsym(wrapper->handle, "xc_monitor_guest_request");
-    wrapper->xc_altp2m_set_mem_access = dlsym(wrapper->handle, "xc_altp2m_set_mem_access");
+    wrapper->xc_altp2m_get_domain_state = dlsym ( wrapper->handle , "xc_altp2m_get_domain_state" );
+    wrapper->xc_altp2m_set_domain_state = dlsym ( wrapper->handle , "xc_altp2m_set_domain_state" );
+    wrapper->xc_altp2m_set_vcpu_enable_notify = dlsym ( wrapper->handle , "xc_altp2m_set_vcpu_enable_notify" );
+    wrapper->xc_altp2m_create_view = dlsym ( wrapper->handle , "xc_altp2m_create_view" );
+    wrapper->xc_altp2m_destroy_view = dlsym(wrapper->handle, "xc_altp2m_destroy_view");
+    wrapper->xc_altp2m_switch_to_view = dlsym ( wrapper->handle , "xc_altp2m_switch_to_view" );
+    wrapper->xc_altp2m_set_mem_access = dlsym ( wrapper->handle , "xc_altp2m_set_mem_access" );
+    wrapper->xc_altp2m_change_gfn = dlsym ( wrapper->handle , "xc_altp2m_change_gfn" );
     wrapper->xc_monitor_debug_exceptions = dlsym(wrapper->handle, "xc_monitor_debug_exceptions");
     wrapper->xc_monitor_cpuid = dlsym(wrapper->handle, "xc_monitor_cpuid");
 

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -102,8 +102,30 @@ typedef struct {
     int (*xc_monitor_guest_request)
             (xc_interface *xch, domid_t domain_id, bool enable, bool sync);
 
+    int (*xc_altp2m_get_domain_state) 
+            (xc_interface *xch, domid_t domain_id, bool *state );
+
+    int (*xc_altp2m_set_domain_state)
+            (xc_interface *xch, domid_t domain_id, bool state );
+
+    int (*xc_altp2m_set_vcpu_enable_notify)
+            (xc_interface *xch, domid_t domain_id, uint32_t vcpuid, xen_pfn_t gfn );
+
+    int (*xc_altp2m_create_view)
+            (xc_interface *xch, domid_t domain_id, xenmem_access_t default_access, uint16_t *view_id );
+
+    int (*xc_altp2m_destroy_view) 
+            (xc_interface *xch, domid_t domain_id, uint16_t view_id );
+
+    int (*xc_altp2m_switch_to_view) 
+            (xc_interface *xch, domid_t domain_id, uint16_t view_id );
+
     int (*xc_altp2m_set_mem_access)
-        (xc_interface *handle, domid_t domid, uint16_t view_id, xen_pfn_t gfn, xenmem_access_t access);
+            (xc_interface *xch, domid_t domain_id, uint16_t view_id, xen_pfn_t gfn, xenmem_access_t access);
+
+    int (*xc_altp2m_change_gfn) 
+            (xc_interface *xch, domid_t domain_id, uint16_t view_id, xen_pfn_t old_gfn, xen_pfn_t new_gfn );
+
 
     /* Xen 4.8+ */
     int (*xc_monitor_debug_exceptions)

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -32,6 +32,7 @@
 #include "driver/xen/xen_events.h"
 #include "driver/driver_interface.h"
 #include "driver/memory_cache.h"
+#include "driver/xen/altp2m_private.h"
 
 //----------------------------------------------------------------------------
 // Helper functions
@@ -927,6 +928,11 @@ xen_init_vmi(
         goto _bail;
 
     ret = xen_init_events(vmi);
+
+    if ( VMI_FAILURE == ret )
+        goto _bail;
+
+    xen_init_altp2m(vmi);
 
 _bail:
     return ret;

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -556,7 +556,7 @@ status_t process_cpuid_event(vmi_instance_t vmi,
     vmi->event_callback = 0;
 
     if ( !rsp->flags || rsp->flags == (1 << VM_EVENT_FLAG_VCPU_PAUSED) )
-        dbprint(VMI_DEBUG_XEN, "%s warning: CPUID events require the callback to specify how to handle it, we are likely to be going into a CPUID loop right now\n"
+        dbprint(VMI_DEBUG_XEN, "%s warning: CPUID events require the callback to specify how to handle it, we are likely to be going into a CPUID loop right now\n",
                 __FUNCTION__);
 
     return VMI_SUCCESS;

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -44,6 +44,7 @@
 #include "libvmi_extra.h"
 #include "events.h"
 #include "shm.h"
+#include "slat.h"
 #include "rekall.h"
 #include "debug.h"
 #include "driver/driver_interface.h"

--- a/libvmi/slat.c
+++ b/libvmi/slat.c
@@ -1,0 +1,54 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+* memory in a target virtual machine or in a file containing a dump of
+* a system's physical memory.  LibVMI is based on the XenAccess Library.
+*
+* Author: Kevin Mayer (kevin.mayer@gdata.de)
+*
+* This file is part of LibVMI.
+*
+* LibVMI is free software: you can redistribute it and/or modify it under
+* the terms of the GNU Lesser General Public License as published by the
+* Free Software Foundation, either version 3 of the License, or (at your
+* option) any later version.
+*
+* LibVMI is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+* License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "private.h"
+#include "driver/driver_wrapper.h"
+
+status_t vmi_slat_get_domain_state (vmi_instance_t vmi, bool *state)
+{
+    return driver_slat_get_domain_state (vmi, state);
+}
+
+status_t vmi_slat_set_domain_state (vmi_instance_t vmi, bool state)
+{
+    return driver_slat_set_domain_state (vmi, state);
+}
+
+status_t vmi_slat_create (vmi_instance_t vmi, uint16_t *slat_id)
+{
+    return driver_slat_create (vmi, slat_id);
+}
+
+status_t vmi_slat_destroy (vmi_instance_t vmi, uint16_t slat_idx)
+{
+    return driver_slat_destroy (vmi, slat_idx);
+}
+
+status_t vmi_slat_switch (vmi_instance_t vmi, uint16_t slat_idx)
+{
+    return driver_slat_switch (vmi, slat_idx);
+}
+
+status_t vmi_slat_change_gfn (vmi_instance_t vmi, uint16_t slat_idx, addr_t old_gfn, addr_t new_gfn)
+{
+    return driver_slat_change_gfn (vmi, slat_idx, old_gfn, new_gfn);
+}

--- a/libvmi/slat.h
+++ b/libvmi/slat.h
@@ -1,0 +1,118 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+* memory in a target virtual machine or in a file containing a dump of
+* a system's physical memory.  LibVMI is based on the XenAccess Library.
+*
+* Author: Kevin Mayer (kevin.mayer@gdata.de)
+*
+* This file is part of LibVMI.
+*
+* LibVMI is free software: you can redistribute it and/or modify it under
+* the terms of the GNU Lesser General Public License as published by the
+* Free Software Foundation, either version 3 of the License, or (at your
+* option) any later version.
+*
+* LibVMI is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+* License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file slat.h
+* @brief The LibVMI second level address translation API is defined here.
+*
+* The slat (Second Level Address Translation) is used to circumvent the
+* overhead of shadow page tables. By modifying the pointer to the
+* translation tables they can also be used to switch between completely
+* different sets of access rights for memory pages.
+*/
+
+#ifndef LIBVMI_SLAT_H
+#define LIBVMI_SLAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma GCC visibility push(default)
+
+/**
+* Checks if slat is enabled on the domain
+*
+* @param[in] vmi LibVMI instance
+* @param[out] state slat state of the domain
+* @return VMI_SUCCESS or VMI_FAILURE
+*/
+status_t vmi_slat_get_domain_state (
+    vmi_instance_t vmi,
+    bool *state);
+
+/**
+* Enables or disables slat for the domain
+*
+* @param[in] vmi LibVMI instance
+* @param[in] state slat state of the domain
+* @return VMI_SUCCESS or VMI_FAILURE
+*/
+status_t vmi_slat_set_domain_state (
+    vmi_instance_t vmi,
+    bool state);
+
+/**
+* Creates a new slat slat_id
+*
+* @param[in] vmi LibVMI instance
+* @param[out] slat_id Number of the newly created slat_id
+* @return VMI_SUCCESS or VMI_FAILURE
+*/
+status_t vmi_slat_create (
+    vmi_instance_t vmi,
+    uint16_t *slat_id);
+
+/**
+* Destroys an slat slat_id
+*
+* @param[in] vmi LibVMI instance
+* @param[in] slat_id Number of the slat_id which is to be destroyed
+* @return VMI_SUCCESS or VMI_FAILURE
+*/
+status_t vmi_slat_destroy (
+    vmi_instance_t vmi,
+    uint16_t slat_idx);
+
+/**
+* Switches to a specific slat slat_id
+*
+* @param[in] vmi LibVMI instance
+* @param[in] slat_id Number of the slat_id which to which to switch to
+* @return VMI_SUCCESS or VMI_FAILURE
+*/
+status_t vmi_slat_switch (
+    vmi_instance_t vmi,
+    uint16_t slat_idx);
+
+/**
+*
+*
+* @param[in] vmi LibVMI instance
+* @param[in] slat_id Number of the slat_id in which to switch
+* @param[in] old_gfn The old gfn
+* @param[in] new_gfn The new gfn
+* @return VMI_SUCCESS or VMI_FAILURE
+*/
+status_t vmi_slat_change_gfn (
+    vmi_instance_t vmi,
+    uint16_t slat_idx,
+    addr_t old_gfn,
+    addr_t new_gfn);
+
+#pragma GCC visibility pop
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBVMI_SLAT_H */


### PR DESCRIPTION
This adds support for the direct control of the altp2m-features offered by Xen.

I don`t know if exposing these features to a user without any sanity checks fits in with the spirit of libvmi.
But since I use them constantly I hope they can be usefull for others.

Any comments / suggestions?

Cheers

Maro