### PR TITLE
add poll to monitor qemu socket and prevent read errors

### DIFF
--- a/tools/qemu-kvm-patch/kvm-qemu-v2.8-libvmi.patch
+++ b/tools/qemu-kvm-patch/kvm-qemu-v2.8-libvmi.patch
@@ -5,12 +5,12 @@ index 474cc5e..2d569d9 100644
 @@ -459,9 +459,13 @@ ifneq (,$(findstring qemu-ga,$(TOOLS)))
  endif
  endif
- 
+
 +install-headers:
 +	$(INSTALL_DIR) "$(DESTDIR)$(includedir)/qemu"
 +	$(INSTALL_DATA) "$(SRC_PATH)/libvmi_request.h" "$(DESTDIR)$(includedir)/qemu/libvmi_request.h"
 +
- 
+
  install: all $(if $(BUILD_DOCS),install-doc) \
 -install-datadir install-localstatedir
 +install-datadir install-localstatedir install-headers
@@ -55,13 +55,26 @@ index abf210a..8910e1f 100644
 +-> { "execute": "pmemaccess", "arguments": { "file": "/tmp/dKtrhM39cC.sock" } }
 +<- { "return": {} }
 diff --git a/hmp.c b/hmp.c
-index b869617..e721830 100644
+index b869617..cb8cb68 100644
 --- a/hmp.c
 +++ b/hmp.c
-@@ -1029,6 +1029,15 @@ void hmp_pmemsave(Monitor *mon, const QDict *qdict)
+@@ -67,9 +67,10 @@ void hmp_info_version(Monitor *mon, const QDict *qdict)
+
+     info = qmp_query_version(NULL);
+
+-    monitor_printf(mon, "%" PRId64 ".%" PRId64 ".%" PRId64 "%s\n",
++    monitor_printf(mon, "%" PRId64 ".%" PRId64 ".%" PRId64 "%s %s\n",
+                    info->qemu->major, info->qemu->minor, info->qemu->micro,
+-                   info->package);
++                   info->package,
++                   "vmi");
+
+     qapi_free_VersionInfo(info);
+ }
+@@ -1029,6 +1030,15 @@ void hmp_pmemsave(Monitor *mon, const QDict *qdict)
      hmp_handle_error(mon, &err);
  }
