### PR TITLE
Fix MSR events on Xen 4.8

### DIFF
--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -79,6 +79,7 @@ int main (int argc, char **argv) {
     msr_event.type = VMI_EVENT_REGISTER;
     msr_event.reg_event.reg = MSR_ALL;
     msr_event.reg_event.in_access = VMI_REGACCESS_W;
+    msr_event.reg_event.extended_msr = 1;
     msr_event.callback = msr_write_cb;
 
     vmi_register_event(vmi, &msr_event);

--- a/libvmi/driver/xen/msr-index.h
+++ b/libvmi/driver/xen/msr-index.h
@@ -1,0 +1,32 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Tamas K Lengyel (tamas.lengyel@zentific.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MSR_INDEX_H
+#define MSR_INDEX_H
+
+#define _MSR_EFER                0xc0000080 /* extended feature register */
+#define _MSR_STAR                0xc0000081 /* legacy mode SYSCALL target */
+#define _MSR_LSTAR               0xc0000082 /* long mode SYSCALL target */
+#define _MSR_CSTAR               0xc0000083 /* compat mode SYSCALL target */
+#define _MSR_SYSCALL_MASK        0xc0000084 /* EFLAGS mask for syscall */
+#define _MSR_TSC_AUX             0xc0000103 /* Auxiliary TSC */
+
+#endif /* MSR_INDEX_H */

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -1283,6 +1283,9 @@ xen_get_vcpureg_hvm(
     case MSR_EFER:
         *value = (reg_t) hvm_cpu->msr_efer;
         break;
+    case MSR_STAR:
+        *value = (reg_t) hvm_cpu->msr_star;
+        break;
 
 #ifdef DECLARE_HVM_SAVE_TYPE_COMPAT
         /* Handle churn in struct hvm_hw_cpu (from xen/hvm/save.h)
@@ -1605,6 +1608,9 @@ xen_set_vcpureg_hvm(
         break;
     case MSR_EFER:
         cpu->msr_efer = value;
+        break;
+    case MSR_STAR:
+        cpu->msr_star = value;
         break;
 
 #ifdef DECLARE_HVM_SAVE_TYPE_COMPAT

--- a/libvmi/driver/xen/xen_events_48.c
+++ b/libvmi/driver/xen/xen_events_48.c
@@ -59,6 +59,7 @@
 #include "driver/xen/xen_private.h"
 #include "driver/xen/xen_events.h"
 #include "driver/xen/xen_events_private.h"
+#include "driver/xen/msr-index.h"
 
 static inline
 xen_events_t *xen_get_events(vmi_instance_t vmi)
@@ -930,8 +931,17 @@ status_t xen_set_reg_access_48(vmi_instance_t vmi, reg_event_t *event)
             if ( enable == xe->vm_event.monitor_msr_on )
                 goto done;
 
-            rc = xen->libxcw.xc_monitor_mov_to_msr(xch, dom, enable, event->extended_msr);
-            if ( rc )
+            if ( xen->libxcw.xc_monitor_mov_to_msr(xch, dom, _MSR_EFER, event->extended_msr) )
+                goto done;
+            if ( xen->libxcw.xc_monitor_mov_to_msr(xch, dom, _MSR_STAR, event->extended_msr) )
+                goto done;
+            if ( xen->libxcw.xc_monitor_mov_to_msr(xch, dom, _MSR_LSTAR, event->extended_msr) )
+                goto done;
+            if ( xen->libxcw.xc_monitor_mov_to_msr(xch, dom, _MSR_CSTAR, event->extended_msr) )
+                goto done;
+            if ( xen->libxcw.xc_monitor_mov_to_msr(xch, dom, _MSR_SYSCALL_MASK, event->extended_msr) )
+                goto done;
+            if ( xen->libxcw.xc_monitor_mov_to_msr(xch, dom, _MSR_TSC_AUX, event->extended_msr) )
                 goto done;
 
             xe->vm_event.monitor_msr_on = enable;

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -266,6 +266,8 @@ typedef reg_t registers_t;
 #define MSR_EFER         74
 #define MSR_TSC_AUX      75
 
+#define MSR_STAR         119
+
 /**
  * Special generic case for handling MSRs, given their understandably
  * generic treatment for events in Xen and elsewhere. Not relevant for


### PR DESCRIPTION
Starting with Xen 4.8 you have to subscribe to specific MSRs to receive events. For now we shortcut using MSR_ALL to set common MSRs. However, to fully support arbitrary MSR interception we will likely need to define all MSRs in libvmi.h and add the corresponding msr-indexes.