### PR TITLE
Don't include hvm/hvm_op.h in Xen events

### DIFF
--- a/libvmi/driver/xen/xen_events_46.c
+++ b/libvmi/driver/xen/xen_events_46.c
@@ -331,7 +331,7 @@ status_t process_interrupt_event(vmi_instance_t vmi,
                     #define TRAP_int3              3
                     rc = xen->libxcw.xc_hvm_inject_trap(xch, domain_id, req->vcpu_id,
                             TRAP_int3,         /* Vector 3 for INT3 */
-                            HVMOP_TRAP_sw_exc, /* Trap type, here a software intr */
+                            X86_TRAP_sw_exc,   /* Trap type, here a software intr */
                             ~0u, /* error code. ~0u means 'ignore' */
                             event->interrupt_event.insn_length,
                             0    /* cr2 need not be preserved */

--- a/libvmi/driver/xen/xen_events_48.c
+++ b/libvmi/driver/xen/xen_events_48.c
@@ -347,7 +347,7 @@ status_t process_interrupt_event(vmi_instance_t vmi,
                     #define TRAP_int3              3
                     rc = xen->libxcw.xc_hvm_inject_trap(xch, domain_id, req->vcpu_id,
                             TRAP_int3,         /* Vector 3 for INT3 */
-                            HVMOP_TRAP_sw_exc, /* Trap type, here a software intr */
+                            X86_TRAP_sw_exc,   /* Trap type, here a software intr */
                             ~0u, /* error code. ~0u means 'ignore' */
                             event->interrupt_event.insn_length,
                             0    /* cr2 need not be preserved */

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -55,8 +55,6 @@ typedef enum {
 #endif
 
 #ifdef HAVE_HVMMEM_ACCESS_T
-#include <xen/hvm/hvm_op.h>
-
 typedef enum {
     XENMEM_access_n,
     XENMEM_access_r,
@@ -71,6 +69,13 @@ typedef enum {
     XENMEM_access_default
 } xenmem_access_t;
 #endif
+
+#define X86_TRAP_ext_int    0 /* external interrupt */
+#define X86_TRAP_nmi        2 /* nmi */
+#define X86_TRAP_hw_exc     3 /* hardware exception */
+#define X86_TRAP_sw_int     4 /* software interrupt (CD nn) */
+#define X86_TRAP_pri_sw_exc 5 /* ICEBP (F1) */
+#define X86_TRAP_sw_exc     6 /* INT3 (CC), INTO (CE) */
 
 #define HVMPME_mode_disabled   0
 #define HVMPME_mode_async      1

--- a/libvmi/driver/xen/xen_events_legacy.c
+++ b/libvmi/driver/xen/xen_events_legacy.c
@@ -291,7 +291,7 @@ status_t process_interrupt_event(vmi_instance_t vmi, interrupts_t intr,
                 #define TRAP_int3              3
                 rc = xen->libxcw.xc_hvm_inject_trap(xch, domain_id, vcpu_id,
                         TRAP_int3,         /* Vector 3 for INT3 */
-                        HVMOP_TRAP_sw_exc, /* Trap type, here a software intr */
+                        X86_TRAP_sw_exc,   /* Trap type, here a software intr */
                         ~0u, /* error code. ~0u means 'ignore' */
                         event->interrupt_event.insn_length,
                         0   /* cr2 need not be preserved */


### PR DESCRIPTION
This header had been included for the HVMOP_TRAP_* definitions. The header is being renamed in Xen 4.9 so instead of doing configure checks to see which header is available we just define the required constants internally. 