- 
+
 +void hmp_pmemaccess(Monitor *mon, const QDict *qdict)
 +{
 +    const char *path = qdict_get_str(qdict, "path");
@@ -104,10 +117,10 @@ index 0000000..e4fc87a
 +#endif /* LIBVMI_REQUEST_H */
 diff --git a/memory-access.c b/memory-access.c
 new file mode 100644
-index 0000000..09b7cf8
+index 0000000..72ac93a
 --- /dev/null
 +++ b/memory-access.c
-@@ -0,0 +1,213 @@
+@@ -0,0 +1,249 @@
 +/*
 + * Access guest physical memory via a domain socket.
 + *
@@ -127,6 +140,7 @@ index 0000000..09b7cf8
 +#include <unistd.h>
 +#include <signal.h>
 +#include <stdint.h>
++#include <poll.h>
 +
 +#include "memory-access.h"
 +#include "exec/cpu-common.h"
@@ -188,64 +202,98 @@ index 0000000..09b7cf8
 +{
 +    int nbytes;
 +    struct request req;
++    struct pollfd *fds = calloc(1, sizeof(struct pollfd));
++    if (!fds)
++    {
++        fprintf(stderr, "Allocating pollfd failed\n");
++        return;
++    }
++    fds[0].fd = connection_fd;
++    fds[0].events = POLLIN | POLLERR | POLLHUP | POLLNVAL;
 +
 +    while (1){
-+        // client request should match the struct request format
-+        nbytes = read(connection_fd, &req, sizeof(struct request));
-+        if (nbytes != sizeof(struct request)){
-+            // error
++        // poll on our connection fd
++        int nb_modified = poll(fds, 1, -1);
++        if (nb_modified < 0)
++        {
++            // poll failed
++            fprintf(stderr, "Poll failed on vmi socket: %s\n", strerror(errno));
 +            continue;
 +        }
-+        else if (req.type == 0){
-+            // request to quit, goodbye
++        else if (nb_modified == 0)
++        {
++            // timeout
++            fprintf(stderr, "Poll timeout on vmi socket\n");
++            continue;
++        }
++        else if (fds[0].revents & POLLERR
++                || fds[0].revents & POLLHUP
++                || fds[0].revents & POLLNVAL)
++        {
++            // error
++            fprintf(stderr, "Poll error on vmi socket\n");
 +            break;
 +        }
-+        else if (req.type == 1){
-+            // request to read
-+            char *buf = malloc(req.length + 1);
-+            nbytes = connection_read_memory(req.address, buf, req.length);
-+            if (nbytes != req.length){
-+                // read failure, return failure message
-+                buf[req.length] = 0; // set last byte to 0 for failure
-+                nbytes = write(connection_fd, buf, 1);
++        else if (fds[0].revents & POLLIN)
++        {
++            // client request should match the struct request format
++            nbytes = read(connection_fd, &req, sizeof(struct request));
++            if (nbytes == -1 || nbytes != sizeof(struct request)){
++                // error
++                continue;
 +            }
-+            else{
-+                // read success, return bytes
-+                buf[req.length] = 1; // set last byte to 1 for success
-+                nbytes = write(connection_fd, buf, nbytes + 1);
++            else if (req.type == 0){
++                // request to quit, goodbye
++                break;
 +            }
-+            free(buf);
-+        }
-+        else if (req.type == 2){
-+            // request to write
-+            void *write_buf = malloc(req.length);
-+            nbytes = read(connection_fd, write_buf, req.length);
-+            if (nbytes != req.length){
-+                // failed reading the message to write
-+                send_fail_ack(connection_fd);
-+            }
-+            else{
-+                // do the write
-+                nbytes = connection_write_memory(req.address, write_buf, req.length);
-+                if (nbytes == req.length){
-+                    send_success_ack(connection_fd);
++            else if (req.type == 1){
++                // request to read
++                char *buf = malloc(req.length + 1);
++                nbytes = connection_read_memory(req.address, buf, req.length);
++                if (nbytes != req.length){
++                    // read failure, return failure message
++                    buf[req.length] = 0; // set last byte to 0 for failure
++                    nbytes = write(connection_fd, buf, 1);
 +                }
 +                else{
++                    // read success, return bytes
++                    buf[req.length] = 1; // set last byte to 1 for success
++                    nbytes = write(connection_fd, buf, nbytes + 1);
++                }
++                free(buf);
++            }
++            else if (req.type == 2){
++                // request to write
++                void *write_buf = malloc(req.length);
++                nbytes = read(connection_fd, write_buf, req.length);
++                if (nbytes != req.length){
++                    // failed reading the message to write
 +                    send_fail_ack(connection_fd);
 +                }
++                else{
++                    // do the write
++                    nbytes = connection_write_memory(req.address, write_buf, req.length);
++                    if (nbytes == req.length){
++                        send_success_ack(connection_fd);
++                    }
++                    else{
++                        send_fail_ack(connection_fd);
++                    }
++                }
++                free(write_buf);
 +            }
-+            free(write_buf);
-+        }
-+        else{
-+            // unknown command
-+            fprintf(stderr, "Qemu pmemaccess: ignoring unknown command (%" PRIu64 ")\n", req.type);
-+            char *buf = malloc(1);
-+            buf[0] = 0;
-+            nbytes = write(connection_fd, buf, 1);
-+            free(buf);
++            else{
++                // unknown command
++                fprintf(stderr, "Qemu pmemaccess: ignoring unknown command (%" PRIu64 ")\n", req.type);
++                char *buf = malloc(1);
++                buf[0] = 0;
++                nbytes = write(connection_fd, buf, 1);
++                free(buf);
++            }
 +        }
 +    }
 +
++    free(fds);
 +    close(connection_fd);
 +}
 +
@@ -291,7 +339,7 @@ index 0000000..09b7cf8
 +    // create socket
 +    pargs->socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
 +    if (pargs->socket_fd < 0){
-+        error_setg(pargs->errp, "Qemu pmemaccess: socket failed: %s", strerror(errno));
++        error_setg(pargs->errp, "Qemu pmemaccess: socket failed");
 +        return;
 +    }
 +    // unlink path if already exists
@@ -305,13 +353,14 @@ index 0000000..09b7cf8
 +    pargs->address->sun_family = AF_UNIX;
 +    pargs->address_length = sizeof(pargs->address->sun_family) + sprintf(pargs->address->sun_path, "%s", (char *) pargs->path);
 +    if (bind(pargs->socket_fd, (struct sockaddr *) pargs->address, pargs->address_length) != 0){
-+        error_setg(pargs->errp, "Qemu pmemaccess: bind failed: %s", strerror(errno));
++        printf("could not bind\n");
++        error_setg(pargs->errp, "Qemu pmemaccess: bind failed");
 +        return;
 +    }
 +
 +    // listen
 +    if (listen(pargs->socket_fd, 0) != 0){
-+        error_setg(pargs->errp, "Qemu pmemaccess: listen failed: %s", strerror(errno));
++        error_setg(pargs->errp, "Qemu pmemaccess: listen failed");
 +        return;
 +    }
 +


### PR DESCRIPTION
This PR uses `poll` in the QEMU memory-access handler to watch the socket and exit in case of errors.