### PR TITLE
Fix overflow in KVM segment register parsing

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -212,7 +212,7 @@ parse_seg_reg_value(
 {
     int offset;
     char *ptr, *tmp_ptr;
-    char keyword[4] = { [0 ... 3] = '\0' };
+    char keyword[5] = { [0 ... 4] = '\0' };
 
     if (NULL == ir_output || NULL == regname) {
         return 0;


### PR DESCRIPTION
Should fix issue #460 

Null byte off-by-one in KVM driver.