### PR TITLE
Fix memory leak when trying to init events on PV domains

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -901,7 +901,7 @@ xen_init_vmi(
     if ( VMI_FAILURE == ret )
         goto _bail;
 
-    if(vmi->init_mode & VMI_INIT_EVENTS)
+    if(xen->hvm && (vmi->init_mode & VMI_INIT_EVENTS))
     {
         ret = xen_init_events(vmi);
 


### PR DESCRIPTION
Destroying events is only called if xen->hvm is set, so we should mirror that for the initialization.