### PR TITLE
add new API to flush the internal page cache

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -37,6 +37,7 @@
 
 #include "private.h"
 #include "glib_compat.h"
+#include "driver/memory_cache.h"
 
 // This function borrowed from cityhash-1.0.3
 uint64_t hash128to64(
@@ -663,6 +664,13 @@ v2p_cache_flush(
     dbprint(VMI_DEBUG_V2PCACHE, "--V2P cache flushed\n");
 }
 
+void
+page_cache_flush(
+    vmi_instance_t vmi)
+{
+    memory_cache_flush(vmi);
+}
+
 // Below are wrapper functions for external API access to the cache
 void
 vmi_pidcache_add(
@@ -732,4 +740,11 @@ vmi_v2pcache_flush(
     addr_t dtb)
 {
     return v2p_cache_flush(vmi, dtb);
+}
+
+void
+vmi_pagecache_flush(
+    vmi_instance_t vmi)
+{
+    return page_cache_flush(vmi);
 }

--- a/libvmi/cache.h
+++ b/libvmi/cache.h
@@ -68,6 +68,8 @@ void v2p_cache_flush(vmi_instance_t vmi, addr_t dtb);
 status_t v2p_cache_get(vmi_instance_t vmi, addr_t va, addr_t dtb, addr_t *pa);
 status_t v2p_cache_del(vmi_instance_t vmi, addr_t va, addr_t dtb);
 
+void page_cache_flush(vmi_instance_t vmi);
+
 #else
 
 #define pid_cache_init(...)     NOOP

--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -78,7 +78,7 @@ static void
 clean_cache(
     vmi_instance_t vmi)
 {
-    while (g_queue_get_length(vmi->memory_cache_lru) > vmi->memory_cache_size_max / 2) {
+    while (g_queue_get_length(vmi->memory_cache_lru)) {
         gint64 *paddr = g_queue_pop_tail(vmi->memory_cache_lru);
 
         g_hash_table_remove(vmi->memory_cache, paddr);
@@ -261,6 +261,13 @@ memory_cache_destroy(
     release_data_callback = NULL;
 }
 
+void
+memory_cache_flush(
+        vmi_instance_t vmi)
+{
+    clean_cache(vmi);
+}
+
 #else
 void
 memory_cache_init(
@@ -314,4 +321,16 @@ memory_cache_destroy(
     get_data_callback = NULL;
     release_data_callback = NULL;
 }
+
+void
+memory_cache_flush(
+        vmi_instance_t vmi)
+{
+    if(vmi->last_used_page_key && vmi->last_used_page) {
+        release_data_callback(vmi->last_used_page, vmi->page_size);
+    }
+    vmi->last_used_page_key = 0;
+    vmi->last_used_page = NULL;
+}
+
 #endif

--- a/libvmi/driver/memory_cache.h
+++ b/libvmi/driver/memory_cache.h
@@ -49,4 +49,7 @@ void memory_cache_remove(
 void memory_cache_destroy(
     vmi_instance_t vmi);
 
+void memory_cache_flush(
+    vmi_instance_t vmi);
+
 #endif

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -2143,6 +2143,16 @@ void vmi_pidcache_add(
     addr_t dtb);
 
 /**
+ * Removes all entries from LibVMI's internal page cache.
+ * This is generally only useful if you believe that an entry in
+ * the cache is incorrect, or out of date.
+ *
+ * @param[in] vmi LibVMI instance
+ */
+void vmi_pagecache_flush(
+    vmi_instance_t vmi);
+
+/**
  * Returns the path of the Linux system map file for the given vmi instance
  *
  * @param[in] vmi LibVMI instance


### PR DESCRIPTION
A few weeks ago, i opened an issue on libvmi : #464 

The solution was to flush the internal page cache, which is not accessible from any exposed API.

This PR exposes an API to flush the cache when the user thinks the memory layout has changed.

It worked for me, but maybe it will need more polishing from your side.
give me your feedback :)