### PR TITLE
[linux-offset-finder] Add mm_types.h header

### DIFF
--- a/tools/linux-offset-finder/findoffsets.c
+++ b/tools/linux-offset-finder/findoffsets.c
@@ -28,6 +28,7 @@
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/sched.h>
+#include <linux/mm_types.h>
 
 #define MYMODNAME "FindOffsets "
 


### PR DESCRIPTION
The struct mm_struct not found by the compiler. This commit includes
<linux/mm_types.h> which exposes struct mm_struct. The struct mm_struct
was previously exported through <linux/sched.h>, however, this has been
changed in Linux version 4.11.

Signed-off-by: Marius Momeu <momeu@sec.in.tum.de>