### PR TITLE
Fix windows-offset-tool scripts downloading PDB

### DIFF
--- a/tools/windows-offset-finder/dumpPDB.py
+++ b/tools/windows-offset-finder/dumpPDB.py
@@ -182,7 +182,7 @@ def main():
 		if opts.infile: #if -f option is provided, use that filename
 			dump_types(opts.infile, opts.outfile)
 		else: #otherwise use stdin (piped from downloadPDB.py)
-			infile = sys.stdin.read().rstrip() #read stdin, strip out newline
+			infile = sys.stdin.read().rstrip().split("\n")[-1].strip() #read stdin, strip out newline
 			dump_types(infile, opts.outfile)
 	else:
 		print "Must supply an output filename.  Use -h for help"


### PR DESCRIPTION
windows-offset-tool currently does not work, as it cannot download the PDB file from the microsoft website using the python urlbuilder (at least on Fedora).  This fix that, and reduces the complexity of the code used.