### PR TITLE
Test peparse on XP VMs only

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,6 +2,7 @@
 
 function error_exit
 {
+    cat tests/test-suite.log
     sudo make clean
     exit 1
 }

--- a/tests/test_peparse.c
+++ b/tests/test_peparse.c
@@ -264,7 +264,7 @@ START_TEST (test_peparse)
     vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
     addr_t kernbase;
 
-    if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)){
+    if (VMI_OS_WINDOWS == vmi_get_ostype(vmi) && VMI_OS_WINDOWS_XP == vmi_get_winver(vmi)){
 
         kernbase = vmi_translate_ksym2v(vmi, "KernBase");
 


### PR DESCRIPTION
Testing peparse on Win7 results in the following error:
test_peparse.c:294:F:LibVMI PEparse:test_peparse:0: Failed to read PE image @ 0x0!

This is because the test relies on getting the KernBase symbol that is only available when initializing with KDBG search, which only applies to XP images.