### PR TITLE
Init rework

### DIFF
--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -42,7 +42,7 @@ main(
     if ( argc != 3 )
         return 1;
 
-    vmi_instance_t vmi;
+    vmi_instance_t vmi = NULL;
     char *filename = NULL;
     FILE *f = NULL;
     unsigned char memory[PAGE_SIZE];
@@ -51,6 +51,7 @@ main(
     memset(zeros, 0, PAGE_SIZE);
     addr_t address = 0;
     addr_t size = 0;
+    vmi_mode_t mode;
 
     /* this is the VM or file that we are looking at */
     char *name = argv[1];
@@ -58,9 +59,12 @@ main(
     /* this is the file name to write the memory image to */
     filename = strndup(argv[2], 50);
 
+    if (VMI_FAILURE == vmi_get_access_mode(vmi, (void*)name, VMI_INIT_DOMAINNAME, NULL, &mode) )
+        goto error_exit;
+
     /* initialize the libvmi library */
-    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_PARTIAL, name) ==
-        VMI_FAILURE) {
+    if (VMI_FAILURE == vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         goto error_exit;
     }

--- a/examples/event-example.c
+++ b/examples/event-example.c
@@ -229,17 +229,16 @@ int main (int argc, char **argv)
     sigaction(SIGINT,  &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_COMPLETE | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    /* initialize the libvmi library */
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
+                          NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
-        if (vmi != NULL ) {
-            vmi_destroy(vmi);
-        }
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     // Get the cr3 for this process.
     if(pid != -1) {

--- a/examples/interrupt-event-example.c
+++ b/examples/interrupt-event-example.c
@@ -86,13 +86,14 @@ int main (int argc, char **argv) {
     name = argv[1];
 
     // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_PARTIAL | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    if (VMI_FAILURE ==
+        vmi_init(&vmi, VMI_XEN, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     /* Register event to track INT3 interrupts */
     memset(&interrupt_event, 0, sizeof(vmi_event_t));

--- a/examples/map-addr.c
+++ b/examples/map-addr.c
@@ -52,8 +52,10 @@ main(
     addr_t addr = (addr_t) strtoul(addr_str, NULL, 16);
 
     /* initialize the libvmi library */
-    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name) ==
-        VMI_FAILURE) {
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+                          VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         goto error_exit;
     }

--- a/examples/map-symbol.c
+++ b/examples/map-symbol.c
@@ -51,8 +51,10 @@ main(
     char *symbol = argv[2];
 
     /* initialize the libvmi library */
-    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name) ==
-        VMI_FAILURE) {
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+                          VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         goto error_exit;
     }

--- a/examples/module-list.c
+++ b/examples/module-list.c
@@ -47,8 +47,10 @@ main(
     char *name = argv[1];
 
     /* initialize the libvmi library */
-    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name) ==
-        VMI_FAILURE) {
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+                          VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }
@@ -92,7 +94,7 @@ main(
         if (VMI_OS_LINUX == vmi_get_ostype(vmi)) {
             char *modname = NULL;
 
-            if (VMI_PM_IA32E == vmi_get_page_mode(vmi)) {   // 64-bit paging
+            if (VMI_PM_IA32E == vmi_get_page_mode(vmi, 0)) {   // 64-bit paging
                 modname = vmi_read_str_va(vmi, next_module + 16, 0);
             }
             else {
@@ -111,7 +113,7 @@ main(
              * These offset values are stable (at least) between XP and Windows 7.
              */
 
-            if (VMI_PM_IA32E == vmi_get_page_mode(vmi)) {
+            if (VMI_PM_IA32E == vmi_get_page_mode(vmi, 0)) {
                 us = vmi_read_unicode_str_va(vmi, next_module + 0x58, 0);
             } else {
                 us = vmi_read_unicode_str_va(vmi, next_module + 0x2c, 0);

--- a/examples/msr-event-example.c
+++ b/examples/msr-event-example.c
@@ -64,14 +64,16 @@ int main (int argc, char **argv) {
     // Arg 1 is the VM name.
     name = argv[1];
 
-    // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_PARTIAL | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    /* initialize the libvmi library */
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
+                          NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     /* Register event to track any writes to a MSR. */
     memset(&msr_event, 0, sizeof(vmi_event_t));

--- a/examples/process-list.c
+++ b/examples/process-list.c
@@ -52,7 +52,10 @@ int main (int argc, char **argv)
     char *name = argv[1];
 
     /* initialize the libvmi library */
-    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name) == VMI_FAILURE) {
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+                          VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }
@@ -90,8 +93,12 @@ int main (int argc, char **argv)
 
     /* demonstrate name and id accessors */
     char *name2 = vmi_get_name(vmi);
+    vmi_mode_t mode;
 
-    if (VMI_FILE != vmi_get_access_mode(vmi)) {
+    if (VMI_FAILURE == vmi_get_access_mode(vmi, NULL, 0, NULL, &mode))
+        goto error_exit;
+
+    if ( VMI_FILE != mode ) {
         uint64_t id = vmi_get_vmid(vmi);
 
         printf("Process listing for VM %s (id=%"PRIu64")\n", name2, id);

--- a/examples/shm-snapshot-process-list.c
+++ b/examples/shm-snapshot-process-list.c
@@ -39,10 +39,14 @@ void list_processes(vmi_instance_t vmi, addr_t current_process,
     addr_t list_head, unsigned long tasks_offset, addr_t current_list_entry,
     addr_t next_list_entry, unsigned long pid_offset,
     vmi_pid_t pid, char* procname, unsigned long name_offset) {
+    vmi_mode_t mode;
 
     /* demonstrate name and id accessors */
     char* name2 = vmi_get_name(vmi);
-    if (VMI_FILE != vmi_get_access_mode(vmi)) {
+    if (VMI_FAILURE == vmi_get_access_mode(vmi, NULL, 0, NULL, &mode))
+        return;
+
+    if ( VMI_FILE != mode ) {
         uint64_t id = vmi_get_vmid(vmi);
 
         printf("Process listing for VM %s (id=%"PRIu64")\n", name2, id);
@@ -136,7 +140,10 @@ int main (int argc, char **argv)
     char *name = argv[1];
 
     /* initialize the libvmi library */
-    if (vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name) == VMI_FAILURE) {
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL,
+                          VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }

--- a/examples/singlestep-event-example.c
+++ b/examples/singlestep-event-example.c
@@ -72,14 +72,14 @@ int main (int argc, char **argv) {
     sigaction(SIGINT,  &act, NULL);
     sigaction(SIGALRM, &act, NULL);
 
-    // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_PARTIAL | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    /* initialize the libvmi library */
+    if (VMI_FAILURE == vmi_init(&vmi, VMI_XEN, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     //Single step setup
     memset(&single_event, 0, sizeof(vmi_event_t));

--- a/examples/step-event-example.c
+++ b/examples/step-event-example.c
@@ -141,16 +141,15 @@ int main (int argc, char **argv)
     sigaction(SIGALRM, &act, NULL);
 
     // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_COMPLETE | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
+                          NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
-        if (vmi != NULL ) {
-            vmi_destroy(vmi);
-        }
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     vmi_pause_vm(vmi);
 

--- a/examples/va-pages.c
+++ b/examples/va-pages.c
@@ -108,16 +108,15 @@ int main (int argc, char **argv)
     sigaction(SIGALRM, &act, NULL);
 
     // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_COMPLETE | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
+                          NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
-        if (vmi != NULL ) {
-            vmi_destroy(vmi);
-        }
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     /* Configure an event to track when the process is running.
      * (The CR3 register is updated on task context switch, allowing

--- a/examples/xen-emulate-response.c
+++ b/examples/xen-emulate-response.c
@@ -82,16 +82,15 @@ int main (int argc, char **argv)
     sigaction(SIGALRM, &act, NULL);
 
     // Initialize the libvmi library.
-    if (vmi_init(&vmi, VMI_XEN | VMI_INIT_COMPLETE | VMI_INIT_EVENTS, name) == VMI_FAILURE){
+    if (VMI_FAILURE ==
+        vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME | VMI_INIT_EVENTS,
+                          NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL))
+    {
         printf("Failed to init LibVMI library.\n");
-        if (vmi != NULL ) {
-            vmi_destroy(vmi);
-        }
         return 1;
     }
-    else{
-        printf("LibVMI init succeeded!\n");
-    }
+
+    printf("LibVMI init succeeded!\n");
 
     vmi_event_t event;
     memset(&event, 0, sizeof(vmi_event_t));

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -30,13 +30,6 @@
 /* NB: Necessary for windows specific API functions */
 #include "os/windows/windows.h"
 
-page_mode_t
-vmi_get_page_mode(
-    vmi_instance_t vmi)
-{
-    return vmi->page_mode;
-}
-
 uint8_t vmi_get_address_width(
     vmi_instance_t vmi)
 {
@@ -45,13 +38,6 @@ uint8_t vmi_get_address_width(
     driver_get_address_width(vmi, &width);
 
     return width;
-}
-
-uint32_t
-vmi_get_access_mode(
-    vmi_instance_t vmi)
-{
-    return vmi->mode;
 }
 
 os_t
@@ -71,7 +57,7 @@ vmi_get_winver(
 #else
     windows_instance_t windows_instance = NULL;
 
-    if (VMI_OS_WINDOWS != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode))
+    if (VMI_OS_WINDOWS != vmi->os_type)
         return VMI_OS_WINDOWS_NONE;
 
     if (!vmi->os_data) {
@@ -542,7 +528,7 @@ vmi_get_linux_sysmap(
 {
     linux_instance_t linux_instance = NULL;
 
-    if(VMI_OS_LINUX != vmi->os_type || (VMI_INIT_PARTIAL & vmi->init_mode)){
+    if(VMI_OS_LINUX != vmi->os_type){
         return NULL;
     }
 

--- a/libvmi/arch/amd64.c
+++ b/libvmi/arch/amd64.c
@@ -168,7 +168,7 @@ status_t v2p_ia32e (vmi_instance_t vmi,
         goto done;
     }
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_ia32e.pml4e_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_ia32e.pml4e_value)) {
         status = VMI_FAILURE;
         goto done;
     }
@@ -179,7 +179,7 @@ status_t v2p_ia32e (vmi_instance_t vmi,
         goto done;
     }
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_ia32e.pdpte_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_ia32e.pdpte_value)) {
         status = VMI_FAILURE;
         goto done;
     }
@@ -198,7 +198,7 @@ status_t v2p_ia32e (vmi_instance_t vmi,
         goto done;
     }
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_ia32e.pgd_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_ia32e.pgd_value)) {
         status = VMI_FAILURE;
         goto done;
     }
@@ -217,7 +217,7 @@ status_t v2p_ia32e (vmi_instance_t vmi,
         goto done;
     }
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_ia32e.pte_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_ia32e.pte_value)) {
         status = VMI_FAILURE;
         goto done;
     }
@@ -255,7 +255,7 @@ GSList* get_va_pages_ia32e(vmi_instance_t vmi, addr_t dtb) {
 
         uint64_t pml4e_value = pml4_page[pml4e_index];
 
-        if(!ENTRY_PRESENT(vmi->os_type, pml4e_value)) {
+        if(!ENTRY_PRESENT(vmi->x86.transition_pages, pml4e_value)) {
             continue;
         }
 
@@ -270,7 +270,7 @@ GSList* get_va_pages_ia32e(vmi_instance_t vmi, addr_t dtb) {
 
             uint64_t pdpte_value = pdpt_page[pdpte_index];
 
-            if(!ENTRY_PRESENT(vmi->os_type, pdpte_value)) {
+            if(!ENTRY_PRESENT(vmi->x86.transition_pages, pdpte_value)) {
                 continue;
             }
 

--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -37,7 +37,7 @@ status_t arch_init(vmi_instance_t vmi) {
     }
 
     if(vmi->page_mode == VMI_PM_UNKNOWN) {
-        if(VMI_FAILURE == find_page_mode_live(vmi)) {
+        if(VMI_FAILURE == find_page_mode_live(vmi, 0, NULL)) {
             return ret;
         }
     }

--- a/libvmi/arch/intel.c
+++ b/libvmi/arch/intel.c
@@ -288,7 +288,7 @@ status_t v2p_nopae (vmi_instance_t vmi,
 
     dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pgd = 0x%.8"PRIx64"\n", info->x86_legacy.pgd_value);
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_legacy.pgd_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_legacy.pgd_value)) {
         buffalo_nopae(vmi, info->x86_legacy.pgd_value, 0);
         status = VMI_FAILURE;
         goto done;
@@ -309,7 +309,7 @@ status_t v2p_nopae (vmi_instance_t vmi,
 
     dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: pte = 0x%.8"PRIx64"\n", info->x86_legacy.pte_value);
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_legacy.pte_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_legacy.pte_value)) {
         buffalo_nopae(vmi, info->x86_legacy.pte_value, 1);
         status = VMI_FAILURE;
         goto done;
@@ -340,7 +340,7 @@ status_t v2p_pae (vmi_instance_t vmi,
 
     dbprint(VMI_DEBUG_PTLOOKUP, "--PAE PTLookup: pdpe = 0x%"PRIx64"\n", info->x86_pae.pdpe_value);
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_pae.pdpe_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_pae.pdpe_value)) {
         goto done;
     }
 
@@ -349,7 +349,7 @@ status_t v2p_pae (vmi_instance_t vmi,
         goto done;
     }
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_pae.pgd_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_pae.pgd_value)) {
         status = VMI_FAILURE;
         goto done;
     }
@@ -367,7 +367,7 @@ status_t v2p_pae (vmi_instance_t vmi,
         goto done;
     }
 
-    if (!ENTRY_PRESENT(vmi->os_type, info->x86_pae.pte_value)) {
+    if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_pae.pte_value)) {
         status = VMI_FAILURE;
         goto done;
     }
@@ -472,7 +472,7 @@ GSList* get_va_pages_pae(vmi_instance_t vmi, addr_t dtb) {
         uint64_t pdp_base_va = pdp_index * PTRS_PER_PAE_PGD * PTRS_PER_PAE_PGD * PTRS_PER_PAE_PTE * entry_size;
         uint64_t pdp_entry = pdpi_table[pdp_index];
 
-        if(!ENTRY_PRESENT(vmi->os_type, pdp_entry)) {
+        if(!ENTRY_PRESENT(vmi->x86.transition_pages, pdp_entry)) {
             continue;
         }
 

--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -137,7 +137,8 @@ void
 pid_cache_destroy(
     vmi_instance_t vmi)
 {
-    g_hash_table_destroy(vmi->pid_cache);
+    if ( vmi->pid_cache )
+        g_hash_table_destroy(vmi->pid_cache);
 }
 
 status_t
@@ -262,7 +263,8 @@ void
 sym_cache_destroy(
     vmi_instance_t vmi)
 {
-    g_hash_table_destroy(vmi->sym_cache);
+    if ( vmi->sym_cache )
+        g_hash_table_destroy(vmi->sym_cache);
 }
 
 status_t
@@ -415,7 +417,8 @@ void
 rva_cache_destroy(
     vmi_instance_t vmi)
 {
-    g_hash_table_destroy(vmi->rva_cache);
+    if ( vmi->rva_cache )
+        g_hash_table_destroy(vmi->rva_cache);
 }
 
 status_t
@@ -541,7 +544,8 @@ void
 v2p_cache_destroy(
     vmi_instance_t vmi)
 {
-    g_hash_table_destroy(vmi->v2p_cache);
+    if ( vmi->v2p_cache )
+        g_hash_table_destroy(vmi->v2p_cache);
 }
 
 status_t

--- a/libvmi/config/grammar.y
+++ b/libvmi/config/grammar.y
@@ -274,6 +274,7 @@ int vmi_parse_config (const char *target_name)
 %token<str>    LINUX_NAME
 %token<str>    LINUX_PGD
 %token<str>    LINUX_ADDR
+%token<str>    LINUX_INIT_TASK
 %token<str>    WIN_NTOSKRNL
 %token<str>    WIN_NTOSKRNL_VA
 %token<str>    WIN_TASKS
@@ -335,6 +336,8 @@ assignment:
         linux_pgd_assignment
         |
         linux_addr_assignment
+        |
+        linux_init_task_assignment
         |
         win_ntoskrnl_assignment
         |
@@ -415,6 +418,17 @@ linux_addr_assignment:
         LINUX_ADDR EQUALS NUM
         {
             fprintf(stderr, "VMI_WARNING: linux_addr is no longer used and should be removed from your config file\n");
+            free($3);
+        }
+        ;
+
+linux_init_task_assignment:
+        LINUX_INIT_TASK EQUALS NUM
+        {
+            uint64_t tmp = strtoull($3, NULL, 0);
+            uint64_t *tmp_ptr = malloc(sizeof(uint64_t));
+            (*tmp_ptr) = tmp;
+            g_hash_table_insert(tmp_entry, $1, tmp_ptr);
             free($3);
         }
         ;

--- a/libvmi/config/lexicon.l
+++ b/libvmi/config/lexicon.l
@@ -48,6 +48,7 @@ linux_name              { BeginToken(yytext); yylval.str = strndup(yytext, CONFI
 linux_pid               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PID; }
 linux_pgd               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PGD; }
 linux_addr              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_ADDR; }
+linux_init_task         { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_INIT_TASK; }
 win_ntoskrnl            { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL; }
 win_ntoskrnl_va         { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL_VA; }
 win_tasks               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_TASKS; }

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -43,29 +43,29 @@
 #include "driver/kvm/kvm.h"
 #endif
 
-status_t driver_init_mode(vmi_instance_t vmi, uint64_t domainid, const char *name)
+status_t driver_init_mode(const char *name, uint64_t domainid, vmi_mode_t *mode)
 {
     unsigned long count = 0;
 
     /* see what systems are accessable */
 #if ENABLE_XEN == 1
-    if (VMI_SUCCESS == xen_test(vmi, domainid, name)) {
+    if (VMI_SUCCESS == xen_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found Xen\n");
-        vmi->mode = VMI_XEN;
+        *mode = VMI_XEN;
         count++;
     }
 #endif
 #if ENABLE_KVM == 1
-    if (VMI_SUCCESS == kvm_test(vmi, domainid, name)) {
+    if (VMI_SUCCESS == kvm_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found KVM\n");
-        vmi->mode = VMI_KVM;
+        *mode = VMI_KVM;
         count++;
     }
 #endif
 #if ENABLE_FILE == 1
     if (VMI_SUCCESS == file_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found file\n");
-        vmi->mode = VMI_FILE;
+        *mode = VMI_FILE;
         count++;
     }
 #endif
@@ -114,6 +114,8 @@ status_t driver_init(vmi_instance_t vmi)
         rc = driver_file_setup(vmi);
         break;
 #endif
+    default:
+        break;
     };
 
     if (rc == VMI_SUCCESS && vmi->driver.init_ptr)

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -176,9 +176,9 @@ typedef struct driver_interface {
 } driver_interface_t;
 
 status_t driver_init_mode(
-    vmi_instance_t vmi,
+    const char *name,
     uint64_t domainid,
-    const char *name);
+    vmi_mode_t *mode);
 
 status_t driver_init(
     vmi_instance_t vmi);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1328,6 +1328,7 @@ kvm_init(
     kvm->conn = conn;
 
     vmi->driver.driver_data = (void*)kvm;
+
     return VMI_SUCCESS;
 }
 
@@ -1848,10 +1849,12 @@ kvm_is_pv(
 
 status_t
 kvm_test(
-    vmi_instance_t vmi,
     uint64_t domainid,
     const char *name)
 {
+    struct vmi_instance _vmi = {0};
+    vmi_instance_t vmi = &_vmi;
+
     if ( VMI_FAILURE == kvm_init(vmi) )
         return VMI_FAILURE;
 

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -78,7 +78,6 @@ status_t kvm_write(
 int kvm_is_pv(
     vmi_instance_t vmi);
 status_t kvm_test(
-    vmi_instance_t vmi,
     uint64_t domainid,
     const char *name);
 status_t kvm_pause_vm(

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -890,7 +890,7 @@ xen_init_vmi(
     }
 
 #if ENABLE_SHM_SNAPSHOT == 1
-    if (vmi->flags & VMI_INIT_SHM_SNAPSHOT) {
+    if (vmi->init_flags & VMI_INIT_SHM) {
         ret = xen_create_shm_snapshot(vmi);
     }
     else {
@@ -909,7 +909,7 @@ xen_init_vmi(
     if ( VMI_FAILURE == ret )
         goto _bail;
 
-    if(xen->hvm && (vmi->init_mode & VMI_INIT_EVENTS))
+    if(xen->hvm && (vmi->init_flags & VMI_INIT_EVENTS))
     {
         ret = xen_init_events(vmi);
 
@@ -929,7 +929,7 @@ xen_destroy(
 {
     xen_instance_t *xen = xen_get_instance(vmi);
 
-    if(xen->hvm && (vmi->init_mode & VMI_INIT_EVENTS))
+    if(xen->hvm && (vmi->init_flags & VMI_INIT_EVENTS))
         xen_events_destroy(vmi);
 
 #if ENABLE_SHM_SNAPSHOP == 1
@@ -2730,10 +2730,12 @@ xen_is_pv(
 
 status_t
 xen_test(
-    vmi_instance_t vmi,
     uint64_t domainid,
     const char *name)
 {
+    struct vmi_instance _vmi = {0};
+    vmi_instance_t vmi = &_vmi;
+
     if (domainid == VMI_INVALID_DOMID && name == NULL) {
         errprint("VMI_ERROR: xen_test: domid or name must be specified\n");
         return VMI_FAILURE;
@@ -2755,6 +2757,7 @@ xen_test(
         return VMI_FAILURE;
     }
 
+    xen_destroy(vmi);
     return VMI_SUCCESS;
 }
 

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -95,7 +95,6 @@ status_t xen_write(
 int xen_is_pv(
     vmi_instance_t vmi);
 status_t xen_test(
-    vmi_instance_t vmi,
     uint64_t domainid,
     const char *name);
 status_t xen_pause_vm(

--- a/libvmi/memory.c
+++ b/libvmi/memory.c
@@ -34,7 +34,7 @@
  * check that this vm uses a paging method that we support
  * and set pm/cr3/pae/pse/lme flags optionally on the given pointers
  */
-status_t probe_memory_layout_x86(vmi_instance_t vmi) {
+status_t probe_memory_layout_x86(vmi_instance_t vmi, unsigned long vcpu, page_mode_t *out_pm) {
     // To get the paging layout, the following bits are needed:
     // 1. CR0.PG
     // 2. CR4.PAE
@@ -51,7 +51,7 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     int pae = 0, pse = 0, lme = 0;
 
     /* get the control register values */
-    if (driver_get_vcpureg(vmi, &cr0, CR0, 0) == VMI_FAILURE) {
+    if (driver_get_vcpureg(vmi, &cr0, CR0, vcpu) == VMI_FAILURE) {
         errprint("**failed to get CR0\n");
         goto _exit;
     }
@@ -60,9 +60,7 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     if (!VMI_GET_BIT(cr0, 31)) {
         dbprint(VMI_DEBUG_CORE, "Paging disabled for this VM, only physical addresses supported.\n");
         vmi->page_mode = VMI_PM_UNKNOWN;
-        vmi->x86.pae = 0;
         vmi->x86.pse = 0;
-        vmi->x86.lme = 0;
 
         ret = VMI_SUCCESS;
         goto _exit;
@@ -71,7 +69,7 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     //
     // Paging enabled (PG==1)
     //
-    if (driver_get_vcpureg(vmi, &cr4, CR4, 0) == VMI_FAILURE) {
+    if (driver_get_vcpureg(vmi, &cr4, CR4, vcpu) == VMI_FAILURE) {
         errprint("**failed to get CR4\n");
         goto _exit;
     }
@@ -84,7 +82,7 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
     pse = VMI_GET_BIT(cr4, 4);
     dbprint(VMI_DEBUG_CORE, "**set pse = %d\n", pse);
 
-    ret = driver_get_vcpureg(vmi, &efer, MSR_EFER, 0);
+    ret = driver_get_vcpureg(vmi, &efer, MSR_EFER, vcpu);
     if (VMI_SUCCESS == ret) {
         lme = VMI_GET_BIT(efer, 8);
         dbprint(VMI_DEBUG_CORE, "**set lme = %d\n", lme);
@@ -104,7 +102,7 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
              dom_addr_width, lme);
     }   // if
     // Get current cr3 for sanity checking
-    if (driver_get_vcpureg(vmi, &cr3, CR3, 0) == VMI_FAILURE) {
+    if (driver_get_vcpureg(vmi, &cr3, CR3, vcpu) == VMI_FAILURE) {
         errprint("**failed to get CR3\n");
         goto _exit;
     }
@@ -133,29 +131,31 @@ status_t probe_memory_layout_x86(vmi_instance_t vmi) {
                 cr3, vmi->max_physical_address);
     }
 
-    vmi->page_mode = pm;
-    vmi->x86.pae = pae;
-    vmi->x86.pse = pse;
-    vmi->x86.lme = lme;
+    if ( out_pm ) {
+        *out_pm = pm;
+    } else {
+        vmi->page_mode = pm;
+        vmi->x86.pse = pse;
+    }
 
 _exit:
     return ret;
 }
 
-status_t probe_memory_layout_arm(vmi_instance_t vmi) {
+status_t probe_memory_layout_arm(vmi_instance_t vmi, unsigned long vcpu, page_mode_t *out_pm) {
     //Note: this will need to be a more comprehensive check when we start supporting AArch64
     status_t ret = VMI_FAILURE;
     page_mode_t pm = VMI_PM_UNKNOWN;
 
     reg_t cpsr;
-    if (VMI_SUCCESS == driver_get_vcpureg(vmi, &cpsr, CPSR, 0)) {
+    if (VMI_SUCCESS == driver_get_vcpureg(vmi, &cpsr, CPSR, vcpu)) {
         if (cpsr & PSR_MODE_BIT) {
             pm = VMI_PM_AARCH32;
             dbprint(VMI_DEBUG_CORE, "Found ARM32 pagemode\n");
         } else {
             /* See ARM ARMv8-A D7.2.84 TCR_EL1, Translation Control Register (EL1) */
             reg_t tcr_el1;
-            if (VMI_SUCCESS == driver_get_vcpureg(vmi, &tcr_el1, TCR_EL1, 0)) {
+            if ( !out_pm && VMI_SUCCESS == driver_get_vcpureg(vmi, &tcr_el1, TCR_EL1, vcpu)) {
                 vmi->arm64.t0sz = tcr_el1 & VMI_BIT_MASK(0,5);
                 vmi->arm64.t1sz = (tcr_el1 & VMI_BIT_MASK(16,21)) >> 16;
                 switch((tcr_el1 & VMI_BIT_MASK(14,15)) >> 14) {
@@ -192,7 +192,14 @@ status_t probe_memory_layout_arm(vmi_instance_t vmi) {
         ret = VMI_SUCCESS;
     }
 
-    vmi->page_mode = pm;
+    if ( VMI_SUCCESS == ret )
+    {
+        if ( out_pm )
+            *out_pm = pm;
+        else
+            vmi->page_mode = pm;
+    }
+
     return ret;
 }
 
@@ -200,18 +207,18 @@ status_t probe_memory_layout_arm(vmi_instance_t vmi) {
  * This function attempts to probe the memory layout
  * of a live VM to find the correct page mode.
  */
-status_t find_page_mode_live(vmi_instance_t vmi) {
+status_t find_page_mode_live(vmi_instance_t vmi, unsigned long vcpu, page_mode_t *out_pm) {
     if (VMI_FILE == vmi->mode) {
         /* skip all of this for files */
         return VMI_FAILURE;
     }
 
 #if defined(I386) || defined(X86_64)
-    if (VMI_SUCCESS == probe_memory_layout_x86(vmi)) {
+    if (VMI_SUCCESS == probe_memory_layout_x86(vmi, vcpu, out_pm)) {
         return VMI_SUCCESS;
     }
 #elif defined(ARM32) || defined(ARM64)
-    if (VMI_SUCCESS == probe_memory_layout_arm(vmi)) {
+    if (VMI_SUCCESS == probe_memory_layout_arm(vmi, vcpu, out_pm)) {
         return VMI_SUCCESS;
     }
 #endif

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -296,12 +296,12 @@ status_t init_kaslr(vmi_instance_t vmi) {
     return ret;
 }
 
-status_t linux_init(vmi_instance_t vmi) {
+status_t linux_init(vmi_instance_t vmi, GHashTable *config) {
 
     status_t rc;
     os_interface_t os_interface = NULL;
 
-    if (vmi->config == NULL) {
+    if (!config) {
         errprint("No config table found\n");
         return VMI_FAILURE;
     }
@@ -317,7 +317,7 @@ status_t linux_init(vmi_instance_t vmi) {
 
     linux_instance_t linux_instance = vmi->os_data;
 
-    g_hash_table_foreach(vmi->config, (GHFunc)linux_read_config_ghashtable_entries, vmi);
+    g_hash_table_foreach(config, (GHFunc)linux_read_config_ghashtable_entries, vmi);
 
     if(linux_instance->rekall_profile)
         rc = init_from_rekall_profile(vmi);

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -321,11 +321,13 @@ status_t linux_init(vmi_instance_t vmi, GHashTable *config) {
 
     if(linux_instance->rekall_profile)
         rc = init_from_rekall_profile(vmi);
-    else
+    else if ( !vmi->init_task )
         rc = linux_symbol_to_address(vmi, "init_task", NULL, &vmi->init_task);
+    else
+        rc = VMI_SUCCESS;
 
-    if (VMI_FAILURE == rc) {
-        errprint("Could not get init_task from Rekall profile or System.map\n");
+    if ( VMI_FAILURE == rc ) {
+        errprint("Failed to determine init_task!\n");
         goto _exit;
     }
 
@@ -415,6 +417,11 @@ void linux_read_config_ghashtable_entries(char* key, gpointer value,
 
     if (strncmp(key, "linux_pgd", CONFIG_STR_LENGTH) == 0) {
         linux_instance->pgd_offset = *(addr_t *)value;
+        goto _done;
+    }
+
+    if (strncmp(key, "linux_init_task", CONFIG_STR_LENGTH) == 0) {
+        vmi->init_task = *(addr_t*)value;
         goto _done;
     }
 

--- a/libvmi/os/linux/linux.h
+++ b/libvmi/os/linux/linux.h
@@ -41,7 +41,7 @@ struct linux_instance {
 };
 typedef struct linux_instance *linux_instance_t;
 
-status_t linux_init(vmi_instance_t instance);
+status_t linux_init(vmi_instance_t instance, GHashTable *config);
 
 uint64_t linux_get_offset(vmi_instance_t vmi, const char* offset_name);
 

--- a/libvmi/os/windows/unicode.c
+++ b/libvmi/os/windows/unicode.c
@@ -43,7 +43,7 @@ windows_read_unicode_struct(
     addr_t buffer_va = 0;
     uint16_t buffer_len = 0;
 
-    if (VMI_PM_IA32E == vmi_get_page_mode(vmi)) {   // 64 bit guest
+    if (VMI_PM_IA32E == vmi->page_mode) {   // 64 bit guest
         win64_unicode_string_t us64 = { 0 };
         struct_size = sizeof(us64);
         // read the UNICODE_STRING struct

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -51,7 +51,7 @@ struct windows_instance {
 };
 typedef struct windows_instance *windows_instance_t;
 
-status_t windows_init(vmi_instance_t instance);
+status_t windows_init(vmi_instance_t instance, GHashTable *config);
 
 addr_t windows_pid_to_pgd(vmi_instance_t vmi, vmi_pid_t pid);
 vmi_pid_t windows_pgd_to_pid(vmi_instance_t vmi, addr_t pgd);

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -66,13 +66,7 @@ struct vmi_instance {
 
     driver_interface_t driver; /**< The driver supporting the chosen mode */
 
-    uint32_t flags;         /**< flags passed to init function */
-
-    uint32_t init_mode;     /**< VMI_INIT_PARTIAL or VMI_INIT_COMPLETE */
-
-    GHashTable* config;    /**< configuration */
-
-    uint32_t config_mode;     /**< VMI_CONFIG_NONE/FILE/STRING/GHASHTABLE */
+    uint32_t init_flags;    /**< init flags (events, shm, etc.) */
 
     char *image_type;       /**< image type that we are accessing */
 
@@ -88,11 +82,9 @@ struct vmi_instance {
 
     union {
         struct {
-            int pae;        /**< nonzero if PAE is enabled */
+            bool pse;        /**< true if PSE is enabled */
 
-            int pse;        /**< nonzero if PSE is enabled */
-
-            int lme;        /**< nonzero if LME is enabled */
+            bool transition_pages; /**< true if transition-pages are enabled */
         } x86;
 
         struct {
@@ -299,8 +291,10 @@ status_t vmi_pagetable_lookup_cache(
 
     #define PSR_MODE_BIT 0x10 // set on cpsr iff ARM32
 
-    status_t find_page_mode_live(
-    vmi_instance_t vmi);
+status_t find_page_mode_live(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    page_mode_t *out_pm);
 
 /*-----------------------------------------
  * strmatch.c
@@ -333,7 +327,7 @@ status_t vmi_pagetable_lookup_cache(
 /*----------------------------------------------
  * events.c
  */
-    void events_init(
+    status_t events_init(
         vmi_instance_t vmi);
     void events_destroy(
         vmi_instance_t vmi);

--- a/libvmi/x86.h
+++ b/libvmi/x86.h
@@ -106,11 +106,11 @@ extern "C" {
  * If a page is called, but not present, a page fault will occur,
  * and the OS should handle it. (See below.)
  */
-#define ENTRY_PRESENT(os_type, entry) \
+#define ENTRY_PRESENT(transition_pages, entry) \
     (VMI_GET_BIT(entry, 0) \
         ? 1 : \
         ( \
-            (os_type == VMI_OS_WINDOWS && \
+            (transition_pages && \
                 (TRANSITION(entry) && !(PROTOTYPE(entry))) \
             ) \
             ? 1 : 0 \

--- a/tests/check_runner.c
+++ b/tests/check_runner.c
@@ -28,7 +28,19 @@
 #include "check_tests.h"
 #include "../libvmi/libvmi.h"
 
-char *testvm = NULL;
+TCase *init_tcase();
+TCase *translate_tcase();
+TCase *read_tcase();
+TCase *write_tcase();
+TCase *print_tcase();
+TCase *accessor_tcase();
+TCase *util_tcase();
+TCase *peparse_tcase();
+TCase *cache_tcase();
+TCase *get_va_pages_tcase();
+TCase *shm_snapshot_tcase();
+
+const char *testvm = NULL;
 
 const char *get_testvm (void)
 {
@@ -60,11 +72,12 @@ main (void)
     suite_add_tcase(s, accessor_tcase());
     suite_add_tcase(s, util_tcase());
     suite_add_tcase(s, peparse_tcase());
+    suite_add_tcase(s, cache_tcase());
+    suite_add_tcase(s, get_va_pages_tcase());
+
 #if ENABLE_SHM_SNAPSHOT == 1
     suite_add_tcase(s, shm_snapshot_tcase());
 #endif
-    suite_add_tcase(s, cache_tcase());
-    suite_add_tcase(s, get_va_pages_tcase());
 
     /* run the tests */
     SRunner *sr = srunner_create(s);

--- a/tests/test_accessor.c
+++ b/tests/test_accessor.c
@@ -34,7 +34,8 @@ START_TEST (test_vmi_get_name)
     vmi_instance_t vmi = NULL;
     char *name = NULL;
     int compare = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     name = vmi_get_name(vmi);
     compare = strcmp(name, get_testvm());
     fail_unless(compare == 0, "vmi_get_name failed");
@@ -49,7 +50,8 @@ START_TEST (test_vmi_get_memsize_max_phys_addr)
     uint64_t memsize = 0;
     addr_t max_physical_addr = 0;
 
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
 
     memsize = vmi_get_memsize(vmi);
     max_physical_addr = vmi_get_max_physical_address(vmi);

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -35,13 +35,14 @@
 START_TEST (test_libvmi_cache)
 {
     vmi_instance_t vmi = NULL;
-    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
 
     v2p_cache_flush(vmi, ~0ull);
     v2p_cache_set(vmi, 0x400000, 0xabcde, 0x3b40a000);
 
     addr_t pa = 0;
-    ret = v2p_cache_get(vmi, 0x880000400000ull, 0xabcde, &pa);
+    status_t ret = v2p_cache_get(vmi, 0x880000400000ull, 0xabcde, &pa);
     fail_if(ret == VMI_SUCCESS, "hit a wrong cache");
 
     /* @awsaba 's complementary */

--- a/tests/test_getvapages.c
+++ b/tests/test_getvapages.c
@@ -38,7 +38,8 @@
 START_TEST (test_get_va_pages)
 {
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     GHashTable *config = NULL;
 
     if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)){

--- a/tests/test_init.c
+++ b/tests/test_init.c
@@ -37,37 +37,43 @@ START_TEST (test_libvmi_init4)
 {
     const char *name = get_testvm();
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, name);
+    vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     if (VMI_OS_WINDOWS == vmi_get_ostype(vmi) && VMI_OS_WINDOWS_XP == vmi_get_winver(vmi))
     {
-
         char location[100];
         getcwd(location, sizeof(location));
 
 #define XP_REKALL_PROFILE_LIVE "ntkrnlpa.pdb.bd8f451f3e754ed8a34b50560ceb08e31.rekall.json"
 #define XP_REKALL_PROFILE_FILE "ntoskrnl.pdb.32962337f0f646388b39535cd8dd70e82.rekall.json"
 
-        char *sysmap = NULL;
-        if(vmi_get_access_mode(vmi) == VMI_FILE) {
-            sysmap = g_malloc0(snprintf(NULL,0,"%s/%s", location, XP_REKALL_PROFILE_FILE)+1);
-            sprintf(sysmap, "%s/%s", location, XP_REKALL_PROFILE_FILE);
+        char *rekall_profile = NULL;
+        vmi_mode_t mode;
+        if(VMI_FAILURE == vmi_get_access_mode(vmi, NULL, 0, NULL, &mode))
+            goto done;
+
+        if ( mode == VMI_FILE) {
+            rekall_profile = g_malloc0(snprintf(NULL,0,"%s/%s", location, XP_REKALL_PROFILE_FILE)+1);
+            sprintf(rekall_profile, "%s/%s", location, XP_REKALL_PROFILE_FILE);
         } else {
-            sysmap = g_malloc0(snprintf(NULL,0,"%s/%s", location, XP_REKALL_PROFILE_LIVE)+1);
-            sprintf(sysmap, "%s/%s", location, XP_REKALL_PROFILE_LIVE);
+            rekall_profile = g_malloc0(snprintf(NULL,0,"%s/%s", location, XP_REKALL_PROFILE_LIVE)+1);
+            sprintf(rekall_profile, "%s/%s", location, XP_REKALL_PROFILE_LIVE);
         }
 
         vmi_destroy(vmi);
 
         GHashTable *config = g_hash_table_new(g_str_hash, g_str_equal);
         g_hash_table_insert(config, "ostype", "Windows");
-        g_hash_table_insert(config, "name", name);
-        g_hash_table_insert(config, "sysmap", sysmap);
-        if(VMI_FAILURE == vmi_init_custom(&vmi, VMI_AUTO | VMI_INIT_COMPLETE | VMI_CONFIG_GHASHTABLE, config)) {
-            fail_unless(0, "failed to init XP test domain from Rekall profile %s.", sysmap);
+        g_hash_table_insert(config, "rekall_profile", rekall_profile);
+        if(VMI_FAILURE == vmi_init_complete(&vmi, (void*)name, VMI_INIT_DOMAINNAME, NULL,
+                                            VMI_CONFIG_GHASHTABLE, config, NULL)) {
+            fail_unless(0, "failed to init XP test domain from Rekall profile %s.", rekall_profile);
         }
         g_hash_table_destroy(config);
-        g_free(sysmap);
+        g_free(rekall_profile);
     }
+
+done:
     vmi_destroy(vmi);
 }
 END_TEST
@@ -76,15 +82,13 @@ END_TEST
 START_TEST (test_libvmi_init3)
 {
     FILE *f = NULL;
-    char *ptr = NULL;
+    const char *ptr = NULL;
     char location[100];
-    char *sudo_user = NULL;
+    const char *sudo_user = NULL;
     struct passwd *pw_entry = NULL;
     vmi_instance_t vmi = NULL;
-    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_PARTIAL, get_testvm());
 
     /* read the config entry from the config file */
-
     /* first check home directory of sudo user */
     if ((sudo_user = getenv("SUDO_USER")) != NULL) {
         if ((pw_entry = getpwnam(sudo_user)) != NULL) {
@@ -156,9 +160,10 @@ success:
     memcpy(config, buf + start, entry_length);
     free(buf);
 
-    /* complete the init */
-    ret = vmi_init_complete(&vmi, config);
+    status_t ret = vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                                     VMI_CONFIG_STRING, (void*)config, NULL);
     free(config);
+
     fail_unless(ret == VMI_SUCCESS,
                 "vmi_init_complete failed");
     fail_unless(vmi != NULL,
@@ -167,20 +172,19 @@ success:
 }
 END_TEST
 
-/* test partial init and init_complete function */
+/* test determine mode and init function */
 START_TEST (test_libvmi_init2)
 {
     vmi_instance_t vmi = NULL;
-    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_PARTIAL, get_testvm());
+    vmi_mode_t mode;
+    status_t ret = vmi_get_access_mode(vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL, &mode);
     fail_unless(ret == VMI_SUCCESS,
-                "vmi_init failed with AUTO | PARTIAL");
+                "vmi_get_access_mode failed to identify the hypervisor");
+    ret = vmi_init(&vmi, mode, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL, NULL);
+    fail_unless(ret == VMI_SUCCESS,
+                "vmi_init failed");
     fail_unless(vmi != NULL,
                 "vmi_init failed to initialize vmi instance struct");
-    ret = vmi_init_complete(&vmi, NULL);
-    fail_unless(ret == VMI_SUCCESS,
-                "vmi_init_complete failed");
-    fail_unless(vmi != NULL,
-                "vmi_init_complete failed to initialize vmi instance struct");
     vmi_destroy(vmi);
 }
 END_TEST
@@ -189,9 +193,10 @@ END_TEST
 START_TEST (test_libvmi_init1)
 {
     vmi_instance_t vmi = NULL;
-    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    status_t ret = vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                                     VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     fail_unless(ret == VMI_SUCCESS,
-                "vmi_init failed with AUTO | COMPLETE");
+                "vmi_init failed with VMI_INIT_DOMAINNAME and global config");
     fail_unless(vmi != NULL,
                 "vmi_init failed to initialize vmi instance struct");
     vmi_destroy(vmi);

--- a/tests/test_peparse.c
+++ b/tests/test_peparse.c
@@ -261,7 +261,8 @@ status_t check_pe_sections(vmi_instance_t vmi, addr_t image_base_v, uint8_t *pe)
 START_TEST (test_peparse)
 {
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     addr_t kernbase;
 
     if (VMI_OS_WINDOWS == vmi_get_ostype(vmi) && VMI_OS_WINDOWS_XP == vmi_get_winver(vmi)){

--- a/tests/test_read.c
+++ b/tests/test_read.c
@@ -57,7 +57,8 @@ START_TEST (test_vmi_read_ksym)
     char *sym = NULL;
     char *buf = malloc(100);
     size_t count = 100;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     sym = get_sym(vmi);
     size_t read = vmi_read_ksym(vmi, sym, buf, count);
     fail_unless(read == count, "vmi_read_ksym failed");
@@ -72,7 +73,8 @@ START_TEST (test_vmi_read_va)
     addr_t va = 0;
     char *buf = malloc(100);
     size_t count = 100;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     va = get_vaddr(vmi);
     size_t read = vmi_read_va(vmi, va, 0, buf, count);
     fail_unless(read == count, "vmi_read_va failed");
@@ -87,7 +89,8 @@ START_TEST (test_vmi_read_pa)
     addr_t pa = 0;
     char *buf = malloc(100);
     size_t count = 100;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     pa = get_paddr(vmi);
     size_t read = vmi_read_pa(vmi, pa, buf, count);
     fail_unless(read == count, "vmi_read_pa failed");
@@ -102,7 +105,8 @@ START_TEST (test_vmi_read_8_ksym)
     char *sym = NULL;
     status_t status = VMI_FAILURE;
     uint8_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     sym = get_sym(vmi);
     status = vmi_read_8_ksym(vmi, sym, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_8_ksym failed");
@@ -116,7 +120,8 @@ START_TEST (test_vmi_read_16_ksym)
     char *sym = NULL;
     status_t status = VMI_FAILURE;
     uint16_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     sym = get_sym(vmi);
     status = vmi_read_16_ksym(vmi, sym, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_16_ksym failed");
@@ -130,7 +135,8 @@ START_TEST (test_vmi_read_32_ksym)
     char *sym = NULL;
     status_t status = VMI_FAILURE;
     uint32_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     sym = get_sym(vmi);
     status = vmi_read_32_ksym(vmi, sym, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_32_ksym failed");
@@ -144,7 +150,8 @@ START_TEST (test_vmi_read_64_ksym)
     char *sym = NULL;
     status_t status = VMI_FAILURE;
     uint64_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     sym = get_sym(vmi);
     status = vmi_read_64_ksym(vmi, sym, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_64_ksym failed");
@@ -158,7 +165,8 @@ START_TEST (test_vmi_read_8_va)
     addr_t va = 0;
     status_t status = VMI_FAILURE;
     uint8_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     va = get_vaddr(vmi);
     status = vmi_read_8_va(vmi, va, 0, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_8_va failed");
@@ -172,7 +180,8 @@ START_TEST (test_vmi_read_16_va)
     addr_t va = 0;
     status_t status = VMI_FAILURE;
     uint16_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     va = get_vaddr(vmi);
     status = vmi_read_16_va(vmi, va, 0, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_16_va failed");
@@ -186,7 +195,8 @@ START_TEST (test_vmi_read_32_va)
     addr_t va = 0;
     status_t status = VMI_FAILURE;
     uint32_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     va = get_vaddr(vmi);
     status = vmi_read_32_va(vmi, va, 0, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_32_va failed");
@@ -200,7 +210,8 @@ START_TEST (test_vmi_read_64_va)
     addr_t va = 0;
     status_t status = VMI_FAILURE;
     uint64_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     va = get_vaddr(vmi);
     status = vmi_read_64_va(vmi, va, 0, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_64_va failed");
@@ -214,7 +225,8 @@ START_TEST (test_vmi_read_8_pa)
     addr_t pa = 0;
     status_t status = VMI_FAILURE;
     uint8_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     pa = get_paddr(vmi);
     status = vmi_read_8_pa(vmi, pa, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_8_pa failed");
@@ -228,7 +240,8 @@ START_TEST (test_vmi_read_16_pa)
     addr_t pa = 0;
     status_t status = VMI_FAILURE;
     uint16_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     pa = get_paddr(vmi);
     status = vmi_read_16_pa(vmi, pa, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_16_pa failed");
@@ -242,7 +255,8 @@ START_TEST (test_vmi_read_32_pa)
     addr_t pa = 0;
     status_t status = VMI_FAILURE;
     uint32_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     pa = get_paddr(vmi);
     status = vmi_read_32_pa(vmi, pa, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_32_pa failed");
@@ -256,7 +270,8 @@ START_TEST (test_vmi_read_64_pa)
     addr_t pa = 0;
     status_t status = VMI_FAILURE;
     uint64_t value = 0;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     pa = get_paddr(vmi);
     status = vmi_read_64_pa(vmi, pa, &value);
     fail_unless(status == VMI_SUCCESS, "vmi_read_64_pa failed");

--- a/tests/test_shm_snapshot.c
+++ b/tests/test_shm_snapshot.c
@@ -38,9 +38,10 @@
 START_TEST (test_libvmi_shm_snapshot_create)
 {
     vmi_instance_t vmi = NULL;
-    status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE | VMI_INIT_SHM_SNAPSHOT, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME | VMI_INIT_SHM,
+                      NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
 
-    ret = vmi_shm_snapshot_create(vmi);
+    status_t ret = vmi_shm_snapshot_create(vmi);
     vmi_shm_snapshot_destroy(vmi);
 
     fail_unless(ret == VMI_SUCCESS,
@@ -56,7 +57,8 @@ END_TEST
 START_TEST (test_vmi_get_dgpma)
 {
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE | VMI_INIT_SHM_SNAPSHOT, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME | VMI_INIT_SHM,
+                      NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     vmi_shm_snapshot_create(vmi);
 
     addr_t pa = 0x1000; // just because vmi_read_page() deny to fetch frame 0.
@@ -93,7 +95,8 @@ END_TEST
 START_TEST (test_vmi_get_dgvma)
 {
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME | VMI_INIT_SHM,
+                      NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
     vmi_shm_snapshot_create(vmi);
 
     addr_t va = 0x0;

--- a/tests/test_translate.c
+++ b/tests/test_translate.c
@@ -36,7 +36,9 @@ START_TEST (test_libvmi_piddtb)
     int tasks_offset, pid_offset, name_offset;
     int failed = 1;
 
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
+
     if (VMI_OS_LINUX == vmi_get_ostype(vmi)) {
         tasks_offset = vmi_get_offset(vmi, "linux_tasks");
         name_offset = vmi_get_offset(vmi, "linux_name");
@@ -92,7 +94,8 @@ START_TEST (test_libvmi_invalid_pid)
     uint8_t buffer[8];
     size_t bytes_read = 0;
 
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
 
     bytes_read = vmi_read(vmi, &ctx, &buffer, sizeof(buffer));
 
@@ -106,7 +109,9 @@ END_TEST
 START_TEST (test_libvmi_kv2p)
 {
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
+
     addr_t va = 0;
     if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)){
         va = vmi_translate_ksym2v(vmi, "PsInitialSystemProcess");
@@ -135,7 +140,9 @@ END_TEST
 START_TEST (test_libvmi_ksym2v)
 {
     vmi_instance_t vmi = NULL;
-    vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
+    vmi_init_complete(&vmi, (void*)get_testvm(), VMI_INIT_DOMAINNAME, NULL,
+                      VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL);
+
     addr_t va = 0;
     if (VMI_OS_WINDOWS == vmi_get_ostype(vmi)){
         va = vmi_translate_ksym2v(vmi, "PsInitialSystemProcess");


### PR DESCRIPTION
Fixes #287 

This PR sanitizes the various init functions so that we have a more intuitive API. Here we deprecate the init_custom functions and rework vmi_init and vmi_init_complete as follows.

- vmi_init will allocate the vmi_instance and then only initialize the hypervisor driver interface of LibVMI (ie. only physical memory access and vCPU register functions). This requires the user to specify the hypervisor mode. VMI_AUTO mode is deprecated, instead a dedicated function is exposed - vmi_get_access_mode - the user can call if automatical hypervisor identification is needed. The inputs to this function are made more flexible but allowing the user to pass various domain-identification inputs, such as domain name or domain id. This approach will allow us to add other types of IDs later if necessary (ie. UUID) without having to change the API. A new field is added that can further carry information that may be required for the hypervisor driver to init (as anticipated for the VirtualBox driver).

 - vmi_init_paging remains largely as it was, initializing the v2p translation architecture specific functions of LibVMI. A new flags input is added to be able to configure paging specific features (ie. transition-pages) that previously relied on the OS interface being initialized. Calling this function multiple times will re-set the interface automatically.

 - vmi_init_os will initialize the OS specific components of LibVMI (ie. vmi_*_ksym) and this is the only init function that requires further configuration to be provided.

- vmi_init_complete will call all previous functions automatically - going from vmi_get_access_mode to vmi_init_os