### PR TITLE
Alter vmi_get_offset prototype to use a const char *

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -132,7 +132,7 @@ vmi_get_winver_manual(
 uint64_t
 vmi_get_offset(
     vmi_instance_t vmi,
-    char *offset_name)
+    const char *offset_name)
 {
     if (vmi->os_interface == NULL || vmi->os_interface->os_get_offset == NULL ) {
         return 0;

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1728,7 +1728,7 @@ win_ver_t vmi_get_winver_manual(
  */
 uint64_t vmi_get_offset(
     vmi_instance_t vmi,
-    char *offset_name);
+    const char *offset_name);
 
 /**
  * Gets the memory size of the guest or file that LibVMI is currently


### PR DESCRIPTION
Alter vmi_get_offset to take a const char * offset name, matching the prototype of the underlying os_get_offset_t