### PR TITLE
Fix key memory leak on various events tables

### DIFF
--- a/libvmi/driver/xen/xen_events_46.c
+++ b/libvmi/driver/xen/xen_events_46.c
@@ -1070,7 +1070,7 @@ status_t xen_events_listen_46(vmi_instance_t vmi, uint32_t timeout)
             loop = loop->next;
         }
 
-        g_hash_table_foreach_steal(vmi->clear_events, clear_events, vmi);
+        g_hash_table_foreach_remove(vmi->clear_events, clear_events, vmi);
 
         vmi_resume_vm(vmi);
     }

--- a/libvmi/driver/xen/xen_events_48.c
+++ b/libvmi/driver/xen/xen_events_48.c
@@ -1242,7 +1242,7 @@ status_t xen_events_listen_48(vmi_instance_t vmi, uint32_t timeout)
             loop = loop->next;
         }
 
-        g_hash_table_foreach_steal(vmi->clear_events, clear_events, vmi);
+        g_hash_table_foreach_remove(vmi->clear_events, clear_events, vmi);
 
         vmi_resume_vm(vmi);
     }

--- a/libvmi/driver/xen/xen_events_legacy.c
+++ b/libvmi/driver/xen/xen_events_legacy.c
@@ -1062,7 +1062,7 @@ status_t xen_events_listen_45(vmi_instance_t vmi, uint32_t timeout)
         vmi_pause_vm(vmi); // Pause all vCPUs
         vrc = process_requests_45(vmi, &req, &rsp);
 
-        g_hash_table_foreach_steal(vmi->clear_events, clear_events, vmi);
+        g_hash_table_foreach_remove(vmi->clear_events, clear_events, vmi);
 
         vmi_resume_vm(vmi);
     }


### PR DESCRIPTION
Using g_hash_table_foreach_steal was not correctly freeing the keys.