### PR TITLE
Fix Windows RVA to Symbol lookup

### DIFF
--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -601,7 +601,7 @@ windows_rva_to_export(
         if(VMI_FAILURE==vmi_read_16(vmi, &_ctx, &ordinal))
             continue;
 
-        _ctx.addr = base3 + ordinal + sizeof(uint32_t);
+        _ctx.addr = base3 + ordinal * sizeof(uint32_t);
         if(VMI_FAILURE==vmi_read_32(vmi, &_ctx, &loc))
             continue;
 


### PR DESCRIPTION
Name ordinal should be _multiplied_ with function address size to get the corresponding Function RVA rather than adding.