### PR TITLE
fix error handling in vmi_init_os

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -680,6 +680,7 @@ os_t vmi_init_os(
     if ( VMI_FILE != vmi->mode && VMI_PM_UNKNOWN == vmi->page_mode &&
          VMI_PM_UNKNOWN == vmi_init_paging(vmi, 0) )
     {
+        vmi->os_type = VMI_OS_UNKNOWN;
         if ( error )
             *error = VMI_INIT_ERROR_PAGING;
 
@@ -692,6 +693,7 @@ os_t vmi_init_os(
 #ifdef ENABLE_LINUX
         case VMI_OS_LINUX:
             if(VMI_FAILURE == linux_init(vmi, _config)) {
+                vmi->os_type = VMI_OS_UNKNOWN;
                 if ( error )
                     *error = VMI_INIT_ERROR_OS;
 
@@ -702,6 +704,7 @@ os_t vmi_init_os(
 #ifdef ENABLE_WINDOWS
         case VMI_OS_WINDOWS:
             if(VMI_FAILURE == windows_init(vmi, _config)) {
+                vmi->os_type = VMI_OS_UNKNOWN;
                 if ( error )
                     *error = VMI_INIT_ERROR_OS;
 
@@ -710,6 +713,7 @@ os_t vmi_init_os(
             break;
 #endif
         default:
+            vmi->os_type = VMI_OS_UNKNOWN;
             if ( error )
                 *error = VMI_INIT_ERROR_OS;
 


### PR DESCRIPTION
This fixes `vmi_init_os` error handling.

Without this change, `vmi_init_os` can silently fail, since `vmi_init` function checks for `VMI_OS_UNKNOWN` to determine if there was a failure:

`vmi_init`
~~~C
    if ( VMI_OS_UNKNOWN == vmi_init_os(_vmi, config_mode, config, error) )
return VMI_FAILURE;
~~~

However, it is possible that there was a failure, and that `vmi->os_type` is set to `VMI_OS_WINDOWS` or `VMI_OS_LINUX`:

`vmi_init_os`
~~~C
    /* setup OS specific stuff */
    switch ( vmi->os_type )
    {
#ifdef ENABLE_LINUX
        case VMI_OS_LINUX:
            if(VMI_FAILURE == linux_init(vmi, _config)) {
                if ( error )
                    *error = VMI_INIT_ERROR_OS;

                 goto error_exit;
            }
            break;
#endif
#ifdef ENABLE_WINDOWS
        case VMI_OS_WINDOWS:
            if(VMI_FAILURE == windows_init(vmi, _config)) {
                if ( error )
                    *error = VMI_INIT_ERROR_OS;

                goto error_exit;
            }
            break;
#endif
        default:
            if ( error )
                *error = VMI_INIT_ERROR_OS;

            goto error_exit;
    };

error_exit:
return vmi->os_type;
~~~

Therefore this forces the `os_type` to be `VMI_OS_UNKOWN` in case of any failure (`goto error_exit`).