### PR TITLE
Use proper maximum physical address on KVM

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -153,12 +153,12 @@ exec_info_version(
 
 static char *
 exec_info_mtree(
-  kvm_instance_t *kvm)
-  {
+    kvm_instance_t *kvm)
+{
     char *query =
-      "'{\"execute\": \"human-monitor-command\", \"arguments\": {\"command-line\": \"info mtree\"}}'";
+        "'{\"execute\": \"human-monitor-command\", \"arguments\": {\"command-line\": \"info mtree\"}}'";
     return exec_qmp_cmd(kvm, query);
-  }
+}
 
 static char *
 exec_memory_access(
@@ -301,8 +301,7 @@ parse_mtree(char *mtree_output)
     line = strtok_r(mtree_output, line_delim, &tmp);
     do {
         // check for above 4g
-        if (strstr(line, above_4g) != NULL)
-        {
+        if (strstr(line, above_4g) != NULL) {
             above_4g_line = strdup(line);
             break;
         }
@@ -1685,7 +1684,7 @@ kvm_get_memsize(
     char *bufstr = exec_info_mtree(kvm_get_instance(vmi));
     addr_t parsed_max = parse_mtree(bufstr);
 
-    if(parsed_max != 0)
+    if (parsed_max != 0)
         *maximum_physical_address = (addr_t) parsed_max;
     else
         *maximum_physical_address = *allocated_ram_size;

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -291,10 +291,23 @@ parse_mtree(char *mtree_output)
     char *ptr;
 
     if(NULL == (ptr = strstr(mtree_output, "alias ram-above-4g")))
+    goto error;
+
+    for(int i = 0; i <= 50;i++) {
+      if(ptr[0] == '-') {
+        ptr++;
+        goto success;
+      }
+      ptr--;
+    }
+
+    goto error;
+
+    error:
     return 0;
 
-    ptr -= 32;
-    return (addr_t) strtoll(ptr, (char **) NULL, 16);
+    success:
+    return (addr_t) strtoll(ptr, (char **) NULL, 16) + 1;
 }
 
 status_t


### PR DESCRIPTION
Parse qemu monitor command 'info mtree' to calculate max address

This is a fairly naive parsing of it, as I'm just rewinding the pointer by 16 after I strstr for "alias ram-above-4g".

While I do fallback to the old method if it cannot be found, can someone test on some of the other qemu supported architectures?