### PR TITLE
Prohibit undefined symbols

### DIFF
--- a/libvmi/Makefile.am
+++ b/libvmi/Makefile.am
@@ -123,7 +123,7 @@ lib_LTLIBRARIES= libvmi.la
 libvmi_la_SOURCES= $(h_public) $(h_private) $(drivers) $(os) $(c_sources)
 libvmi_la_CFLAGS= -fvisibility=hidden $(GLIB_CFLAGS)
 libvmi_la_CFLAGS+= -Wall -Wextra
-libvmi_la_LDFLAGS= -release $(RELEASE) $(GLIB_LIBS)
+libvmi_la_LDFLAGS= -release $(RELEASE) $(GLIB_LIBS) -no-undefined
 
 if CONFIGFILE
 libvmi_la_LIBADD= config/libconfig.la


### PR DESCRIPTION
libvmi/Makefile.am -  Ensure that builds fail if an undefined symbols encountered during linking