### PR TITLE
fix QEMU version check

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1430,9 +1430,10 @@ kvm_init_vmi(
     // get major int number
     int minor = json_object_get_int(minor_obj);
     // QEMU should be < 2.8.0
-    if (major >= 2 && minor >= 8)
+    if (major >= 2 && minor >= 8) {
         dbprint(VMI_DEBUG_KVM, "--Fail: incompatibility between libvmi and QEMU request definition detected\n");
         goto out_error;
+    }
     goto success;
 out_error:
     free(qemu_version_obj);


### PR DESCRIPTION
Fix missing braces, otherwise the code will always `goto out_error`

Thanks to @soft for reporting it.