### PR TITLE
Add generic mem_access event types

### DIFF
--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -176,7 +176,7 @@ int main (int argc, char **argv)
 
     printf("Preparing memory event to catch next RIP 0x%lx, PA 0x%lx, page 0x%lx for PID %u\n",
             rip, rip_pa, rip_pa >> 12, pid);
-    SETUP_MEM_EVENT(&mm_event, rip_pa, VMI_MEMACCESS_X, mm_callback);
+    SETUP_MEM_EVENT(&mm_event, rip_pa, VMI_MEMACCESS_X, mm_callback, 0);
 
     vmi_resume_vm(vmi);
 

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -118,7 +118,7 @@ typedef struct driver_interface {
         bool enabled);
     status_t (*set_mem_access_ptr)(
         vmi_instance_t,
-        mem_access_event_t*,
+        addr_t gpfn,
         vmi_mem_access_t,
         uint16_t vmm_pagetable_id);
     status_t (*start_single_step_ptr)(

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -400,12 +400,12 @@ driver_set_intr_access(
 static inline status_t
 driver_set_mem_access(
     vmi_instance_t vmi,
-    mem_access_event_t *event,
+    addr_t gpfn,
     vmi_mem_access_t page_access_flag,
     uint16_t vmm_pagetable_id)
 {
     if (vmi->driver.initialized && vmi->driver.set_mem_access_ptr){
-        return vmi->driver.set_mem_access_ptr(vmi, event, page_access_flag, vmm_pagetable_id);
+        return vmi->driver.set_mem_access_ptr(vmi, gpfn, page_access_flag, vmm_pagetable_id);
     }
     else{
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_mem_access function not implemented.\n");

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -987,8 +987,8 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
 
     access = memaccess_conversion[page_access_flag];
 
-    dbprint(VMI_DEBUG_XEN, "--Setting memaccess for domain %"PRIu16" on physical address: %"PRIu64" npages: %"PRIu64"\n",
-        dom, event->physical_address, npages);
+    dbprint(VMI_DEBUG_XEN, "--Setting memaccess for domain %"PRIu16" on GPFN: %"PRIu64"\n",
+            dom, gpfn);
 
     if ( !altp2m_idx )
         rc = xen->libxcw.xc_set_mem_access(xch, dom, access, page_key, npages);

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -417,6 +417,7 @@ status_t process_mem(vmi_instance_t vmi,
 
     xc_interface * xch = xen_get_xchandle(vmi);
     domid_t dom = xen_get_domainid(vmi);
+    vmi_event_t *event;
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -433,16 +434,37 @@ status_t process_mem(vmi_instance_t vmi,
     if(req->u.mem_access.flags & MEM_ACCESS_W) out_access |= VMI_MEMACCESS_W;
     if(req->u.mem_access.flags & MEM_ACCESS_X) out_access |= VMI_MEMACCESS_X;
 
-    vmi_event_t *event = g_hash_table_lookup(vmi->mem_events, &req->u.mem_access.gfn);
+    if ( g_hash_table_size(vmi->mem_events_on_gfn) ) {
+        event = g_hash_table_lookup(vmi->mem_events_on_gfn, &req->u.mem_access.gfn);
+        if (event && (event->mem_event.in_access & out_access) )
+        {
+            event->regs.x86 = (x86_registers_t *)&req->data.regs.x86;
+            event->vmm_pagetable_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
+            vmi->event_callback = 1;
+            process_response( issue_mem_cb(vmi, event, req, out_access), event, rsp );
+            vmi->event_callback = 0;
+            return VMI_SUCCESS;
+        }
+    }
 
-    if (event && (event->mem_event.in_access & out_access) )
-    {
-        event->regs.x86 = (x86_registers_t *)&req->data.regs.x86;
-        event->vmm_pagetable_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
-        vmi->event_callback = 1;
-        process_response( issue_mem_cb(vmi, event, req, out_access), event, rsp );
-        vmi->event_callback = 0;
-        return VMI_SUCCESS;
+    if ( g_hash_table_size(vmi->mem_events_generic) ) {
+        GHashTableIter i;
+        vmi_mem_access_t *key = NULL;
+        bool cb_issued = 0;
+
+        ghashtable_foreach(vmi->mem_events_generic, i, &key, &event) {
+            if ( (*key) & out_access ) {
+                event->regs.x86 = (x86_registers_t *)&req->data.regs.x86;
+                event->vmm_pagetable_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
+                vmi->event_callback = 1;
+                process_response( issue_mem_cb(vmi, event, req, out_access), event, rsp );
+                vmi->event_callback = 0;
+                cb_issued = 1;
+            }
+        }
+
+        if ( cb_issued )
+            return VMI_SUCCESS;
     }
 
     /*
@@ -925,7 +947,7 @@ done:
     return VMI_FAILURE;
 }
 
-status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
+status_t xen_set_mem_access(vmi_instance_t vmi, addr_t gpfn,
                             vmi_mem_access_t page_access_flag, uint16_t altp2m_idx)
 {
     int rc;
@@ -966,11 +988,6 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
         return VMI_FAILURE;
     }
 
-    addr_t page_key = event->physical_address >> 12;
-
-    uint64_t npages = page_key + event->npages > xen->max_gpfn
-        ? xen->max_gpfn - page_key: event->npages;
-
     // Convert betwen vmi_mem_access_t and mem_access_t
     // Xen does them backwards....
     static const xenmem_access_t memaccess_conversion[] = {
@@ -991,15 +1008,15 @@ status_t xen_set_mem_access(vmi_instance_t vmi, mem_access_event_t *event,
             dom, gpfn);
 
     if ( !altp2m_idx )
-        rc = xen->libxcw.xc_set_mem_access(xch, dom, access, page_key, npages);
+        rc = xen->libxcw.xc_set_mem_access(xch, dom, access, gpfn, 1); // 1 page at a time
     else
-        rc = xen->libxcw.xc_altp2m_set_mem_access(xch, dom, altp2m_idx, page_key, access);
+        rc = xen->libxcw.xc_altp2m_set_mem_access(xch, dom, altp2m_idx, gpfn, access);
 
     if(rc) {
         errprint("xc_hvm_set_mem_access failed with code: %d\n", rc);
         return VMI_FAILURE;
     }
-    dbprint(VMI_DEBUG_XEN, "--Done Setting memaccess on physical address: %"PRIu64"\n", event->physical_address);
+    dbprint(VMI_DEBUG_XEN, "--Done Setting memaccess on GPFN: %"PRIu64"\n", gpfn);
     return VMI_SUCCESS;
 }
 

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -123,7 +123,7 @@ status_t xen_events_listen_45(vmi_instance_t vmi, uint32_t timeout);
 status_t xen_set_reg_access_legacy(vmi_instance_t vmi, reg_event_t *event);
 status_t xen_set_intr_access_legacy(vmi_instance_t vmi, interrupt_event_t *event, bool enabled);
 status_t xen_set_mem_access_legacy(vmi_instance_t vmi,
-                                   mem_access_event_t *event,
+                                   addr_t gpfn,
                                    vmi_mem_access_t page_access_flag,
                                    uint16_t vmm_pagetable_id);
 status_t xen_start_single_step_legacy(vmi_instance_t vmi, single_step_event_t *event);
@@ -136,7 +136,7 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout);
 status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event);
 status_t xen_set_intr_access(vmi_instance_t vmi, interrupt_event_t *event, bool enabled);
 status_t xen_set_mem_access(vmi_instance_t vmi,
-                            mem_access_event_t *event,
+                            addr_t gpfn,
                             vmi_mem_access_t page_access_flag,
                             uint16_t vmm_pagetable_id);
 status_t xen_set_guest_requested_event(vmi_instance_t vmi, bool enabled);

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -158,7 +158,9 @@ struct vmi_instance {
 
     GHashTable *interrupt_events; /**< interrupt event to function mapping (key: interrupt) */
 
-    GHashTable *mem_events; /**< mem event to functions mapping (key: physical address) */
+    GHashTable *mem_events_on_gfn; /**< mem event to functions mapping (key: physical address) */
+
+    GHashTable *mem_events_generic; /**< mem event to functions mapping (key: access type) */
 
     GHashTable *reg_events; /**< reg event to functions mapping (key: reg) */
 


### PR DESCRIPTION
The current mem_access event API requires the user to create a vmi_event_t for each page they want to set an event on. This can incur heavy memory overhead when the same type of access restriction is placed on multiple pages.

In this PR we introduce a generic mem event type which allows the user to subscribe to  vmi_mem_access_t events regardless of which page the access violation occurred. We further introduce vmi_set_mem_event which allows the user to change specific page permissions once a handler has been registered.

Notice: we currently don't allow to mix generic mem events with gfn-specific mem events. Doing so may be possible in the future if there is need for it, however for now we choose to reduce the complexity of the code this way.