### PR TITLE
Support out of tree builds for examples

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -2,7 +2,7 @@
 
 SUBDIRS =
 
-AM_CFLAGS = -I$(top_builddir) $(GLIB_CFLAGS)
+AM_CFLAGS = -I$(top_srcdir) $(GLIB_CFLAGS)
 AM_CFLAGS += -Werror -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 AM_LDFLAGS = -L$(top_builddir)/libvmi/.libs/
 LDADD = -lvmi -lm $(LIBS) $(GLIB_LIBS)


### PR DESCRIPTION
When building examples out of tree, include files relative to the top
source directory rather than the top build directory.