### PR TITLE
Wrap all hypervisor library calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ xen_space='      '
 
     [if test "$with_xenstore" = "yes"]
     [then]
-        AC_CHECK_LIB(xenstore, xs_read, [], [missing="yes"])
+        AC_CHECK_LIB(xenstore, xs_read, [missing="no"], [missing="yes"])
         AC_CHECK_HEADERS([xenstore.h])
         AC_CHECK_HEADERS([xs.h])
     [fi]
@@ -188,7 +188,12 @@ xen_space='      '
         enable_xen='no'
         have_xen='missing xenstore'
     [else]
-        AC_CHECK_LIB(xenctrl, xc_interface_open, [], [missing="yes"])
+        [if test "$with_xenstore" = "yes"]
+        [then]
+            AC_DEFINE(HAVE_LIBXENSTORE, [1], [Define to 1 if enable xenstore access])
+        [fi]
+
+        AC_CHECK_LIB(xenctrl, xc_interface_open, [missing="no"], [missing="yes"])
         [if test "$missing" = "yes"]
         [then]
             AC_DEFINE([ENABLE_XEN], [0], [Define to 1 to enable Xen support.])

--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,7 @@ kvm_space='      '
         enable_kvm='no'
         have_kvm='libm missing'
     [else]
-        AC_CHECK_LIB(virt, virConnectOpen, [], [missing="yes"])
+        AC_CHECK_LIB(virt, virConnectOpen, [missing="no"], [missing="yes"])
         [if test "$missing" = "yes"]
         [then]
             AC_DEFINE([ENABLE_KVM], [0], [Define to 1 to enable KVM support.])
@@ -253,6 +253,7 @@ kvm_space='      '
             enable_kvm='no'
             have_kvm='libvirt missing'
         [else]
+            AC_CHECK_LIB(rt, shm_open)
             AC_DEFINE([ENABLE_KVM], [1], [Define to 1 to enable KVM support.])
             missing='no'
             have_kvm='yes'

--- a/configure.ac
+++ b/configure.ac
@@ -352,7 +352,7 @@ missing='no'
         [echo "No working JSON-C library found (libjson-c-dev), Rekall system profiles won't be supported."]
     [fi]
 [fi]
-AM_CONDITIONAL([REKALL_PROFILES], [test x$rekall = xyes])
+AM_CONDITIONAL([REKALL_PROFILES], [test x"$rekall" = xyes])
 
 [if test "$enable_address_cache" = "yes"]
 [then]

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -63,7 +63,9 @@ endif
 if HAVE_KVM
 drivers     += driver/kvm/kvm.h \
                driver/kvm/kvm_private.h \
-               driver/kvm/kvm.c
+               driver/kvm/kvm.c \
+               driver/kvm/libvirt_wrapper.c \
+               driver/kvm/libvirt_wrapper.h
 if SHM
 drivers     += driver/kvm/kvm_shm.h
 endif
@@ -82,7 +84,9 @@ drivers     += driver/xen/altp2m.c \
                driver/xen/xen_events_48.c \
                driver/xen/xen_events_legacy.c \
                driver/xen/libxc_wrapper.c \
-               driver/xen/libxs_wrapper.c
+               driver/xen/libxc_wrapper.h \
+               driver/xen/libxs_wrapper.c \
+               driver/xen/libxs_wrapper.h
 endif
 
 os =

--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -81,7 +81,8 @@ drivers     += driver/xen/altp2m.c \
                driver/xen/xen_events_46.c \
                driver/xen/xen_events_48.c \
                driver/xen/xen_events_legacy.c \
