### PR TITLE
add descriptive error if socket connection fails in KVM driver

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -315,7 +315,7 @@ init_domain_socket(
 
     if (connect(socket_fd, (struct sockaddr *) &address, address_length)
         != 0) {
-        dbprint(VMI_DEBUG_KVM, "--connect() failed to %s\n", kvm->ds_path);
+        dbprint(VMI_DEBUG_KVM, "--connect() failed to %s, %s\n", kvm->ds_path, strerror(errno));
         close(socket_fd);
         return VMI_FAILURE;
     }


### PR DESCRIPTION
This gives some feedback to the user with a more descrptive error than `connect failed`.

An example of  possible output that helped me to debug my issue

~~~
xc: error: Could not obtain handle on privileged command interface (2 = No such file or directory): Internal error
VMI_ERROR: Failed to open libxc interface.
Failed to find a suitable xenctrl.so!
--found KVM
LibVMI Version 0.11.0
LibVMI Driver Mode 1
--completed driver init.
--got id from name (nitro_win7x64 --> 1)
**set image_type = nitro_win7x64
--libvirt version 1003001
--qmp: virsh -c qemu:///system qemu-monitor-command nitro_win7x64 '{"execute": "pmemaccess", "arguments": {"path": "/tmp/vmiwjPMSv"}}'
--kvm: using custom patch for fast memory access
--connect() failed to /tmp/vmiwjPMSv, Permission denied
~~~

My user wasn't in the `libvirt-qemu` group, therefore the `permission denied`.