### PR TITLE
Fix GCC warnings about ignored return values

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -315,7 +315,10 @@ destroy_domain_socket(
         req.type = 0;   // quit
         req.address = 0;
         req.length = 0;
-        write(kvm->socket_fd, &req, sizeof(struct request));
+        int size = write(kvm->socket_fd, &req, sizeof(struct request));
+        if (size == -1) {
+            dbprint(VMI_DEBUG_KVM, "--destroy domain socket failed\n");
+        }
     }
 }
 
@@ -1213,9 +1216,12 @@ kvm_put_memory(
     else {
         uint8_t status = 0;
 
-        write(kvm_get_instance(vmi)->socket_fd, buf, length);
-        read(kvm_get_instance(vmi)->socket_fd, &status, 1);
-        if (0 == status) {
+        int size = write(kvm_get_instance(vmi)->socket_fd, buf, length);
+        if (size == -1) {
+            goto error_exit;
+        }
+        size = read(kvm_get_instance(vmi)->socket_fd, &status, 1);
+        if (size == -1 || 0 == status) {
             goto error_exit;
         }
     }


### PR DESCRIPTION
This fixes the following errors when compiling with GCC 6.2.1:

driver/kvm/kvm.c:1216:9: error: ignoring return value of 'write', declared with attribute warn_unused_result [-Werror=unused-result]
         write(kvm_get_instance(vmi)->socket_fd, buf, length);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
driver/kvm/kvm.c:1217:9: error: ignoring return value of 'read', declared with attribute warn_unused_result [-Werror=unused-result]
         read(kvm_get_instance(vmi)->socket_fd, &status, 1);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
driver/kvm/kvm.c: In function 'destroy_domain_socket':
driver/kvm/kvm.c:318:9: error: ignoring return value of 'write', declared with attribute warn_unused_result [-Werror=unused-result]
         write(kvm->socket_fd, &req, sizeof(struct request));

Signed-off-by: W. Michael Petullo <mike@flyn.org>