### PR TITLE
Handle low-memory scenarios gracefully

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,11 @@ AM_PROG_LIBTOOL
 AM_SANITY_CHECK
 
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.4], [have_check="yes"], [have_check="no"])
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.16])
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.16],
+                  [AC_DEFINE([GLIB_VERSION],
+                    [m4_esyscmd_s([pkg-config --modversion glib-2.0 | tr -d . | cut -c1-3])],
+                    [GLib version])],
+                  [AC_MSG_ERROR(GLib 2.16 or newer not found. Install missing package and re-run)])
 AC_SUBST([GLIB_CFLAGS])
 AC_SUBST([GLIB_LIBS])
 

--- a/libvmi/arch/amd64.c
+++ b/libvmi/arch/amd64.c
@@ -359,8 +359,9 @@ GSList* get_va_pages_ia32e(vmi_instance_t vmi, addr_t dtb) {
 status_t amd64_init(vmi_instance_t vmi) {
 
     if(!vmi->arch_interface) {
-        vmi->arch_interface = safe_malloc(sizeof(struct arch_interface));
-        bzero(vmi->arch_interface, sizeof(struct arch_interface));
+        vmi->arch_interface = g_malloc0(sizeof(struct arch_interface));
+        if ( !vmi->arch_interface )
+            return VMI_FAILURE;
     }
 
     vmi->arch_interface->v2p = v2p_ia32e;

--- a/libvmi/arch/arm_aarch32.c
+++ b/libvmi/arch/arm_aarch32.c
@@ -189,8 +189,9 @@ GSList* get_va_pages_aarch32(vmi_instance_t UNUSED(vmi), addr_t UNUSED(dtb)) {
 status_t aarch32_init(vmi_instance_t vmi) {
 
     if(!vmi->arch_interface) {
-        vmi->arch_interface = safe_malloc(sizeof(struct arch_interface));
-        bzero(vmi->arch_interface, sizeof(struct arch_interface));
+        vmi->arch_interface = g_malloc0(sizeof(struct arch_interface));
+        if ( !vmi->arch_interface )
+            return VMI_FAILURE;
     }
 
     vmi->arch_interface->v2p = v2p_aarch32;

--- a/libvmi/arch/arm_aarch64.c
+++ b/libvmi/arch/arm_aarch64.c
@@ -310,8 +310,9 @@ GSList* get_va_pages_aarch64(vmi_instance_t UNUSED(vmi), addr_t UNUSED(dtb)) {
 status_t aarch64_init(vmi_instance_t vmi) {
 
     if(!vmi->arch_interface) {
-        vmi->arch_interface = safe_malloc(sizeof(struct arch_interface));
-        bzero(vmi->arch_interface, sizeof(struct arch_interface));
+        vmi->arch_interface = g_malloc0(sizeof(struct arch_interface));
+        if ( !vmi->arch_interface )
+            return VMI_FAILURE;
     }
 
     vmi->arch_interface->v2p = v2p_aarch64;

--- a/libvmi/arch/intel.c
+++ b/libvmi/arch/intel.c
@@ -543,8 +543,9 @@ status_t intel_init(vmi_instance_t vmi) {
     status_t ret = VMI_SUCCESS;
 
     if(!vmi->arch_interface) {
-        vmi->arch_interface = safe_malloc(sizeof(struct arch_interface));
-        bzero(vmi->arch_interface, sizeof(struct arch_interface));
+        vmi->arch_interface = g_malloc0(sizeof(struct arch_interface));
+        if ( !vmi->arch_interface )
+            return VMI_FAILURE;
     }
 
     if(vmi->page_mode == VMI_PM_LEGACY) {
@@ -555,7 +556,7 @@ status_t intel_init(vmi_instance_t vmi) {
         vmi->arch_interface->get_va_pages = get_va_pages_pae;
     } else {
         ret = VMI_FAILURE;
-        free(vmi->arch_interface);
+        g_free(vmi->arch_interface);
         vmi->arch_interface = NULL;
     }
 

--- a/libvmi/cache.h
+++ b/libvmi/cache.h
@@ -64,7 +64,7 @@ status_t rva_cache_del(vmi_instance_t vmi, addr_t base_addr, addr_t dtb, addr_t 
 void v2p_cache_init(vmi_instance_t vmi);
 void v2p_cache_destroy(vmi_instance_t vmi);
 void v2p_cache_set(vmi_instance_t vmi, addr_t va, addr_t dtb, addr_t pa);
-void v2p_cache_flush(vmi_instance_t vmi);
+void v2p_cache_flush(vmi_instance_t vmi, addr_t dtb);
 status_t v2p_cache_get(vmi_instance_t vmi, addr_t va, addr_t dtb, addr_t *pa);
 status_t v2p_cache_del(vmi_instance_t vmi, addr_t va, addr_t dtb);
 

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -79,8 +79,10 @@ open_config_file(
 
     /* check current directory */
     if (getcwd(cwd, sizeof(cwd)) != NULL) {
-        location = safe_malloc(snprintf(NULL,0,"%s/libvmi.conf",
-                                       cwd)+1);
+        location = g_malloc0(snprintf(NULL,0,"%s/libvmi.conf", cwd)+1);
+        if ( !location )
+            return NULL;
+
         sprintf(location, "%s/libvmi.conf", cwd);
         dbprint(VMI_DEBUG_CORE, "--looking for config file at %s\n", location);
 
@@ -89,14 +91,16 @@ open_config_file(
         if (f) {
             goto success;
         }
-        free(location);
+        g_free(location);
     }
 
     /* next check home directory of sudo user */
     if ((sudo_user = getenv("SUDO_USER")) != NULL) {
         if ((pw_entry = getpwnam(sudo_user)) != NULL) {
-            location = safe_malloc(snprintf(NULL,0,"%s/etc/libvmi.conf",
-                                          pw_entry->pw_dir)+1);
+            location = g_malloc0(snprintf(NULL,0,"%s/etc/libvmi.conf", pw_entry->pw_dir)+1);
+            if ( !location )
+                return NULL;
+
             sprintf(location, "%s/etc/libvmi.conf",
                      pw_entry->pw_dir);
             dbprint(VMI_DEBUG_CORE, "--looking for config file at %s\n", location);
@@ -106,13 +110,15 @@ open_config_file(
             if (f) {
                 goto success;
             }
-            free(location);
+            g_free(location);
         }
     }
 
     /* next check home directory for current user */
-    location = safe_malloc(snprintf(NULL,0,"%s/etc/libvmi.conf",
-                                  getenv("HOME"))+1);
+    location = g_malloc0(snprintf(NULL,0,"%s/etc/libvmi.conf", getenv("HOME"))+1);
+    if ( !location )
+        return NULL;
+
     sprintf(location, "%s/etc/libvmi.conf", getenv("HOME"));
     dbprint(VMI_DEBUG_CORE, "--looking for config file at %s\n", location);
 
@@ -121,17 +127,20 @@ open_config_file(
     if (f) {
         goto success;
     }
-    free(location);
+    g_free(location);
 
     /* finally check in /etc */
     dbprint(VMI_DEBUG_CORE, "--looking for config file at /etc/libvmi.conf\n");
-    location = safe_malloc(strlen("/etc/libvmi.conf")+1);
+    location = g_malloc0(strlen("/etc/libvmi.conf")+1);
+    if ( !location )
+        return NULL;
+
     sprintf(location, "/etc/libvmi.conf");
     f = fopen(location, "r");
     if (f) {
         goto success;
     }
-    free(location);
+    g_free(location);
 
     return NULL;
 success:
@@ -406,8 +415,9 @@ vmi_init_private(
     status_t status = VMI_FAILURE;
 
     /* allocate memory for instance structure */
-    vmi_instance_t _vmi = (vmi_instance_t) safe_malloc(sizeof(struct vmi_instance));
-    memset(_vmi, 0, sizeof(struct vmi_instance));
+    vmi_instance_t _vmi = (vmi_instance_t) g_malloc0(sizeof(struct vmi_instance));
+    if ( !_vmi )
+        return VMI_FAILURE;
 
     /* initialize instance struct to default values */
     dbprint(VMI_DEBUG_CORE, "LibVMI Version 0.11.0\n");  //TODO change this with each release

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -67,7 +67,10 @@ file_get_memory(
         goto error_noprint;
     }   // if
 
-    memory = safe_malloc(length);
+    memory = g_malloc0(length);
+
+    if ( !memory )
+        return NULL;
 
 #if USE_MMAP
     (void) memcpy(memory,

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1051,7 +1051,7 @@ kvm_setup_shm_snapshot_mode(
         pid_cache_flush(vmi);
         sym_cache_flush(vmi);
         rva_cache_flush(vmi);
-        v2p_cache_flush(vmi);
+        v2p_cache_flush(vmi, ~0ull);
         v2m_cache_flush(vmi);
         memory_cache_destroy(vmi);
         memory_cache_init(vmi, kvm_get_memory_shm_snapshot, kvm_release_memory_shm_snapshot,
@@ -1085,7 +1085,7 @@ kvm_teardown_shm_snapshot_mode(
         pid_cache_flush(vmi);
         sym_cache_flush(vmi);
         rva_cache_flush(vmi);
-        v2p_cache_flush(vmi);
+        v2p_cache_flush(vmi, ~0ull);
         memory_cache_destroy(vmi);
     }
     return VMI_SUCCESS;
@@ -1245,7 +1245,7 @@ kvm_setup_live_mode(
         pid_cache_flush(vmi);
         sym_cache_flush(vmi);
         rva_cache_flush(vmi);
-        v2p_cache_flush(vmi);
+        v2p_cache_flush(vmi, ~0ull);
         memory_cache_destroy(vmi);
         memory_cache_init(vmi, kvm_get_memory_patch, kvm_release_memory,
                           1);

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -76,11 +76,16 @@ exec_qmp_cmd(
     char *query)
 {
     FILE *p;
-    char *output = safe_malloc(20000);
+    char *output = g_malloc0(20000);
+    if ( !output )
+        return NULL;
+
     size_t length = 0;
     const char *name = kvm->libvirt.virDomainGetName(kvm->dom);
     int cmd_length = strlen(name) + strnlen(query, QMP_CMD_LENGTH) + 47;
-    char *cmd = safe_malloc(cmd_length);
+    char *cmd = g_malloc0(cmd_length);
+    if ( !cmd )
+        return NULL;
 
     int rc = snprintf(cmd, cmd_length, "virsh -c qemu:///system qemu-monitor-command %s %s", name,
              query);
@@ -124,7 +129,10 @@ exec_memory_access(
     kvm_instance_t *kvm)
 {
     char *tmpfile = tempnam("/tmp", "vmi");
-    char *query = (char *) safe_malloc(QMP_CMD_LENGTH);
+    char *query = (char *) g_malloc0(QMP_CMD_LENGTH);
+
+    if ( !query )
+        return NULL;
 
     int rc = snprintf(query,
             QMP_CMD_LENGTH,
@@ -149,7 +157,9 @@ exec_xp(
     int numwords,
     addr_t paddr)
 {
-    char *query = (char *) safe_malloc(QMP_CMD_LENGTH);
+    char *query = (char *) g_malloc0(QMP_CMD_LENGTH);
+    if ( !query )
+        return NULL;
 
     int rc = snprintf(query,
             QMP_CMD_LENGTH,
@@ -353,12 +363,15 @@ exec_shm_snapshot(
         char *shm_filename = basename(unique_shm_path);
         char *query_template = "'{\"execute\": \"snapshot-create\", \"arguments\": {"
             " \"filename\": \"/%s\"}}'";
-        char *query = (char *) safe_malloc(strlen(query_template) - strlen("%s") + NAME_MAX + 1);
+        char *query = (char *) g_malloc0(strlen(query_template) - strlen("%s") + NAME_MAX + 1);
+        if ( !query )
+            return NULL;
+
         sprintf(query, query_template, shm_filename);
         kvm->shm_snapshot_path = strdup(shm_filename);
         free(unique_shm_path);
         char *output = exec_qmp_cmd(kvm, query);
-        free(query);
+        g_free(query);
         return output;
     }
     else {
@@ -1098,7 +1111,10 @@ kvm_get_memory_patch(
     addr_t paddr,
     uint32_t length)
 {
-    char *buf = safe_malloc(length + 1);
+    char *buf = g_malloc0(length + 1);
+    if ( !buf )
+        return NULL;
+
     struct request req;
 
     req.type = 1;   // read request
@@ -1142,13 +1158,24 @@ kvm_get_memory_native(
     uint32_t length)
 {
     int numwords = ceil(length / 4);
-    char *buf = safe_malloc(numwords * 4);
+    char *buf = g_malloc0(numwords * 4);
+    if ( !buf )
+        return NULL;
+
     char *bufstr = exec_xp(kvm_get_instance(vmi), numwords, paddr);
-    char *paddrstr = safe_malloc(32);
+    char *paddrstr = g_malloc0(32);
+
+    if ( !paddrstr )
+    {
+        g_free(buf);
+        return NULL;
+    }
 
     int rc = snprintf(paddrstr, 32, "%.16lx", paddr);
     if (rc < 0 || rc >= 32) {
         errprint("Failed to properly format physical address\n");
+        g_free(buf);
+        g_free(paddrstr);
         return NULL;
     }
 
@@ -1173,10 +1200,9 @@ kvm_get_memory_native(
         }
         ptr = strcasestr(ptr, paddrstr);
     }
-    if (bufstr)
-        free(bufstr);
-    if (paddrstr)
-        free(paddrstr);
+
+    g_free(bufstr);
+    g_free(paddrstr);
     return buf;
 }
 

--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -136,7 +136,10 @@ static memory_cache_entry_t create_new_entry (vmi_instance_t vmi, addr_t paddr,
 
     memory_cache_entry_t entry =
         (memory_cache_entry_t)
-        safe_malloc(sizeof(struct memory_cache_entry));
+        g_malloc0(sizeof(struct memory_cache_entry));
+
+    if ( !entry )
+        return NULL;
 
     entry->paddr = paddr;
     entry->length = length;
@@ -201,11 +204,16 @@ memory_cache_insert(
             return 0;
         }
 
-        key = safe_malloc(sizeof(gint64));
+        key = g_malloc0(sizeof(gint64));
+        if ( !key )
+            return 0;
+
         *key = paddr;
         g_hash_table_insert(vmi->memory_cache, key, entry);
 
-        gint64 *key2 = safe_malloc(sizeof(gint64));
+        gint64 *key2 = g_malloc0(sizeof(gint64));
+        if ( !key2 )
+            return 0;
 
         *key2 = paddr;
         g_queue_push_head(vmi->memory_cache_lru, key2);

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1985,9 +1985,11 @@ status_t vmi_resume_vm(
  * the cache is incorrect, or out of date.
  *
  * @param[in] vmi LibVMI instance
+ * @param[in] dtb The process address space to flush, or ~0ull for all.
  */
 void vmi_v2pcache_flush(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi,
+    addr_t dtb);
 
 /**
  * Adds one entry to LibVMI's internal virtual to physical address

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -308,11 +308,13 @@ status_t linux_init(vmi_instance_t vmi) {
 
     if (vmi->os_data != NULL) {
         errprint("os data already initialized, reinitializing\n");
-        free(vmi->os_data);
+        g_free(vmi->os_data);
     }
 
-    vmi->os_data = safe_malloc(sizeof(struct linux_instance));
-    bzero(vmi->os_data, sizeof(struct linux_instance));
+    vmi->os_data = g_malloc0(sizeof(struct linux_instance));
+    if ( !vmi->os_data )
+        return VMI_FAILURE;
+
     linux_instance_t linux_instance = vmi->os_data;
 
     g_hash_table_foreach(vmi->config, (GHFunc)linux_read_config_ghashtable_entries, vmi);
@@ -351,7 +353,10 @@ status_t linux_init(vmi_instance_t vmi) {
 
     dbprint(VMI_DEBUG_MISC, "**set vmi->kpgd (0x%.16"PRIx64").\n", vmi->kpgd);
 
-    os_interface = safe_malloc(sizeof(struct os_interface));
+    os_interface = g_malloc(sizeof(struct os_interface));
+    if ( !os_interface )
+        goto _exit;
+
     bzero(os_interface, sizeof(struct os_interface));
     os_interface->os_get_offset = linux_get_offset;
     os_interface->os_get_kernel_struct_offset = linux_get_kernel_struct_offset;
@@ -368,7 +373,7 @@ status_t linux_init(vmi_instance_t vmi) {
     return VMI_SUCCESS;
 
     _exit:
-    free(vmi->os_data);
+    g_free(vmi->os_data);
     vmi->os_data = NULL;
     return VMI_FAILURE;
 }

--- a/libvmi/os/linux/symbols.c
+++ b/libvmi/os/linux/symbols.c
@@ -109,7 +109,10 @@ linux_system_map_symbol_to_address(
         goto done;
     }
 
-    row = safe_malloc(MAX_ROW_LENGTH);
+    row = g_malloc0(MAX_ROW_LENGTH);
+    if ( !row )
+        goto done;
+
     if ((f = fopen(linux_instance->sysmap, "r")) == NULL) {
         fprintf(stderr,
                 "ERROR: could not find System.map file after checking:\n");
@@ -172,7 +175,10 @@ char* linux_system_map_address_to_symbol(
         goto done;
     }
 
-    row = safe_malloc(MAX_ROW_LENGTH);
+    row = g_malloc0(MAX_ROW_LENGTH);
+    if ( !row )
+        goto done;
+
     if ((f = fopen(linux_instance->sysmap, "r")) == NULL) {
         fprintf(stderr,
                 "ERROR: could not find System.map file after checking:\n");

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -754,18 +754,23 @@ windows_init(
 
     if (vmi->os_data != NULL) {
         errprint("VMI_ERROR: os data already initialized, resetting\n");
+        bzero(vmi->os_data, sizeof(struct windows_instance));
     } else {
-        vmi->os_data = safe_malloc(sizeof(struct windows_instance));
+        vmi->os_data = g_malloc0(sizeof(struct windows_instance));
+        if ( !vmi->os_data )
+            return VMI_FAILURE;
     }
 
-    bzero(vmi->os_data, sizeof(struct windows_instance));
     windows = vmi->os_data;
     windows->version = VMI_OS_WINDOWS_UNKNOWN;
 
     g_hash_table_foreach(vmi->config, (GHFunc)windows_read_config_ghashtable_entries, vmi);
 
     /* Need to provide this functions so that find_page_mode will work */
-    os_interface = safe_malloc(sizeof(struct os_interface));
+    os_interface = g_malloc0(sizeof(struct os_interface));
+    if ( !os_interface )
+        goto error_exit;
+
     bzero(os_interface, sizeof(struct os_interface));
     os_interface->os_get_kernel_struct_offset = windows_get_kernel_struct_offset;
     os_interface->os_get_offset = windows_get_offset;
@@ -858,8 +863,7 @@ status_t windows_teardown(vmi_instance_t vmi) {
     }
 
     g_free(windows->rekall_profile);
-
-    free(vmi->os_data);
+    g_free(vmi->os_data);
     vmi->os_data = NULL;
 
 done:

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -44,7 +44,10 @@ windows_get_eprocess_name(
     }
 
     addr_t name_paddr = paddr + windows->pname_offset;
-    char *name = (char *) safe_malloc(name_length);
+    char *name = (char *) g_malloc0(name_length);
+
+    if ( !name )
+        return NULL;
 
     if (name_length == vmi_read_pa(vmi, name_paddr, name, name_length)) {
         return name;

--- a/libvmi/os/windows/unicode.c
+++ b/libvmi/os/windows/unicode.c
@@ -69,10 +69,15 @@ windows_read_unicode_struct(
     }   // if-else
 
     // allocate the return value
-    us = safe_malloc(sizeof(unicode_string_t));
+    us = g_malloc0(sizeof(unicode_string_t));
+    if ( !us )
+        return NULL;
 
     us->length = buffer_len;
-    us->contents = safe_malloc(sizeof(uint8_t) * (buffer_len + 2));
+    us->contents = g_malloc0(sizeof(uint8_t) * (buffer_len + 2));
+
+    if ( !us->contents )
+        goto out_error;
 
     _ctx.addr = buffer_va;
     read = vmi_read(vmi, &_ctx, us->contents, us->length);
@@ -93,9 +98,9 @@ windows_read_unicode_struct(
 out_error:
     if (us) {
         if (us->contents) {
-            free(us->contents);
+            g_free(us->contents);
         }
-        free(us);
+        g_free(us);
     }
     return 0;
 }

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -267,6 +267,19 @@ addr_t canonical_addr(addr_t va) {
 #  define UNUSED_FUNCTION(x) UNUSED_ ## x
 #endif
 
+static inline gboolean
+g_hash_table_insert_compat(GHashTable *table,
+                           gpointer key,
+                           gpointer value)
+{
+#if GLIB_VERSION <= 238
+    g_hash_table_insert(table, key, value);
+    return true;
+#else
+    return g_hash_table_insert(table, key, value);
+#endif
+}
+
 /*-------------------------------------
  * accessors.c
  */

--- a/libvmi/shm.c
+++ b/libvmi/shm.c
@@ -70,7 +70,10 @@ typedef struct v2m_cache_entry *v2m_cache_entry_t;
 
 static v2m_cache_entry_t v2m_cache_entry_create (vmi_instance_t vmi, addr_t ma, uint64_t length)
 {
-    v2m_cache_entry_t entry = (v2m_cache_entry_t) safe_malloc(sizeof(struct v2m_cache_entry));
+    v2m_cache_entry_t entry = (v2m_cache_entry_t) g_malloc0(sizeof(struct v2m_cache_entry));
+    if ( !entry )
+        return NULL;
+
     ma &= ~((addr_t)vmi->page_size - 1);
     entry->ma = ma;
     entry->length = length;

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -37,7 +37,7 @@ START_TEST (test_libvmi_cache)
     vmi_instance_t vmi = NULL;
     status_t ret = vmi_init(&vmi, VMI_AUTO | VMI_INIT_COMPLETE, get_testvm());
 
-    v2p_cache_flush(vmi);
+    v2p_cache_flush(vmi, ~0ull);
     v2p_cache_set(vmi, 0x400000, 0xabcde, 0x3b40a000);
 
     addr_t pa = 0;
@@ -48,7 +48,7 @@ START_TEST (test_libvmi_cache)
     ret = v2p_cache_get(vmi, 0x00000400000ull, 0xabcde, &pa);
     fail_if(ret == VMI_FAILURE, "cache entry not found");
 
-    v2p_cache_flush(vmi);
+    v2p_cache_flush(vmi, ~0ull);
     vmi_destroy(vmi);
 }
 END_TEST


### PR DESCRIPTION
In low-memory scenarios crashing because of cache memory allocations is not acceptable and has to be handled more gracefully. This PR replaces all uses of safe_malloc in cache.c with g_malloc0 and adds appropriate tests to see whether memory was indeed allocated.

Also, alter vmi_v2p_cacheflush to add an option to flush by DTB. This is useful in multi-vCPU VM setups where flushing the whole cache is not always necessary.