### PR TITLE
get offset of symbol+subsymbol

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -141,6 +141,16 @@ vmi_get_offset(
     return vmi->os_interface->os_get_offset(vmi, offset_name);
 }
 
+status_t
+vmi_get_kernel_struct_offset(
+    vmi_instance_t vmi,
+    const char* symbol,
+    const char* member,
+    addr_t *addr)
+{
+    return vmi->os_interface->os_get_kernel_struct_offset(vmi,symbol,member,addr);
+}
+
 uint64_t
 vmi_get_memsize(
     vmi_instance_t vmi)

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1731,6 +1731,21 @@ uint64_t vmi_get_offset(
     const char *offset_name);
 
 /**
+ * Get the memory offset associated with the given symbol and subsymbol in the struct
+ * @param[in] vmi LibVMI instance
+ * @param[in] struct_name String name for desired symbol
+ * @param[in] subsymbol String name for desired subsymbol
+ * @param[out] offset of subsymbol in struct (symbol)
+ *
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_get_kernel_struct_offset(
+    vmi_instance_t vmi,
+    const char* struct_name,
+    const char* member,
+    addr_t *addr);
+
+/**
  * Gets the memory size of the guest or file that LibVMI is currently
  * accessing.  This is the amount of RAM allocated to the guest, but
  * does not necessarily indicate the highest addressable physical address;

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -354,6 +354,7 @@ status_t linux_init(vmi_instance_t vmi) {
     os_interface = safe_malloc(sizeof(struct os_interface));
     bzero(os_interface, sizeof(struct os_interface));
     os_interface->os_get_offset = linux_get_offset;
+    os_interface->os_get_kernel_struct_offset = linux_get_kernel_struct_offset;
     os_interface->os_pid_to_pgd = linux_pid_to_pgd;
     os_interface->os_pgd_to_pid = linux_pgd_to_pid;
     os_interface->os_ksym2v = linux_symbol_to_address;
@@ -431,6 +432,11 @@ void linux_read_config_ghashtable_entries(char* key, gpointer value,
     warnprint("Invalid offset %s given for Linux target\n", key);
 
     _done: return;
+}
+
+status_t linux_get_kernel_struct_offset(vmi_instance_t vmi, const char* symbol, const char* member, addr_t *addr){
+    linux_instance_t linux_instance = vmi->os_data;
+    return rekall_profile_symbol_to_rva(linux_instance->rekall_profile,symbol,member,addr);
 }
 
 uint64_t linux_get_offset(vmi_instance_t vmi, const char* offset_name) {

--- a/libvmi/os/linux/linux.h
+++ b/libvmi/os/linux/linux.h
@@ -45,6 +45,9 @@ status_t linux_init(vmi_instance_t instance);
 
 uint64_t linux_get_offset(vmi_instance_t vmi, const char* offset_name);
 
+status_t linux_get_kernel_struct_offset(vmi_instance_t vmi, 
+        const char*  symbol, const char* member, addr_t *addr);
+
 status_t linux_symbol_to_address(vmi_instance_t instance,
         const char *symbol, addr_t *__unused, addr_t *address);
 

--- a/libvmi/os/os_interface.h
+++ b/libvmi/os/os_interface.h
@@ -28,6 +28,9 @@
 typedef uint64_t (*os_get_offset_t)(vmi_instance_t vmi,
         const char* offset_name);
 
+typedef status_t (*os_get_kernel_struct_offset_t)(vmi_instance_t vmi,
+	const char* symbol, const char* member, addr_t *addr);
+
 typedef vmi_pid_t (*os_pgd_to_pid_t)(vmi_instance_t vmi, addr_t pgd);
 
 typedef addr_t (*os_pid_to_pgd_t)(vmi_instance_t vmi, vmi_pid_t pid);
@@ -47,6 +50,7 @@ typedef unicode_string_t* (*os_read_unicode_struct_t)(vmi_instance_t vmi,
 typedef status_t (*os_teardown_t)(vmi_instance_t vmi);
 
 typedef struct os_interface {
+    os_get_kernel_struct_offset_t os_get_kernel_struct_offset;
     os_get_offset_t os_get_offset;
     os_pgd_to_pid_t os_pgd_to_pid;
     os_pid_to_pgd_t os_pid_to_pgd;

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -414,6 +414,11 @@ error_exit:
     return VMI_FAILURE;
 }
 
+status_t windows_get_kernel_struct_offset(vmi_instance_t vmi, const char* symbol, const char* member, addr_t *addr){
+    windows_instance_t windows = vmi->os_data;
+    return rekall_profile_symbol_to_rva(windows->rekall_profile,symbol,member,addr);
+}
+
 uint64_t windows_get_offset(vmi_instance_t vmi, const char* offset_name) {
     const size_t max_length = 100;
     windows_instance_t windows = vmi->os_data;
@@ -762,6 +767,7 @@ windows_init(
     /* Need to provide this functions so that find_page_mode will work */
     os_interface = safe_malloc(sizeof(struct os_interface));
     bzero(os_interface, sizeof(struct os_interface));
+    os_interface->os_get_kernel_struct_offset = windows_get_kernel_struct_offset;
     os_interface->os_get_offset = windows_get_offset;
     os_interface->os_pid_to_pgd = windows_pid_to_pgd;
     os_interface->os_pgd_to_pid = windows_pgd_to_pid;

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -59,6 +59,10 @@ vmi_pid_t windows_pgd_to_pid(vmi_instance_t vmi, addr_t pgd);
 status_t
 windows_kernel_symbol_to_address(vmi_instance_t vmi, const char *symbol,
         addr_t *kernel_base_address, addr_t *address);
+
+status_t windows_get_kernel_struct_offset(vmi_instance_t vmi, 
+        const char*  symbol, const char* member, addr_t *addr);
+
 status_t
 windows_export_to_rva(vmi_instance_t vmi, const access_context_t *ctx,
         const char *symbol, addr_t *rva);


### PR DESCRIPTION
This patch is to get the symbol + sub-symbol offset from the rekall profile.