### PR TITLE
Compile with -Werror -Wall -Wextra and fix associated warnings

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,9 +1,9 @@
 ## Source directory
 
-SUBDIRS = 
+SUBDIRS =
 
 AM_CFLAGS = -I$(top_builddir) $(GLIB_CFLAGS)
-AM_CPPFLAGS = -I$(top_builddir) $(GLIB_CFLAGS)
+AM_CFLAGS += -Werror -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 AM_LDFLAGS = -L$(top_builddir)/libvmi/.libs/
 LDADD = -lvmi -lm $(LIBS) $(GLIB_LIBS)
 

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -39,6 +39,9 @@ main(
     int argc,
     char **argv)
 {
+    if ( argc != 2 )
+        return 1;
+
     vmi_instance_t vmi;
     char *filename = NULL;
     FILE *f = NULL;
@@ -46,7 +49,6 @@ main(
     unsigned char zeros[PAGE_SIZE];
 
     memset(zeros, 0, PAGE_SIZE);
-    uint32_t offset = 0;
     addr_t address = 0;
     addr_t size = 0;
 

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -355,7 +355,6 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
-leave:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -104,7 +104,6 @@ int main (int argc, char **argv) {
     }
     printf("Finished with test.\n");
 
-leave:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 

--- a/examples/map-addr.c
+++ b/examples/map-addr.c
@@ -38,6 +38,9 @@ main(
     int argc,
     char **argv)
 {
+    if ( argc != 3 )
+        return 1;
+
     vmi_instance_t vmi;
     unsigned char *memory = malloc(PAGE_SIZE);
 

--- a/examples/map-symbol.c
+++ b/examples/map-symbol.c
@@ -38,6 +38,9 @@ main(
     int argc,
     char **argv)
 {
+    if ( argc != 2 )
+        return 1;
+
     vmi_instance_t vmi;
     unsigned char *memory = malloc(PAGE_SIZE);
 

--- a/examples/module-list.c
+++ b/examples/module-list.c
@@ -38,8 +38,10 @@ main(
     char **argv)
 {
     vmi_instance_t vmi;
-    uint32_t offset;
     addr_t next_module, list_head;
+
+    if ( argc != 2 )
+        return 1;
 
     /* this is the VM or file that we are looking at */
     char *name = argv[1];

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -31,11 +31,11 @@
 #include <libvmi/libvmi.h>
 #include <libvmi/events.h>
 
-#if HAVE_MEM_EVENT_REASON_MSR || HAVE_VM_EVENT_INTERFACE_VERSION
 vmi_event_t msr_event;
 
-void msr_write_cb(vmi_instance_t vmi, vmi_event_t *event){
+event_response_t msr_write_cb(vmi_instance_t vmi, vmi_event_t *event) {
     printf("MSR write happened: MSR=%lx Value=%lx\n", event->reg_event.context, event->reg_event.value);
+    return 0;
 }
 
 static int interrupted = 0;
@@ -88,15 +88,8 @@ int main (int argc, char **argv) {
     }
     printf("Finished with test.\n");
 
-leave:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 
     return 0;
 }
-#else
-int main (int argc, char **argv) {
-    fprintf(stderr, "MSR events not supported by this hypervisor platform.\n");
-    return 1;
-}
-#endif

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -36,11 +36,8 @@
 int main (int argc, char **argv)
 {
     vmi_instance_t vmi;
-    unsigned char *memory = NULL;
-    uint32_t offset;
     addr_t list_head = 0, next_list_entry = 0;
     addr_t current_process = 0;
-    addr_t tmp_next = 0;
     char *procname = NULL;
     vmi_pid_t pid = 0;
     unsigned long tasks_offset = 0, pid_offset = 0, name_offset = 0;

--- a/examples/shm-snapshot-process-list.c
+++ b/examples/shm-snapshot-process-list.c
@@ -119,6 +119,12 @@ void list_processes(vmi_instance_t vmi, addr_t current_process,
 
 int main (int argc, char **argv)
 {
+    /* this is the VM or file that we are looking at */
+    if (argc != 2) {
+        printf("Usage: %s <vmname>\n", argv[0]);
+        return 1;
+    }
+
 #if ENABLE_SHM_SNAPSHOT == 1
     vmi_instance_t vmi;
     unsigned char *memory = NULL;
@@ -130,12 +136,6 @@ int main (int argc, char **argv)
     vmi_pid_t pid = 0;
     unsigned long tasks_offset, pid_offset, name_offset;
     status_t status;
-
-    /* this is the VM or file that we are looking at */
-    if (argc != 2) {
-        printf("Usage: %s <vmname>\n", argv[0]);
-        return 1;
-    } // if
 
     char *name = argv[1];
 

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -189,7 +189,6 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
-leave:
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);
 

--- a/examples/va-pages.c
+++ b/examples/va-pages.c
@@ -89,7 +89,6 @@ int main (int argc, char **argv)
 
     char *name = NULL;
     va_pages = NULL;
-    vmi_pid_t pid = -1;
 
     if(argc < 2){
         fprintf(stderr, "Usage: events_example <name of VM>\n");
@@ -137,7 +136,6 @@ int main (int argc, char **argv)
     }
     printf("Finished with test.\n");
 
-leave:
     free_va_pages();
     // cleanup any memory associated with the libvmi instance
     vmi_destroy(vmi);

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -104,4 +104,5 @@ lib_LTLIBRARIES= libvmi.la
 libvmi_la_SOURCES= $(h_public) $(h_private) $(drivers) $(os) $(c_sources)
 libvmi_la_LIBADD= config/libconfig.la
 libvmi_la_CFLAGS= -fvisibility=hidden $(GLIB_CFLAGS)
+libvmi_la_CFLAGS+= -Werror -Wall -Wextra -Wno-missing-field-initializers
 libvmi_la_LDFLAGS= -release $(RELEASE) $(GLIB_LIBS)

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -134,8 +134,6 @@ vmi_get_offset(
     vmi_instance_t vmi,
     char *offset_name)
 {
-    size_t max_length = 100;
-
     if (vmi->os_interface == NULL || vmi->os_interface->os_get_offset == NULL ) {
         return 0;
     }

--- a/libvmi/arch/arm_aarch32.c
+++ b/libvmi/arch/arm_aarch32.c
@@ -181,7 +181,7 @@ status_t v2p_aarch32 (vmi_instance_t vmi,
     return status;
 }
 
-GSList* get_va_pages_aarch32(vmi_instance_t vmi, addr_t dtb) {
+GSList* get_va_pages_aarch32(vmi_instance_t UNUSED(vmi), addr_t UNUSED(dtb)) {
     //TODO: investigate best method to loop over all tables
     return NULL;
 }

--- a/libvmi/arch/arm_aarch64.c
+++ b/libvmi/arch/arm_aarch64.c
@@ -302,7 +302,7 @@ done:
     return status;
 }
 
-GSList* get_va_pages_aarch64(vmi_instance_t vmi, addr_t dtb) {
+GSList* get_va_pages_aarch64(vmi_instance_t UNUSED(vmi), addr_t UNUSED(dtb)) {
     //TODO: investigate best method to loop over all tables
     return NULL;
 }

--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -399,7 +399,7 @@ rva_cache_get(
     if ((entry = g_hash_table_lookup(rva_table, GUINT_TO_POINTER(rva))) != NULL) {
         entry->last_used = time(NULL);
         *sym = entry->sym;
-        dbprint(VMI_DEBUG_RVACACHE, "--RVA cache hit 0x%.16%"PRIx64":0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n",
+        dbprint(VMI_DEBUG_RVACACHE, "--RVA cache hit 0x%.16"PRIx64":0x%.16"PRIx64":%s -- 0x%.16"PRIx64"\n",
                 dtb, base_addr, *sym, rva);
         ret=VMI_SUCCESS;
     }

--- a/libvmi/convenience.c
+++ b/libvmi/convenience.c
@@ -134,7 +134,6 @@ vmi_convert_str_encoding(
     size_t inlen = in->length;
     size_t outlen = 2 * (inlen + 1);
 
-    char *instart = (char*)in->contents;
     char *incurr = (char*)in->contents;
 
     memset(out, 0, sizeof(*out));

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -276,7 +276,6 @@ set_image_type_for_file(
 static status_t
 set_id_and_name(
     vmi_instance_t vmi,
-    vmi_mode_t mode,
     uint64_t id,
     const char *name)
 {
@@ -412,7 +411,7 @@ vmi_init_private(
     dbprint(VMI_DEBUG_CORE, "--completed driver init.\n");
 
     /* resolve the id and name */
-    if (VMI_FAILURE == set_id_and_name(*vmi, access_mode, id, name)) {
+    if (VMI_FAILURE == set_id_and_name(*vmi, id, name)) {
         goto error_exit;
     }
 
@@ -530,6 +529,9 @@ vmi_init_private(
     }
 
 error_exit:
+    if ( VMI_FAILURE == status )
+        vmi_destroy(*vmi);
+
     return status;
 }
 

--- a/libvmi/debug.h
+++ b/libvmi/debug.h
@@ -53,6 +53,6 @@ typedef enum {
 } vmi_debug_flag_t;
 
 /* uncomment this and recompile to enable debug output */
-//#define VMI_DEBUG __VMI_DEBUG_ALL
+#define VMI_DEBUG VMI_DEBUG_EVENTS
 
 #endif

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -74,10 +74,12 @@ file_get_memory(
                   ((uint8_t *) file_get_instance(vmi)->map) + paddr,
                   length);
 #else
-    if (paddr != lseek(file_get_instance(vmi)->fd, paddr, SEEK_SET)) {
+    off_t rc = lseek(file_get_instance(vmi)->fd, paddr, SEEK_SET);
+    if ( rc < 0 || (addr_t)rc != paddr ) {
         goto error_print;
     }
-    if (length != read(file_get_instance(vmi)->fd, memory, length)) {
+    ssize_t rc2 = read(file_get_instance(vmi)->fd, memory, length);
+    if ( rc2 < 0 || (size_t)rc2 != length ) {
         goto error_print;
     }
 #endif // USE_MMAP
@@ -97,7 +99,7 @@ error_noprint:
 void
 file_release_memory(
     void *memory,
-    size_t length)
+    size_t UNUSED(length))
 {
     if (memory)
         free(memory);
@@ -238,7 +240,7 @@ file_get_vcpureg(
     vmi_instance_t vmi,
     reg_t *value,
     registers_t reg,
-    unsigned long vcpu)
+    unsigned long UNUSED(vcpu))
 {
     switch (reg) {
     case CR3:
@@ -272,24 +274,24 @@ file_read_page(
 //TODO decide if this functionality makes sense for files
 status_t
 file_write(
-    vmi_instance_t vmi,
-    addr_t paddr,
-    void *buf,
-    uint32_t length)
+    vmi_instance_t UNUSED(vmi),
+    addr_t UNUSED(paddr),
+    void* UNUSED(buf),
+    uint32_t UNUSED(length))
 {
     return VMI_FAILURE;
 }
 
 int
 file_is_pv(
-    vmi_instance_t vmi)
+    vmi_instance_t UNUSED(vmi))
 {
     return 0;
 }
 
 status_t
 file_test(
-    uint64_t id,
+    uint64_t UNUSED(id),
     const char *name)
 {
     status_t ret = VMI_FAILURE;
@@ -318,14 +320,14 @@ error_exit:
 
 status_t
 file_pause_vm(
-    vmi_instance_t vmi)
+    vmi_instance_t UNUSED(vmi))
 {
     return VMI_SUCCESS;
 }
 
 status_t
 file_resume_vm(
-    vmi_instance_t vmi)
+    vmi_instance_t UNUSED(vmi))
 {
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1115,11 +1115,12 @@ kvm_get_memory_patch(
     }
     else {
         // get the data from kvm
-        nbytes =
-            read(kvm_get_instance(vmi)->socket_fd, buf, length + 1);
-        if (nbytes != (length + 1)) {
+        nbytes = read(kvm_get_instance(vmi)->socket_fd, buf, length + 1);
+        if ( nbytes <= 0 )
             goto error_exit;
-        }
+
+        if ( (uint32_t)nbytes != (length + 1) )
+            goto error_exit;
 
         // check that kvm thinks everything is ok by looking at the last byte
         // of the buffer, 0 is failure and 1 is success
@@ -1184,7 +1185,7 @@ kvm_get_memory_native(
 void
 kvm_release_memory(
     void *memory,
-    size_t length)
+    size_t UNUSED(length))
 {
     if (memory)
         free(memory);
@@ -1350,8 +1351,6 @@ void
 kvm_destroy(
     vmi_instance_t vmi)
 {
-    kvm_instance_t *kvm = kvm_get_instance(vmi);
-
     destroy_domain_socket(kvm_get_instance(vmi));
 
 #if ENABLE_SHM_SNAPSHOT == 1
@@ -1370,7 +1369,7 @@ kvm_destroy(
 
 uint64_t
 kvm_get_id_from_name(
-    vmi_instance_t vmi,
+    vmi_instance_t UNUSED(vmi),
     const char *name)
 {
     virConnectPtr conn = NULL;
@@ -1403,7 +1402,7 @@ kvm_get_id_from_name(
 
 status_t
 kvm_get_name_from_id(
-    vmi_instance_t vmi,
+    vmi_instance_t UNUSED(vmi),
     uint64_t domainid,
     char **name)
 {
@@ -1461,7 +1460,7 @@ kvm_set_id(
 
 status_t
 kvm_check_id(
-    vmi_instance_t vmi,
+    vmi_instance_t UNUSED(vmi),
     uint64_t domainid)
 {
     virConnectPtr conn = NULL;
@@ -1540,8 +1539,9 @@ kvm_get_vcpureg(
     vmi_instance_t vmi,
     reg_t *value,
     registers_t reg,
-    unsigned long vcpu)
+    unsigned long UNUSED(vcpu))
 {
+    // TODO: vCPU specific registers
     char *regs = NULL;
 
 #if ENABLE_SHM_SNAPSHOT == 1
@@ -1827,7 +1827,7 @@ kvm_write(
 
 int
 kvm_is_pv(
-    vmi_instance_t vmi)
+    vmi_instance_t UNUSED(vmi))
 {
     return 0;
 }

--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -78,8 +78,6 @@ static void
 clean_cache(
     vmi_instance_t vmi)
 {
-    GList *list = NULL;
-
     while (g_queue_get_length(vmi->memory_cache_lru) > vmi->memory_cache_size_max / 2) {
         gint64 *paddr = g_queue_pop_tail(vmi->memory_cache_lru);
 
@@ -220,7 +218,6 @@ void memory_cache_remove(
     vmi_instance_t vmi,
     addr_t paddr)
 {
-    memory_cache_entry_t entry = NULL;
     addr_t paddr_aligned = paddr & ~(((addr_t) vmi->page_size) - 1);
 
     if (paddr != paddr_aligned) {
@@ -240,12 +237,8 @@ memory_cache_destroy(
     vmi->memory_cache_size_max = 0;
 
     if (vmi->memory_cache_lru) {
-#if GLIB_CHECK_VERSION(2, 32, 0)
-        g_queue_free_full(vmi->memory_cache_lru, g_free);
-#else
-        g_queue_foreach(vmi->memory_cache_lru, g_free, NULL);
+        g_queue_foreach(vmi->memory_cache_lru, (GFunc)g_free, NULL);
         g_queue_free(vmi->memory_cache_lru);
-#endif
         vmi->memory_cache_lru = NULL;
     }
 

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -28,7 +28,6 @@
 #include "xen_events_abi.h"
 
 struct xen_instance;
-typedef struct xen_instance xen_instance_t;
 
 typedef struct {
     void *handle;
@@ -114,4 +113,4 @@ typedef struct {
 
 } libxc_wrapper_t;
 
-status_t create_libxc_wrapper(xen_instance_t *xen);
+status_t create_libxc_wrapper(struct xen_instance *xen);

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -49,7 +49,6 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     /* pull info from registers, if we can */
     reg_t cr0, cr3, cr4, efer;
     int pae = 0, pse = 0, lme = 0;
-    uint8_t msr_efer_lme = 0;   // LME bit in MSR_EFER
 
     /* get the control register values */
     if (driver_get_vcpureg(vmi, &cr0, CR0, 0) == VMI_FAILURE) {

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -271,7 +271,6 @@ status_t linux_init(vmi_instance_t vmi) {
 
     dbprint(VMI_DEBUG_MISC, "**set vmi->kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
-done:
     os_interface = safe_malloc(sizeof(struct os_interface));
     bzero(os_interface, sizeof(struct os_interface));
     os_interface->os_get_offset = linux_get_offset;

--- a/libvmi/os/linux/memory.c
+++ b/libvmi/os/linux/memory.c
@@ -74,7 +74,6 @@ linux_get_taskstruct_addr_from_pid(
         /* if we are back at the list head, we are done */
     } while(list_head != next_process);
 
-error_exit:
     return 0;
 }
 
@@ -85,7 +84,6 @@ linux_get_taskstruct_addr_from_pgd(
 {
     addr_t list_head = 0, next_process = 0;
     addr_t task_pgd = 0;
-    status_t rc = VMI_FAILURE;
     uint8_t width = 0;
     int tasks_offset = 0;
     int mm_offset = 0;
@@ -113,7 +111,8 @@ linux_get_taskstruct_addr_from_pgd(
     /* May fail for some drivers, but handle gracefully below by
      * testing width
      */
-    rc = driver_get_address_width(vmi, &width);
+    if ( VMI_FAILURE == driver_get_address_width(vmi, &width) )
+        return 0;
 
     do {
         addr_t ptr = 0;
@@ -140,7 +139,6 @@ linux_get_taskstruct_addr_from_pgd(
         /* if we are back at the list head, we are done */
     } while (list_head != next_process);
 
-error_exit:
     return 0;
 }
 
@@ -154,8 +152,6 @@ linux_pid_to_pgd(
     uint8_t width = 0;
     status_t rc = VMI_FAILURE;
     linux_instance_t linux_instance = NULL;
-    int pid_offset = 0;
-    int tasks_offset = 0;
     int mm_offset = 0;
     int pgd_offset = 0;
 
@@ -166,8 +162,6 @@ linux_pid_to_pgd(
 
     linux_instance = vmi->os_data;
 
-    pid_offset = linux_instance->pid_offset;
-    tasks_offset = linux_instance->tasks_offset;
     mm_offset = linux_instance->mm_offset;
     pgd_offset = linux_instance->pgd_offset;
 

--- a/libvmi/os/linux/symbols.c
+++ b/libvmi/os/linux/symbols.c
@@ -214,8 +214,8 @@ status_t
 linux_symbol_to_address(
     vmi_instance_t vmi,
     const char *symbol,
-    addr_t *__unused,
-    addr_t *address)
+    addr_t* UNUSED(__unused),
+    addr_t* address)
 {
     status_t ret = VMI_FAILURE;
     linux_instance_t linux_instance = vmi->os_data;

--- a/libvmi/os/os_interface.c
+++ b/libvmi/os/os_interface.c
@@ -40,5 +40,5 @@ status_t os_destroy(vmi_instance_t vmi) {
     }
     vmi->os_data = NULL;
 
-    return VMI_SUCCESS;
+    return status;
 }

--- a/libvmi/os/windows/memory.c
+++ b/libvmi/os/windows/memory.c
@@ -104,7 +104,6 @@ windows_pid_to_pgd(
 {
     addr_t pgd = 0;
     addr_t eprocess = 0;
-    int pid_offset = 0;
     int tasks_offset = 0;
     int pdbase_offset = 0;
     windows_instance_t windows = vmi->os_data;
@@ -113,7 +112,6 @@ windows_pid_to_pgd(
         return VMI_FAILURE;
     }
 
-    pid_offset = windows->pid_offset;
     tasks_offset = windows->tasks_offset;
     pdbase_offset = windows->pdbase_offset;
 
@@ -125,8 +123,7 @@ windows_pid_to_pgd(
     }
 
     /* now follow the pointer to the memory descriptor and grab the pgd value */
-    vmi_read_addr_va(vmi, eprocess + pdbase_offset - tasks_offset, 0,
-                     &pgd);
+    vmi_read_addr_va(vmi, eprocess + pdbase_offset - tasks_offset, 0, &pgd);
 
 error_exit:
     return pgd;

--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -449,7 +449,6 @@ peparse_get_export_table(
 
     access_context_t _ctx = *ctx;
     addr_t export_header_rva = 0;
-    addr_t export_header_va = 0;
     size_t export_header_size = 0;
     size_t nbytes = 0;
 
@@ -475,7 +474,7 @@ peparse_get_export_table(
         *export_table_size=export_header_size;
     }
 
-    dbprint(VMI_DEBUG_PEPARSE, "--PEParse: DLL base 0x%.16"PRIx64". Export header [RVA] 0x%.16"PRIx64". Size %u.\n",
+    dbprint(VMI_DEBUG_PEPARSE, "--PEParse: DLL base 0x%.16"PRIx64". Export header [RVA] 0x%.16"PRIx64". Size %" PRIu64 ".\n",
             ctx->addr, export_header_rva, export_header_size);
 
     _ctx.addr = ctx->addr + export_header_rva;
@@ -534,13 +533,15 @@ windows_export_to_rva(
     }
 
     // find AddressOfNames index for export symbol
-    if ((aon_index = get_aon_index(vmi, symbol, &et, ctx)) == -1) {
+    aon_index = get_aon_index(vmi, symbol, &et, ctx);
+    if ( -1 == aon_index ) {
         dbprint(VMI_DEBUG_PEPARSE, "--PEParse: failed to get aon index\n");
         return VMI_FAILURE;
     }
 
     // find AddressOfFunctions index for export symbol
-    if ((aof_index = get_aof_index(vmi, aon_index, &et, ctx)) == -1) {
+    aof_index = get_aof_index(vmi, aon_index, &et, ctx);
+    if ( -1 == aof_index ) {
         dbprint(VMI_DEBUG_PEPARSE, "--PEParse: failed to get aof index\n");
         return VMI_FAILURE;
     }
@@ -552,7 +553,7 @@ windows_export_to_rva(
         // If the function's RVA is inside the exports section (as given by the
         // VirtualAddress and Size fields in the idd), the symbol is forwarded.
         if(*rva>=et_rva && *rva < et_rva+et_size) {
-            dbprint(VMI_DEBUG_PEPARSE, "--PEParse: %s @ %u:0x%"PRIx64" is forwarded\n", symbol, ctx);
+            dbprint(VMI_DEBUG_PEPARSE, "--PEParse: %s @ 0x%p is forwarded\n", symbol, ctx);
             return VMI_FAILURE;
         } else {
             return VMI_SUCCESS;
@@ -573,9 +574,6 @@ windows_rva_to_export(
     struct export_table et;
     addr_t et_rva;
     size_t et_size;
-    int aon_index = -1;
-    int aof_index = -1;
-    char* symbol = NULL;
 
     // get export table structure
     if (peparse_get_export_table(vmi, ctx, &et, &et_rva, &et_size) != VMI_SUCCESS) {

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -36,7 +36,7 @@ windows_get_eprocess_name(
     vmi_instance_t vmi,
     addr_t paddr)
 {
-    int name_length = 16;   //TODO verify that this is correct for all versions
+    size_t name_length = 16;   //TODO verify that this is correct for all versions
     windows_instance_t windows = vmi->os_data;
 
     if (windows == NULL) {
@@ -251,7 +251,8 @@ windows_find_eprocess(
 
     if (!windows->pname_offset) {
         if(windows->rekall_profile) {
-            rekall_profile_symbol_to_rva(windows->rekall_profile, "_EPROCESS", "ImageFileName", &windows->pname_offset);
+            if ( VMI_FAILURE == rekall_profile_symbol_to_rva(windows->rekall_profile, "_EPROCESS", "ImageFileName", &windows->pname_offset) )
+                return 0;
         } else {
             windows->pname_offset = find_pname_offset(vmi, check);
         }

--- a/libvmi/performance.c
+++ b/libvmi/performance.c
@@ -84,7 +84,7 @@ stddev(
 }
 
 static void
-avg_measurement(
+UNUSED_FUNCTION(avg_measurement)(
     long int *data,
     int loops)
 {

--- a/libvmi/pretty_print.c
+++ b/libvmi/pretty_print.c
@@ -33,13 +33,13 @@ vmi_print_hex(
     unsigned char *data,
     unsigned long length)
 {
-    int i, j, numrows, index;
+    unsigned long i, j, numrows, index;
 
     numrows = (length + 15) >> 4;
 
     for (i = 0; i < numrows; ++i) {
         /* print the byte count */
-        printf("%.8x|  ", i * 16);
+        printf("%.8lx|  ", i * 16);
 
         /* print the first 8 hex values */
         for (j = 0; j < 8; ++j) {

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -249,6 +249,18 @@ addr_t canonical_addr(addr_t va) {
     vmi_instance_t vmi,
     addr_t addr);
 
+#ifdef __GNUC__
+#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define UNUSED(x) UNUSED_ ## x
+#endif
+
+#ifdef __GNUC__
+#  define UNUSED_FUNCTION(x) __attribute__((__unused__)) UNUSED_ ## x
+#else
+#  define UNUSED_FUNCTION(x) UNUSED_ ## x
+#endif
+
 /*-------------------------------------
  * accessors.c
  */
@@ -328,6 +340,8 @@ status_t vmi_pagetable_lookup_cache(
         addr_t base_addr,
         addr_t dtb,
         addr_t rva);
+    void rva_cache_flush(
+        vmi_instance_t vmi);
 
     void v2p_cache_init(
     vmi_instance_t vmi);
@@ -427,6 +441,10 @@ status_t vmi_pagetable_lookup_cache(
         vmi_event_t *swap_from,
         vmi_event_t *swap_to,
         vmi_event_free_t free_routine);
+    gboolean clear_events(
+        gpointer key,
+        gpointer value,
+        gpointer data);
 
     #define ghashtable_foreach(table, iter, key, val) \
         g_hash_table_iter_init(&iter, table); \

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -190,7 +190,7 @@ vmi_read_X(
     vmi_instance_t vmi,
     const access_context_t *ctx,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_read = vmi_read(vmi, ctx, value, size);
 
@@ -373,7 +373,7 @@ vmi_read_X_pa(
     vmi_instance_t vmi,
     addr_t paddr,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_read = vmi_read_pa(vmi, paddr, value, size);
 
@@ -473,7 +473,7 @@ vmi_read_X_va(
     addr_t vaddr,
     vmi_pid_t pid,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_read = vmi_read_va(vmi, vaddr, pid, value, size);
 
@@ -590,7 +590,7 @@ vmi_read_X_ksym(
     vmi_instance_t vmi,
     char *sym,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_read = vmi_read_ksym(vmi, sym, value, size);
 

--- a/libvmi/rekall.c
+++ b/libvmi/rekall.c
@@ -32,7 +32,6 @@ rekall_profile_symbol_to_rva(
     addr_t *rva)
 {
     status_t ret = VMI_FAILURE;
-    addr_t mask = 0;
     if(!rekall_profile || !symbol) {
         return ret;
     }
@@ -46,67 +45,48 @@ rekall_profile_symbol_to_rva(
     if(!subsymbol) {
         json_object *constants = NULL, *jsymbol = NULL;
         if (!json_object_object_get_ex(root, "$CONSTANTS", &constants)) {
-            dbprint(VMI_DEBUG_MISC, "Rekall profile: no $CONSTANTS section found\n", symbol);
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: no $CONSTANTS section found\n");
             goto exit;
         }
 
         if (!json_object_object_get_ex(constants, symbol, &jsymbol)){
             dbprint(VMI_DEBUG_MISC, "Rekall profile: symbol '%s' not found\n", symbol);
-            json_object_put(constants);
             goto exit;
         }
 
         *rva = json_object_get_int64(jsymbol);
 
         ret = VMI_SUCCESS;
-
-        json_object_put(jsymbol);
-        json_object_put(constants);
     } else {
         json_object *structs = NULL, *jstruct = NULL, *jstruct2 = NULL, *jmember = NULL, *jvalue = NULL;
         if (!json_object_object_get_ex(root, "$STRUCTS", &structs)) {
-            dbprint(VMI_DEBUG_MISC, "Rekall profile: no $STRUCTS section found\n", symbol);
+            dbprint(VMI_DEBUG_MISC, "Rekall profile: no $STRUCTS section found\n");
             goto exit;
         }
         if (!json_object_object_get_ex(structs, symbol, &jstruct)) {
             dbprint(VMI_DEBUG_MISC, "Rekall profile: no %s found\n", symbol);
-            json_object_put(structs);
             goto exit;
         }
 
         jstruct2 = json_object_array_get_idx(jstruct, 1);
         if (!jstruct2) {
             dbprint(VMI_DEBUG_MISC, "Rekall profile: struct %s has no second element\n", symbol);
-            json_object_put(jstruct);
-            json_object_put(structs);
             goto exit;
         }
 
         if (!json_object_object_get_ex(jstruct2, subsymbol, &jmember)) {
             dbprint(VMI_DEBUG_MISC, "Rekall profile: %s has no %s member\n", symbol, subsymbol);
-            json_object_put(jstruct2);
-            json_object_put(jstruct);
-            json_object_put(structs);
             goto exit;
         }
 
         jvalue = json_object_array_get_idx(jmember, 0);
         if (!jvalue) {
             dbprint(VMI_DEBUG_MISC, "Rekall profile: %s.%s has no RVA defined\n", symbol, subsymbol);
-            json_object_put(jmember);
-            json_object_put(jstruct2);
-            json_object_put(jstruct);
-            json_object_put(structs);
             goto exit;
         }
 
         *rva = json_object_get_int64(jvalue);
         ret = VMI_SUCCESS;
-
-        json_object_put(jmember);
-        json_object_put(jstruct2);
-        json_object_put(jstruct);
-        json_object_put(structs);
     }
 
 exit:

--- a/libvmi/rekall.h
+++ b/libvmi/rekall.h
@@ -21,6 +21,8 @@
 #ifndef LIBVMI_REKALL_H
 #define LIBVMI_REKALL_H
 
+#include "private.h"
+
 #ifdef REKALL_PROFILES
 
 status_t
@@ -32,15 +34,7 @@ rekall_profile_symbol_to_rva(
 
 #else
 
-static inline status_t
-rekall_profile_symbol_to_rva(
-    const char *rekall_profile,
-    const char *symbol,
-    const char *subsymbol,
-    addr_t *rva)
-{
-    return VMI_FAILURE;
-}
+#define rekall_profile_symbol_to_rva(...) VMI_FAILURE
 
 #endif
 

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -39,7 +39,6 @@ vmi_write(
     addr_t start_addr = 0;
     addr_t dtb = 0;
     addr_t paddr = 0;
-    addr_t pfn = 0;
     addr_t offset = 0;
     size_t buf_offset = 0;
 
@@ -183,7 +182,7 @@ status_t vmi_write_X(
     vmi_instance_t vmi,
     const access_context_t *ctx,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_write = vmi_write(vmi, ctx, value, size);
 
@@ -262,7 +261,7 @@ vmi_write_X_pa(
     vmi_instance_t vmi,
     addr_t paddr,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_write = vmi_write_pa(vmi, paddr, value, size);
 
@@ -332,7 +331,7 @@ vmi_write_X_va(
     addr_t vaddr,
     vmi_pid_t pid,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_write = vmi_write_va(vmi, vaddr, pid, value, size);
 
@@ -406,7 +405,7 @@ vmi_write_X_ksym(
     vmi_instance_t vmi,
     char *sym,
     void *value,
-    int size)
+    size_t size)
 {
     size_t len_write = vmi_write_ksym(vmi, sym, value, size);
 


### PR DESCRIPTION
The changes are mechanic fixing of warnings issued mostly by -Wunused-parameter and -Wunused-variable