### PR TITLE
Fix argument count check so dump-memory runs correctly

### DIFF
--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -39,7 +39,7 @@ main(
     int argc,
     char **argv)
 {
-    if ( argc != 2 )
+    if ( argc != 3 )
         return 1;
 
     vmi_instance_t vmi;


### PR DESCRIPTION
Fix argc check to verify 3 arguments instead of 2 so we can read from argv[2] later on in the program