### PR TITLE
Rework parts of the events ABI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ examples/step-event-example
 examples/step-event-example.o
 examples/va-pages
 examples/va-pages.o
+examples/xen-emulate-response
+examples/xen-emulate-response.o
 install-sh
 libtool
 libvmi.pc

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -50,8 +50,7 @@ vmi_event_t kernel_vsyscall_event;
 vmi_event_t kernel_sysenter_target_event;
 
 void print_event(vmi_event_t event){
-    printf("PAGE %"PRIx64" ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %"PRIu32")\n",
-        event.mem_event.physical_address,
+    printf("PAGE ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %"PRIu32")\n",
         (event.mem_event.out_access & VMI_MEMACCESS_R) ? 'r' : '-',
         (event.mem_event.out_access & VMI_MEMACCESS_W) ? 'w' : '-',
         (event.mem_event.out_access & VMI_MEMACCESS_X) ? 'x' : '-',
@@ -334,20 +333,17 @@ int main (int argc, char **argv)
     memset(&msr_syscall_sysenter_event, 0, sizeof(vmi_event_t));
     msr_syscall_sysenter_event.version = VMI_EVENTS_VERSION;
     msr_syscall_sysenter_event.type = VMI_EVENT_MEMORY;
-    msr_syscall_sysenter_event.mem_event.physical_address = phys_sysenter_ip;
-    msr_syscall_sysenter_event.mem_event.npages = 1;
+    msr_syscall_sysenter_event.mem_event.gfn = phys_sysenter_ip >> 12;
 
     memset(&kernel_sysenter_target_event, 0, sizeof(vmi_event_t));
     kernel_sysenter_target_event.version = VMI_EVENTS_VERSION;
     kernel_sysenter_target_event.type = VMI_EVENT_MEMORY;
-    kernel_sysenter_target_event.mem_event.physical_address = phys_ia32_sysenter_target;
-    kernel_sysenter_target_event.mem_event.npages = 1;
+    kernel_sysenter_target_event.mem_event.gfn = phys_ia32_sysenter_target >> 12;
 
     memset(&kernel_vsyscall_event, 0, sizeof(vmi_event_t));
     kernel_vsyscall_event.version = VMI_EVENTS_VERSION;
     kernel_vsyscall_event.type = VMI_EVENT_MEMORY;
-    kernel_vsyscall_event.mem_event.physical_address = phys_vsyscall;
-    kernel_vsyscall_event.mem_event.npages = 1;
+    kernel_vsyscall_event.mem_event.gfn = phys_vsyscall >> 12;
 
     while(!interrupted){
         printf("Waiting for events...\n");

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -46,8 +46,7 @@ static void close_handler(int sig){
 }
 
 void print_event(vmi_event_t *event){
-    printf("\tPAGE %"PRIx64" ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %u)\n",
-        event->mem_event.physical_address,
+    printf("\tPAGE ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %u)\n",
         (event->mem_event.out_access & VMI_MEMACCESS_R) ? 'r' : '-',
         (event->mem_event.out_access & VMI_MEMACCESS_W) ? 'w' : '-',
         (event->mem_event.out_access & VMI_MEMACCESS_X) ? 'x' : '-',

--- a/examples/xen-emulate-response.c
+++ b/examples/xen-emulate-response.c
@@ -32,8 +32,7 @@
 #include <libvmi/events.h>
 
 void print_event(vmi_event_t *event){
-    printf("PAGE %"PRIx64" ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %"PRIu32")\n",
-        event->mem_event.physical_address,
+    printf("PAGE ACCESS: %c%c%c for GFN %"PRIx64" (offset %06"PRIx64") gla %016"PRIx64" (vcpu %"PRIu32")\n",
         (event->mem_event.out_access & VMI_MEMACCESS_R) ? 'r' : '-',
         (event->mem_event.out_access & VMI_MEMACCESS_W) ? 'w' : '-',
         (event->mem_event.out_access & VMI_MEMACCESS_X) ? 'x' : '-',
@@ -98,8 +97,7 @@ int main (int argc, char **argv)
     memset(&event, 0, sizeof(vmi_event_t));
     event.version = VMI_EVENTS_VERSION;
     event.type = VMI_EVENT_MEMORY;
-    event.mem_event.physical_address = vmi_translate_kv2p(vmi, addr);
-    event.mem_event.npages = 1;
+    event.mem_event.gfn = vmi_translate_kv2p(vmi, addr) >> 12;
     event.mem_event.in_access = VMI_MEMACCESS_X;
     event.callback = cb;
 


### PR DESCRIPTION
Fixes #417 
Fixes #420 

The physical_address and the generic bits are required if the user calls vmi_clear_event in a callback. We simply retire physical_address and use simple gfn going forward, eliminating the need for the union of IN/OUT structs.

Convert some IN fields to CONST IN so that it's more intuitive and conforms to the intended use of vmi_step_event and avoids having to reset fields before calling vmi_clear_event.

Bumping events version as this is an events ABI change.