### PR TITLE
fix vmi_init init_flags type to uint64_t

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -490,7 +490,7 @@ status_t vmi_init(
     vmi_instance_t *vmi,
     vmi_mode_t mode,
     void* domain,
-    uint32_t init_flags,
+    uint64_t init_flags,
     void *init_data,
     vmi_init_error_t *error)
 {

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -676,7 +676,7 @@ status_t vmi_init(
     vmi_instance_t *vmi,
     vmi_mode_t mode,
     void* domain,
-    uint32_t init_flags,
+    uint64_t init_flags,
     void *init_data,
     vmi_init_error_t *error);
 


### PR DESCRIPTION
This fixes issue https://github.com/libvmi/libvmi/issues/531