### PR TITLE
Revert "Add support for VCPU-safe register modification w/ HVMs"

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -2666,50 +2666,15 @@ xen_set_vcpureg(
 #if defined(ARM32) || defined(ARM64)
     return xen_set_vcpureg_arm(vmi, value, reg, vcpu);
 #elif defined(I386) || defined (X86_64)
-    if (xen_get_instance(vmi)->hvm) {
-        switch (reg) {
-        case RAX:
-        case RBX:
-        case RCX:
-        case RDX:
-        case RBP:
-        case RSI:
-        case RDI:
-        case RSP:
-        case R8:
-        case R9:
-        case R10:
-        case R11:
-        case R12:
-        case R13:
-        case R14:
-        case R15:
-        case RIP:
-        case RFLAGS:
-        case CR0:
-        case CR2:
-        case CR4:
-        case DR0:
-        case DR1:
-        case DR2:
-        case DR3:
-        case DR6:
-        case DR7:
-        case FS_BASE:
-        case GS_BASE:
-        case LDTR_BASE:
-            goto pv_compatible;
-        default:
-            return xen_set_vcpureg_hvm(vmi, value, reg, vcpu);
+    if (!xen_get_instance(vmi)->hvm) {
+        if (8 == xen_get_instance(vmi)->addr_width) {
+            return xen_set_vcpureg_pv64(vmi, value, reg, vcpu);
+        } else {
+            return xen_set_vcpureg_pv32(vmi, value, reg, vcpu);
         }
     }
-    
-pv_compatible:
-    if (8 == xen_get_instance(vmi)->addr_width) {
-        return xen_set_vcpureg_pv64(vmi, value, reg, vcpu);
-    } else {
-        return xen_set_vcpureg_pv32(vmi, value, reg, vcpu);
-    }
+
+    return xen_set_vcpureg_hvm (vmi, value, reg, vcpu);
 #endif
 }
 


### PR DESCRIPTION
Reverts libvmi/libvmi#441

Unfortunately there are some side-effects of using the PV register setting functions for HVM guests. The root cause of it is yet unknown but I have verified that setting either RIP or RSP through this method causes application crashes in Windows VMs.

Setting other registers through this method may also have issues, so until we have a better understanding of what causes this regression I'm reverting this patch.

@mattshockl