### PR TITLE
update libvmi-example.conf

### DIFF
--- a/etc/libvmi-example.conf
+++ b/etc/libvmi-example.conf
@@ -10,6 +10,7 @@ WinXP-HVM {
     win_tasks   = 0x88;
     win_pdbase  = 0x18;
     win_pid     = 0x84;
+    win_pname   = 0x174;
 }
 
 # Booted without PAE kernel (ntoskrnl.exe)
@@ -40,3 +41,59 @@ fc6 {
 #    linux_pid   = 0x9c;
 #    linux_pgd   = 0x24;
 #}
+
+winxp {
+    win_pdbase  = 0x18;
+    win_pid     = 0x84;
+    win_tasks   = 0x88;
+    win_pname   = 0x174;
+}
+
+winxp_64 {
+    win_pdbase  = 0x28;
+    win_pid     = 0xd8;
+    win_tasks   = 0xe0;
+    win_pname   = 0x268;
+}
+
+winvista {
+    win_pdbase  = 0x18;
+    win_pid     = 0x9c;
+    win_tasks   = 0xa0;
+    win_pname   = 0x14c;
+}
+
+winvista_64 {
+    win_pdbase  = 0x28;
+    win_pid     = 0xe0;
+    win_tasks   = 0xe8;
+    win_pname   = 0x238;
+}
+
+win7 {
+    win_pdbase  = 0x18;
+    win_pid     = 0xb4;
+    win_tasks   = 0xb8;
+    win_pname   = 0x16c;
+}
+
+win7_64 {
+    win_pdbase  = 0x28;
+    win_pid     = 0x180;
+    win_tasks   = 0x188;
+    win_pname   = 0x2d8;
+}
+
+win8.1 {
+    win_pdbase  = 0x18;
+    win_pid     = 0xb4;
+    win_tasks   = 0xb8;
+    win_pname   = 0x170;
+}
+
+win8.1_64 {
+    win_pdbase  = 0x28;
+    win_pid     = 0x2e0;
+    win_tasks   = 0x2e8;
+    win_pname   = 0x438;
+}


### PR DESCRIPTION
I added some configuration examples, from `XP` to `8.1`, because it's always painful to search for the offsets and install `WinDBG` somewhere.

for each of them, I dumped the `EPROCESS` structure and kept it in a repo.
So, if you are looking for some other offsets one day, you can take a look:
[link](https://github.com/Wenzel/windows_internals)