### PR TITLE
KVM: Parse registers as unsigned

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -217,7 +217,7 @@ parse_reg_value(
 
     if (NULL != ptr) {
         ptr += strlen(regname) + 1;
-        return (reg_t) strtoll(ptr, (char **) NULL, 16);
+        return (reg_t) strtoull(ptr, (char **) NULL, 16);
     }
     else {
         return 0;
@@ -274,7 +274,7 @@ parse_seg_reg_value(
     }
 
     ptr += offset;
-    return (reg_t) strtoll(ptr, (char **) NULL, 16);
+    return (reg_t) strtoull(ptr, (char **) NULL, 16);
 }
 
 status_t


### PR DESCRIPTION
Using strtoll meant that any value over LONG_MAX would be returned as LONG_MAX. Change these calls to the unsigned version so we don't end up mangling all the higher virtual addresses.