### PR TITLE
remove read_pa_padded and add padding parameter to read_pa

### DIFF
--- a/tools/pyvmi/libvmi/libvmi.py
+++ b/tools/pyvmi/libvmi/libvmi.py
@@ -383,26 +383,20 @@ class Libvmi(object):
         buffer = ffi.unpack(buffer, bytes_read[0])
         return (buffer, bytes_read[0])
 
-    def read_pa(self, paddr, count):
+    def read_pa(self, paddr, count, padding=False):
         buffer = ffi.new("char[]", count)
         bytes_read = ffi.new("size_t *")
         status = lib.vmi_read_pa(self.vmi, paddr, count, buffer, bytes_read)
-        check(status)
         # transform into Python bytes
         buffer = ffi.unpack(buffer, bytes_read[0])
+        if padding:
+            if VMIStatus(status) == VMIStatus.FAILURE:
+                # pad with zeroes
+                pad_size = count - bytes_read[0]
+                buffer += bytes(pad_size)
+        else:
+            check(status)
         return (buffer, bytes_read[0])
-
-    def read_pa_padded(self, paddr, count):
-        buffer = ffi.new("char[]", count)
-        bytes_read = ffi.new("size_t *")
-        status = lib.vmi_read_pa(self.vmi, paddr, count, buffer, bytes_read)
-        # transform into Python bytes
-        buffer = ffi.unpack(buffer, bytes_read[0])
-        if VMIStatus(status) == VMIStatus.FAILURE:
-            # pad with zeroes
-            pad_size = count - bytes_read[0]
-            buffer += bytes(pad_size)
-        return buffer
 
     def read_8_ksym(self, symbol):
         value = ffi.new("uint8_t *")


### PR DESCRIPTION
This PR unifies the API by removing the extra function `read_pa_padded`, and adding a `padding` parameter to `read_pa`.

Therefore, the method will return a tuple `(buffer, nb_read)` as the rest of the `read_*` APIs  