### PR TITLE
KASLR aware Linux address to symbol lookup

### DIFF
--- a/libvmi/os/linux/symbols.c
+++ b/libvmi/os/linux/symbols.c
@@ -149,6 +149,8 @@ char* linux_system_map_address_to_symbol(
     int size = 0;
     linux_instance_t linux_instance = vmi->os_data;
 
+    address -= linux_instance->kaslr_offset;
+
     switch(ctx->translate_mechanism) {
         case VMI_TM_PROCESS_PID:
             if(ctx->pid != 0)


### PR DESCRIPTION
The address to symbol lookup currently does not work when kasl is used!