### PR TITLE
Correct argument count check in map-symbol example

### DIFF
--- a/examples/map-symbol.c
+++ b/examples/map-symbol.c
@@ -38,7 +38,7 @@ main(
     int argc,
     char **argv)
 {
-    if ( argc != 2 )
+    if ( argc != 3 )
         return 1;
 
     vmi_instance_t vmi;


### PR DESCRIPTION
argc must be at least 3 for argv[2] to not be nil