### PR TITLE
libvmi/driver: Fix wrapper for driver_set_privcall_event

### DIFF
--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -486,7 +486,7 @@ driver_set_privcall_event(
     bool enabled)
 {
     if (vmi->driver.initialized && vmi->driver.set_privcall_event_ptr)
-        return vmi->driver.set_debug_event_ptr(vmi, enabled);
+        return vmi->driver.set_privcall_event_ptr(vmi, enabled);
     else {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_privcall_event function not implemented.\n");
         return VMI_FAILURE;


### PR DESCRIPTION
This fix adjusts the wrapper driver_set_privcall_event so that it calls the
function that was registered in the vmi->driver.set_privcall_event_ptr function
pointer (instead of driver.set_debug_event_ptr).