-               driver/xen/libxc_wrapper.c
+               driver/xen/libxc_wrapper.c \
+               driver/xen/libxs_wrapper.c
 endif
 
 os =

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -49,7 +49,7 @@ status_t driver_init_mode(vmi_instance_t vmi, uint64_t domainid, const char *nam
 
     /* see what systems are accessable */
 #if ENABLE_XEN == 1
-    if (VMI_SUCCESS == xen_test(domainid, name)) {
+    if (VMI_SUCCESS == xen_test(vmi, domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found Xen\n");
         vmi->mode = VMI_XEN;
         count++;

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -56,7 +56,7 @@ status_t driver_init_mode(vmi_instance_t vmi, uint64_t domainid, const char *nam
     }
 #endif
 #if ENABLE_KVM == 1
-    if (VMI_SUCCESS == kvm_test(domainid, name)) {
+    if (VMI_SUCCESS == kvm_test(vmi, domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found KVM\n");
         vmi->mode = VMI_KVM;
         count++;

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -78,6 +78,7 @@ status_t kvm_write(
 int kvm_is_pv(
     vmi_instance_t vmi);
 status_t kvm_test(
+    vmi_instance_t vmi,
     uint64_t domainid,
     const char *name);
 status_t kvm_pause_vm(

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -31,6 +31,9 @@
 #include <libvirt/libvirt.h>
 #include <libvirt/virterror.h>
 
+#include "private.h"
+#include "libvirt_wrapper.h"
+
 #if ENABLE_SHM_SNAPSHOT == 1
 #include "driver/kvm/kvm_shm.h"
 #endif
@@ -42,6 +45,7 @@ typedef struct kvm_instance {
     char *name;
     char *ds_path;
     int socket_fd;
+    libvirt_wrapper_t libvirt;
 #if ENABLE_SHM_SNAPSHOT == 1
     char *shm_snapshot_path;  /** shared memory snapshot device path in /dev/shm directory */
     int   shm_snapshot_fd;    /** file description of the shared memory snapshot device */

--- a/libvmi/driver/kvm/libvirt_wrapper.c
+++ b/libvmi/driver/kvm/libvirt_wrapper.c
@@ -1,0 +1,63 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel <tamas.lengyel@zentific.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "kvm_private.h"
+
+static inline status_t sanity_check(kvm_instance_t *kvm)
+{
+    libvirt_wrapper_t *w = &kvm->libvirt;
+
+    if ( !w->virConnectOpenAuth || !w->virConnectGetLibVersion || !w->virConnectAuthPtrDefault ||
+         !w->virConnectClose || !w->virDomainGetName || !w->virDomainGetID ||
+         !w->virDomainLookupByID || !w->virDomainLookupByName || !w->virDomainGetInfo ||
+         !w->virDomainFree || !w->virDomainSuspend || !w->virDomainResume )
+        return VMI_FAILURE;
+
+    return VMI_SUCCESS;
+}
+
+status_t create_libvirt_wrapper(kvm_instance_t *kvm)
+{
+    libvirt_wrapper_t *wrapper = &kvm->libvirt;
+
+    wrapper->handle = dlopen ("libvirt.so", RTLD_NOW | RTLD_GLOBAL);
+
+    if ( !wrapper->handle )
+        return VMI_FAILURE;
+
+    wrapper->virConnectOpenAuth = dlsym(wrapper->handle, "virConnectOpenAuth");
+    wrapper->virConnectGetLibVersion = dlsym(wrapper->handle, "virConnectGetLibVersion");
+    wrapper->virConnectClose = dlsym(wrapper->handle, "virConnectClose");
+    wrapper->virDomainGetName = dlsym(wrapper->handle, "virDomainGetName");
+    wrapper->virDomainGetID = dlsym(wrapper->handle, "virDomainGetID");
+    wrapper->virDomainLookupByID = dlsym(wrapper->handle, "virDomainLookupByID");
+    wrapper->virDomainLookupByName = dlsym(wrapper->handle, "virDomainLookupByName");
+    wrapper->virDomainGetInfo = dlsym(wrapper->handle, "virDomainGetInfo");
+    wrapper->virDomainFree = dlsym(wrapper->handle, "virDomainFree");
+    wrapper->virDomainSuspend = dlsym(wrapper->handle, "virDomainSuspend");
+    wrapper->virDomainResume = dlsym(wrapper->handle, "virDomainResume");
+    wrapper->virConnectAuthPtrDefault = dlsym(wrapper->handle, "virConnectAuthPtrDefault");
+
+    return sanity_check(kvm);
+}

--- a/libvmi/driver/kvm/libvirt_wrapper.h
+++ b/libvmi/driver/kvm/libvirt_wrapper.h
@@ -1,0 +1,71 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel <tamas.lengyel@zentific.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <libvirt/libvirt.h>
+#include <dlfcn.h>
+
+#include "libvmi.h"
+
+struct kvm_instance;
+
+typedef struct {
+    void *handle;
+
+    virConnectPtr (*virConnectOpenAuth)
+        (const char *name, virConnectAuthPtr auth, unsigned int flags);
+
+    int (*virConnectGetLibVersion)
+        (virConnectPtr conn, unsigned long *libVer);
+
+    int (*virConnectClose)
+        (virConnectPtr conn);
+
+    const char* (*virDomainGetName)
+        (virDomainPtr domain);
+
+    unsigned int (*virDomainGetID)
+        (virDomainPtr domain);
+
+    virDomainPtr (*virDomainLookupByID)
+        (virConnectPtr conn, int id);
+
+    virDomainPtr (*virDomainLookupByName)
+        (virConnectPtr conn, const char *name);
+
+    int (*virDomainGetInfo)
+        (virDomainPtr domain, virDomainInfoPtr info);
+
+    int (*virDomainFree)
+        (virDomainPtr domain);
+
+    int (*virDomainSuspend)
+        (virDomainPtr domain);
+
+    int (*virDomainResume)
+        (virDomainPtr domain);
+
+    virConnectAuthPtr virConnectAuthPtrDefault;
+
+} libvirt_wrapper_t;
+
+status_t create_libvirt_wrapper(struct kvm_instance *kvm);

--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -56,6 +56,9 @@ static status_t sanity_check(xen_instance_t *xen)
 
     switch ( xen->minor_version )
     {
+        case 0:
+            dbprint(VMI_DEBUG_XEN, "Xen 4.0 no longer supported!\n");
+            break;
         case 1:
             if ( !w->xc_domain_maximum_gpfn )
                 break;
@@ -91,6 +94,8 @@ static status_t sanity_check(xen_instance_t *xen)
             break;
 
         /* Things start to be a bit saner from 4.6 */
+        default:
+            /* Fall-through */
         case 8:
             if ( !w->xc_monitor_debug_exceptions || !w->xc_monitor_cpuid ||
                  !w->xc_monitor_mov_to_msr2 )
@@ -113,8 +118,6 @@ static status_t sanity_check(xen_instance_t *xen)
                 break;
 
             ret = VMI_SUCCESS;
-            break;
-        default:
             break;
     };
 

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -28,9 +28,98 @@
 #include "xen_events_abi.h"
 
 struct xen_instance;
+typedef int xc_evtchn_port_or_error_t;
 
 typedef struct {
     void *handle;
+
+    /* Xen 4.1+ */
+    xc_interface* (*xc_interface_open)
+            (xentoollog_logger *logger, xentoollog_logger *dombuild_logger, unsigned open_flags);
+
+    int (*xc_interface_close)
+            (xc_interface *xch);
+
+    int (*xc_version)
+            (xc_interface *xch, int cmd, void *arg);
+
+    void* (*xc_map_foreign_range)
+            (xc_interface *xch, uint32_t domid, int size, int prot, unsigned long mfn );
+
+    int (*xc_vcpu_getcontext)
+            (xc_interface *xch, uint32_t domid, uint32_t vcpu, vcpu_guest_context_any_t *ctxt);
+
+    int (*xc_vcpu_setcontext)
+            (xc_interface *xch, uint32_t domid, uint32_t vcpu, vcpu_guest_context_any_t *ctxt);
+
+    int (*xc_domain_hvm_getcontext)
+            (xc_interface *xch, uint32_t domid, uint8_t *ctxt_buf, uint32_t size);
+
+    int (*xc_domain_hvm_setcontext)
+            (xc_interface *xch, uint32_t domid, uint8_t *hvm_ctxt, uint32_t size);
+
+    int (*xc_domain_hvm_getcontext_partial)
+            (xc_interface *xch, uint32_t domid, uint16_t typecode,
+             uint16_t instance, void *ctxt_buf, uint32_t size);
+
+    int (*xc_domain_getinfo)
+            (xc_interface *xch, uint32_t first_domid, unsigned int max_doms, xc_dominfo_t *info);
+
+    int (*xc_domctl)
+            (xc_interface *xch, struct xen_domctl *domctl);
+
+    int (*xc_domain_pause)
+            (xc_interface *xch, uint32_t domid);
+
+    int (*xc_domain_unpause)
+            (xc_interface *xch, uint32_t domid);
+
+    /* Xen 4.2+ */
+    int (*xc_domain_debug_control)
+            (xc_interface *xch, uint32_t domid, uint32_t sop, uint32_t vcpu);
+
+    int (*xc_domain_set_access_required)
+            (xc_interface *xch, uint32_t domid, unsigned int required);
+
+    int (*xc_domain_decrease_reservation_exact)
+            (xc_interface *xch, uint32_t domid, unsigned long nr_extents,
+             unsigned int extent_order, xen_pfn_t *extent_start);
+
+    int (*xc_hvm_inject_trap)
+            (xc_interface *xch, domid_t dom, int vcpu, uint32_t vector,
+             uint32_t type, uint32_t error_code, uint32_t insn_len, uint64_t cr2);
+
+    int (*xc_domain_getinfolist)
+            (xc_interface *xch, uint32_t first_domain, unsigned int max_domains,
+             xc_domaininfo_t *info);
+
+    int (*xc_domain_populate_physmap_exact)
+            (xc_interface *xch, uint32_t domid, unsigned long nr_extents,
+             unsigned int extent_order, unsigned int mem_flags, xen_pfn_t *extent_start);
+
+    xc_evtchn* (*xc_evtchn_open)
+            (xentoollog_logger *logger, unsigned open_flags);
+
+    int (*xc_evtchn_close)
+            (xc_evtchn *xce);
+
+    int (*xc_evtchn_fd)
+            (xc_evtchn *xce);
+
+    int (*xc_evtchn_notify)
+            (xc_evtchn *xce, evtchn_port_t port);
+
+    xc_evtchn_port_or_error_t (*xc_evtchn_pending)
+        (xc_evtchn *xce);
+
+    int (*xc_evtchn_unmask)
+            (xc_evtchn *xce, evtchn_port_t port);
+
+    int (*xc_evtchn_unbind)
+            (xc_evtchn *xce, evtchn_port_t port);
+
+    xc_evtchn_port_or_error_t (*xc_evtchn_bind_interdomain)
+        (xc_evtchn *xce, int domid, evtchn_port_t remote_port);
 
     /* Xen 4.1 - Xen 4.5 */
     int (*xc_domain_maximum_gpfn)
@@ -43,6 +132,12 @@ typedef struct {
     /* Xen 4.1 - Xen 4.4 */
     void* (*xc_map_foreign_batch)
             (xc_interface *xch, uint32_t dom, int prot, xen_pfn_t *arr, int num);
+
+    int (*xc_set_hvm_param)
+            (xc_interface *handle, domid_t dom, int param, unsigned long value);
+
+    int (*xc_get_hvm_param)
+            (xc_interface *handle, domid_t dom, int param, unsigned long *value);
 
     /* Xen 4.1 - 4.4 */
     int (*xc_hvm_set_mem_access)
@@ -57,6 +152,12 @@ typedef struct {
 
     int (*xc_get_mem_access)
             (xc_interface *xch, domid_t domain_id, uint64_t pfn, xenmem_access_t *access);
+
+    int (*xc_hvm_param_set)
+            (xc_interface *handle, domid_t dom, uint32_t param, uint64_t value);
+
+    int (*xc_hvm_param_get)
+            (xc_interface *handle, domid_t dom, uint32_t param, uint64_t *value);
 
     /* Xen 4.1 - Xen 4.4 */
     int (*xc_mem_access_enable)
@@ -101,7 +202,7 @@ typedef struct {
     int (*xc_monitor_guest_request)
             (xc_interface *xch, domid_t domain_id, bool enable, bool sync);
 
-    int (*xc_altp2m_get_domain_state) 
+    int (*xc_altp2m_get_domain_state)
             (xc_interface *xch, domid_t domain_id, bool *state );
 
     int (*xc_altp2m_set_domain_state)
@@ -113,18 +214,17 @@ typedef struct {
     int (*xc_altp2m_create_view)
             (xc_interface *xch, domid_t domain_id, xenmem_access_t default_access, uint16_t *view_id );
 
-    int (*xc_altp2m_destroy_view) 
+    int (*xc_altp2m_destroy_view)
             (xc_interface *xch, domid_t domain_id, uint16_t view_id );
 
-    int (*xc_altp2m_switch_to_view) 
+    int (*xc_altp2m_switch_to_view)
             (xc_interface *xch, domid_t domain_id, uint16_t view_id );
 
     int (*xc_altp2m_set_mem_access)
             (xc_interface *xch, domid_t domain_id, uint16_t view_id, xen_pfn_t gfn, xenmem_access_t access);
 
-    int (*xc_altp2m_change_gfn) 
+    int (*xc_altp2m_change_gfn)
             (xc_interface *xch, domid_t domain_id, uint16_t view_id, xen_pfn_t old_gfn, xen_pfn_t new_gfn );
-
 
     /* Xen 4.8+ */
     int (*xc_monitor_debug_exceptions)

--- a/libvmi/driver/xen/libxs_wrapper.c
+++ b/libvmi/driver/xen/libxs_wrapper.c
@@ -1,0 +1,59 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel <tamas.lengyel@zentific.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include "xen_private.h"
+
+static status_t sanity_check(xen_instance_t *xen)
+{
+    libxs_wrapper_t *w = &xen->libxsw;
+
+    if ( !w->xs_open || !w->xs_close || !w->xs_read || !w->xs_directory )
+        return VMI_FAILURE;
+
+    xen->xshandle = xen->libxsw.xs_open(0);
+    if ( !xen->xshandle ) {
+        errprint("Failed to open libxenstore interface.\n");
+        return VMI_FAILURE;
+    }
+
+    return VMI_SUCCESS;
+}
+
+status_t create_libxs_wrapper(xen_instance_t *xen)
+{
+    libxs_wrapper_t *wrapper = &xen->libxsw;
+
+    wrapper->handle = dlopen ("libxenstore.so", RTLD_NOW | RTLD_GLOBAL);
+    if ( !wrapper->handle )
+    {
+        fprintf(stderr, "Failed to find a suitable libxenstore.so at any of the standard paths!\n");
+        return VMI_FAILURE;
+    }
+
+    wrapper->xs_open = dlsym(wrapper->handle, "xs_open");
+    wrapper->xs_close = dlsym(wrapper->handle, "xs_close");
+    wrapper->xs_directory = dlsym(wrapper->handle, "xs_directory");
+    wrapper->xs_read = dlsym(wrapper->handle, "xs_read");
+
+    return sanity_check(xen);
+}

--- a/libvmi/driver/xen/libxs_wrapper.h
+++ b/libvmi/driver/xen/libxs_wrapper.h
@@ -1,0 +1,58 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel <tamas.lengyel@zentific.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include <dlfcn.h>
+
+#if HAVE_XENSTORE_H
+  #include <xenstore.h>
+#elif HAVE_XS_H
+  #include <xs.h>
+#endif
+
+#include "libvmi.h"
+
+struct xen_instance;
+
+#ifndef HAVE_LIBXENSTORE
+struct xs_handle;
+typedef struct xs_transaction xs_transaction_t;
+#endif
+
+typedef struct {
+    struct xs_handle* handle;
+
+    struct xs_handle* (*xs_open)
+        (unsigned long flags);
+
+    void (*xs_close)
+        (struct xs_handle *xsh);
+
+    char** (*xs_directory)
+        (struct xs_handle *h, xs_transaction_t t, const char *path, unsigned int *num);
+
+    void* (*xs_read)
+        (struct xs_handle *h, xs_transaction_t t, const char *path, unsigned int *len);
+
+} libxs_wrapper_t;
+
+status_t create_libxs_wrapper(struct xen_instance *xen);

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -88,6 +88,7 @@ status_t xen_write(
 int xen_is_pv(
     vmi_instance_t vmi);
 status_t xen_test(
+    vmi_instance_t vmi,
     uint64_t domainid,
     const char *name);
 status_t xen_pause_vm(

--- a/libvmi/driver/xen/xen_events.h
+++ b/libvmi/driver/xen/xen_events.h
@@ -71,11 +71,14 @@ static inline status_t xen_init_events(vmi_instance_t vmi)
     {
         switch(xen->minor_version)
         {
+        case 0 ... 1:
+            dbprint(VMI_DEBUG_XEN, "Xen 4.0/4.1 has no events support!\n");
+            break;
         case 2 ... 5:
             return xen_init_events_legacy(vmi);
         case 6 ... 7:
             return xen_init_events_46(vmi);
-        case 8:
+        default:
             return xen_init_events_48(vmi);
         };
     };
@@ -89,13 +92,15 @@ static inline void xen_events_destroy(vmi_instance_t vmi)
     {
         switch(xen->minor_version)
         {
+        case 0 ... 1:
+            break;
         case 2 ... 5:
             xen_events_destroy_legacy(vmi);
             break;
         case 6 ... 7:
             xen_events_destroy_46(vmi);
             break;
-        case 8:
+        default:
             xen_events_destroy_48(vmi);
             break;
         };

--- a/libvmi/driver/xen/xen_events_46.c
+++ b/libvmi/driver/xen/xen_events_46.c
@@ -435,7 +435,7 @@ event_response_t issue_mem_cb(vmi_instance_t vmi,
                   vm_event_46_request_t *req,
                   vmi_mem_access_t out_access)
 {
-    if ( req->u.mem_access.flags | MEM_ACCESS_GLA_VALID )
+    if ( req->u.mem_access.flags & MEM_ACCESS_GLA_VALID )
     {
         event->mem_event.gptw = !!(req->u.mem_access.flags | MEM_ACCESS_FAULT_IN_GPT);
         event->mem_event.gla_valid = 1;

--- a/libvmi/driver/xen/xen_events_46.c
+++ b/libvmi/driver/xen/xen_events_46.c
@@ -67,10 +67,10 @@ xen_events_t *xen_get_events(vmi_instance_t vmi)
 }
 
 static
-int wait_for_event_or_timeout(xc_evtchn *xce, unsigned long ms)
+int wait_for_event_or_timeout(xen_instance_t *xen, xc_evtchn *xce, unsigned long ms)
 {
     struct pollfd fd = {
-            .fd = xc_evtchn_fd(xce),
+            .fd = xen->libxcw.xc_evtchn_fd(xce),
             .events = POLLIN | POLLERR
         };
     int port;
@@ -87,14 +87,14 @@ int wait_for_event_or_timeout(xc_evtchn *xce, unsigned long ms)
 
     if ( rc == 1 )
     {
-        port = xc_evtchn_pending(xce);
+        port = xen->libxcw.xc_evtchn_pending(xce);
         if ( port == -1 )
         {
             errprint("Failed to read port from event channel\n");
             goto err;
         }
 
-        rc = xc_evtchn_unmask(xce, port);
+        rc = xen->libxcw.xc_evtchn_unmask(xce, port);
         if ( rc != 0 )
         {
             errprint("Failed to unmask event channel port\n");
@@ -153,6 +153,7 @@ static int resume_domain(vmi_instance_t vmi)
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
     domid_t dom = xen_get_domainid(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -167,7 +168,7 @@ static int resume_domain(vmi_instance_t vmi)
         return -1;
     }
 
-    return xc_evtchn_notify(xe->vm_event.xce_handle, xe->vm_event.port);
+    return xen->libxcw.xc_evtchn_notify(xe->vm_event.xce_handle, xe->vm_event.port);
 }
 
 static status_t xen_set_int3_access(vmi_instance_t vmi, bool enable)
@@ -266,6 +267,7 @@ status_t process_interrupt_event(vmi_instance_t vmi,
     vmi_event_t * event = g_hash_table_lookup(vmi->interrupt_events, &lookup);
     xc_interface * xch  = xen_get_xchandle(vmi);
     domid_t domain_id   = xen_get_domainid(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -327,7 +329,7 @@ status_t process_interrupt_event(vmi_instance_t vmi,
                      *  reinjection.
                      */
                     #define TRAP_int3              3
-                    rc = xc_hvm_inject_trap(xch, domain_id, req->vcpu_id,
+                    rc = xen->libxcw.xc_hvm_inject_trap(xch, domain_id, req->vcpu_id,
                             TRAP_int3,         /* Vector 3 for INT3 */
                             HVMOP_TRAP_sw_exc, /* Trap type, here a software intr */
                             ~0u, /* error code. ~0u means 'ignore' */
@@ -1021,6 +1023,7 @@ status_t xen_events_listen_46(vmi_instance_t vmi, uint32_t timeout)
 {
     vm_event_46_request_t req;
     vm_event_46_response_t rsp;
+    xen_instance_t *xen = xen_get_instance(vmi);
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
     domid_t dom = xen_get_domainid(vmi);
@@ -1042,7 +1045,7 @@ status_t xen_events_listen_46(vmi_instance_t vmi, uint32_t timeout)
     }
 
     // Set whether the access listener is required
-    rc = xc_domain_set_access_required(xch, dom, vmi->event_listener_required);
+    rc = xen->libxcw.xc_domain_set_access_required(xch, dom, vmi->event_listener_required);
     if ( rc < 0 ) {
         errprint("Error %d setting mem_access listener required to %d\n",
             rc, vmi->event_listener_required);
@@ -1050,7 +1053,7 @@ status_t xen_events_listen_46(vmi_instance_t vmi, uint32_t timeout)
 
     if(!vmi->shutting_down && timeout > 0) {
         dbprint(VMI_DEBUG_XEN, "--Waiting for xen events...(%"PRIu32" ms)\n", timeout);
-        rc = wait_for_event_or_timeout(xe->vm_event.xce_handle, timeout);
+        rc = wait_for_event_or_timeout(xen, xe->vm_event.xce_handle, timeout);
         if ( rc < -1 ) {
             errprint("Error while waiting for event.\n");
             return VMI_FAILURE;
@@ -1119,7 +1122,7 @@ void xen_events_destroy_46(vmi_instance_t vmi)
 
 
     xc_dominfo_t info = {0};
-    rc = xc_domain_getinfo(xch, dom, 1, &info);
+    rc = xen->libxcw.xc_domain_getinfo(xch, dom, 1, &info);
 
     if(rc==1 && info.domid==dom && !info.paused && VMI_SUCCESS == vmi_pause_vm(vmi)) {
         resume = 1;
@@ -1148,12 +1151,12 @@ void xen_events_destroy_46(vmi_instance_t vmi)
 
     // Unbind VIRQ
     if ( xe->vm_event.port > 0 )
-        if ( xc_evtchn_unbind(xe->vm_event.xce_handle, xe->vm_event.port) )
+        if ( xen->libxcw.xc_evtchn_unbind(xe->vm_event.xce_handle, xe->vm_event.port) )
             errprint("Error unbinding event port.\n");
 
     // Close event channel
     if ( xe->vm_event.xce_handle )
-        if ( xc_evtchn_close(xe->vm_event.xce_handle) )
+        if ( xen->libxcw.xc_evtchn_close(xe->vm_event.xce_handle) )
             errprint("Error closing event channel.\n");
 
     free(xe);
@@ -1220,7 +1223,7 @@ status_t xen_init_events_46(vmi_instance_t vmi)
     }
 
     /* Open event channel */
-    xe->vm_event.xce_handle = xc_evtchn_open(NULL, 0);
+    xe->vm_event.xce_handle = xen->libxcw.xc_evtchn_open(NULL, 0);
     if ( !xe->vm_event.xce_handle )
     {
         errprint("Failed to open event channel\n");
@@ -1228,9 +1231,9 @@ status_t xen_init_events_46(vmi_instance_t vmi)
     }
 
     /* Bind event notification */
-    rc = xc_evtchn_bind_interdomain(xe->vm_event.xce_handle,
-                                    dom,
-                                    xe->vm_event.evtchn_port);
+    rc = xen->libxcw.xc_evtchn_bind_interdomain(xe->vm_event.xce_handle,
+                                                dom,
+                                                xe->vm_event.evtchn_port);
     if ( rc < 0 ) {
         errprint("Failed to bind event channel\n");
         goto err;

--- a/libvmi/driver/xen/xen_events_48.c
+++ b/libvmi/driver/xen/xen_events_48.c
@@ -68,10 +68,10 @@ xen_events_t *xen_get_events(vmi_instance_t vmi)
 }
 
 static
-int wait_for_event_or_timeout(xc_evtchn *xce, unsigned long ms)
+int wait_for_event_or_timeout(xen_instance_t *xen, xc_evtchn *xce, unsigned long ms)
 {
     struct pollfd fd = {
-            .fd = xc_evtchn_fd(xce),
+            .fd = xen->libxcw.xc_evtchn_fd(xce),
             .events = POLLIN | POLLERR
         };
     int port;
@@ -88,14 +88,14 @@ int wait_for_event_or_timeout(xc_evtchn *xce, unsigned long ms)
 
     if ( rc == 1 )
     {
-        port = xc_evtchn_pending(xce);
+        port = xen->libxcw.xc_evtchn_pending(xce);
         if ( port == -1 )
         {
             errprint("Failed to read port from event channel\n");
             goto err;
         }
 
-        rc = xc_evtchn_unmask(xce, port);
+        rc = xen->libxcw.xc_evtchn_unmask(xce, port);
         if ( rc != 0 )
         {
             errprint("Failed to unmask event channel port\n");
@@ -154,6 +154,7 @@ static int resume_domain(vmi_instance_t vmi)
     xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
     domid_t dom = xen_get_domainid(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -168,7 +169,7 @@ static int resume_domain(vmi_instance_t vmi)
         return -1;
     }
 
-    return xc_evtchn_notify(xe->vm_event.xce_handle, xe->vm_event.port);
+    return xen->libxcw.xc_evtchn_notify(xe->vm_event.xce_handle, xe->vm_event.port);
 }
 
 static status_t xen_set_int3_access(vmi_instance_t vmi, bool enable)
@@ -279,6 +280,7 @@ status_t process_interrupt_event(vmi_instance_t vmi,
     vmi_event_t * event = g_hash_table_lookup(vmi->interrupt_events, &lookup);
     xc_interface * xch  = xen_get_xchandle(vmi);
     domid_t domain_id   = xen_get_domainid(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
 
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
@@ -343,7 +345,7 @@ status_t process_interrupt_event(vmi_instance_t vmi,
                      *  reinjection.
                      */
                     #define TRAP_int3              3
-                    rc = xc_hvm_inject_trap(xch, domain_id, req->vcpu_id,
+                    rc = xen->libxcw.xc_hvm_inject_trap(xch, domain_id, req->vcpu_id,
                             TRAP_int3,         /* Vector 3 for INT3 */
                             HVMOP_TRAP_sw_exc, /* Trap type, here a software intr */
                             ~0u, /* error code. ~0u means 'ignore' */
@@ -656,6 +658,7 @@ status_t process_debug_event(vmi_instance_t vmi,
                              vm_event_48_request_t *req,
                              vm_event_48_response_t *rsp)
 {
+    xen_instance_t *xen = xen_get_instance(vmi);
     xc_interface * xch = xen_get_xchandle(vmi);
     domid_t dom = xen_get_domainid(vmi);
     int rc;
@@ -700,7 +703,7 @@ status_t process_debug_event(vmi_instance_t vmi,
 
     if ( vmi->debug_event->debug_event.reinject )
     {
-        rc = xc_hvm_inject_trap(xen_get_xchandle(vmi),
+        rc = xen->libxcw.xc_hvm_inject_trap(xen_get_xchandle(vmi),
                                 xen_get_domainid(vmi),
                                 rsp->vcpu_id,
                                 X86_TRAP_DEBUG,
@@ -1212,11 +1215,12 @@ int xen_are_events_pending_48(vmi_instance_t vmi)
 
 status_t xen_events_listen_48(vmi_instance_t vmi, uint32_t timeout)
 {
+    xc_interface *xch = xen_get_xchandle(vmi);
+    xen_events_t *xe = xen_get_events(vmi);
+    domid_t dom = xen_get_domainid(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
     vm_event_48_request_t req;
     vm_event_48_response_t rsp;
-    xc_interface * xch = xen_get_xchandle(vmi);
-    xen_events_t * xe = xen_get_events(vmi);
-    domid_t dom = xen_get_domainid(vmi);
 
     int rc = -1;
     status_t vrc = VMI_SUCCESS;
@@ -1235,7 +1239,7 @@ status_t xen_events_listen_48(vmi_instance_t vmi, uint32_t timeout)
     }
 
     // Set whether the access listener is required
-    rc = xc_domain_set_access_required(xch, dom, vmi->event_listener_required);
+    rc = xen->libxcw.xc_domain_set_access_required(xch, dom, vmi->event_listener_required);
     if ( rc < 0 ) {
         errprint("Error %d setting mem_access listener required to %d\n",
             rc, vmi->event_listener_required);
@@ -1243,7 +1247,7 @@ status_t xen_events_listen_48(vmi_instance_t vmi, uint32_t timeout)
 
     if(!vmi->shutting_down && timeout > 0) {
         dbprint(VMI_DEBUG_XEN, "--Waiting for xen events...(%"PRIu32" ms)\n", timeout);
-        rc = wait_for_event_or_timeout(xe->vm_event.xce_handle, timeout);
+        rc = wait_for_event_or_timeout(xen, xe->vm_event.xce_handle, timeout);
         if ( rc < -1 ) {
             errprint("Error while waiting for event.\n");
             return VMI_FAILURE;
@@ -1312,7 +1316,7 @@ void xen_events_destroy_48(vmi_instance_t vmi)
 
 
     xc_dominfo_t info = {0};
-    rc = xc_domain_getinfo(xch, dom, 1, &info);
+    rc = xen->libxcw.xc_domain_getinfo(xch, dom, 1, &info);
 
     if(rc==1 && info.domid==dom && !info.paused && VMI_SUCCESS == vmi_pause_vm(vmi)) {
         resume = 1;
@@ -1355,12 +1359,12 @@ void xen_events_destroy_48(vmi_instance_t vmi)
 
     // Unbind VIRQ
     if ( xe->vm_event.port > 0 )
-        if ( xc_evtchn_unbind(xe->vm_event.xce_handle, xe->vm_event.port) )
+        if ( xen->libxcw.xc_evtchn_unbind(xe->vm_event.xce_handle, xe->vm_event.port) )
             errprint("Error unbinding event port.\n");
 
     // Close event channel
     if ( xe->vm_event.xce_handle )
-        if ( xc_evtchn_close(xe->vm_event.xce_handle) )
+        if ( xen->libxcw.xc_evtchn_close(xe->vm_event.xce_handle) )
             errprint("Error closing event channel.\n");
 
     free(xe);
@@ -1429,7 +1433,7 @@ status_t xen_init_events_48(vmi_instance_t vmi)
     }
 
     /* Open event channel */
-    xe->vm_event.xce_handle = xc_evtchn_open(NULL, 0);
+    xe->vm_event.xce_handle = xen->libxcw.xc_evtchn_open(NULL, 0);
     if ( !xe->vm_event.xce_handle )
     {
         errprint("Failed to open event channel\n");
@@ -1437,7 +1441,7 @@ status_t xen_init_events_48(vmi_instance_t vmi)
     }
 
     /* Bind event notification */
-    rc = xc_evtchn_bind_interdomain(xe->vm_event.xce_handle,
+    rc = xen->libxcw.xc_evtchn_bind_interdomain(xe->vm_event.xce_handle,
                                     dom,
                                     xe->vm_event.evtchn_port);
     if ( rc < 0 ) {

--- a/libvmi/driver/xen/xen_events_48.c
+++ b/libvmi/driver/xen/xen_events_48.c
@@ -452,7 +452,7 @@ event_response_t issue_mem_cb(vmi_instance_t vmi,
                   vm_event_48_request_t *req,
                   vmi_mem_access_t out_access)
 {
-    if ( req->u.mem_access.flags | MEM_ACCESS_GLA_VALID )
+    if ( req->u.mem_access.flags & MEM_ACCESS_GLA_VALID )
     {
         event->mem_event.gptw = !!(req->u.mem_access.flags | MEM_ACCESS_FAULT_IN_GPT);
         event->mem_event.gla_valid = 1;

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -36,15 +36,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <xenctrl.h>
-#if HAVE_XENSTORE_H
-  #include <xenstore.h>
-#elif HAVE_XS_H
-  #include <xs.h>
-#endif
 #include <xen/hvm/save.h>
 
 #include "private.h"
 #include "libxc_wrapper.h"
+#include "libxs_wrapper.h"
 #include "driver/xen/xen_events_private.h"
 
 typedef struct xen_instance {
@@ -53,7 +49,11 @@ typedef struct xen_instance {
 
     xc_interface* xchandle; /**< handle to xenctrl library (libxc) */
 
-    libxc_wrapper_t libxcw; /**< wrapper for libxc for backwards compatibility */
+    struct xs_handle *xshandle;  /**< handle to xenstore daemon (libxs) */
+
+    libxc_wrapper_t libxcw; /**< wrapper for libxc for cross-compatibility */
+
+    libxs_wrapper_t libxsw; /**< wrapper for libxs for cross-compatibility */
 
     uint64_t domainid; /**< domid that we are accessing */
 
@@ -70,10 +70,6 @@ typedef struct xen_instance {
     uint64_t max_gpfn;    /**< result of xc_domain_maximum_gpfn/2() */
 
     uint8_t addr_width;     /**< guest's address width in bytes: 4 or 8 */
-
-#ifdef HAVE_LIBXENSTORE
-    struct xs_handle *xshandle;  /**< handle to xenstore daemon */
-#endif
 
 #if ENABLE_SHM_SNAPSHOT == 1
     char *shm_snapshot_path;  /** reserved for shared memory snapshot device path in /dev/shm directory */

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -128,7 +128,7 @@ void events_destroy(vmi_instance_t vmi)
         vmi->reg_events = NULL;
     }
 
-    if (vmi->reg_events)
+    if (vmi->msr_events)
     {
         dbprint(VMI_DEBUG_EVENTS, "Destroying MSR events\n");
         g_hash_table_foreach_remove(vmi->msr_events, event_entry_free, vmi);


### PR DESCRIPTION
Fixes #423 

This PR allows us to compile all supported driver code into LibVMI but only activate the drivers when the run-time environment supports it. With this PR the library no longer has a hard-dependency on all shared libraries being present at once.