### PR TITLE
add Python bindings to Libvmi events API

### DIFF
--- a/tools/pyvmi/examples/singlestep-event.py
+++ b/tools/pyvmi/examples/singlestep-event.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+
+import sys
+import signal
+
+from libvmi import Libvmi, INIT_DOMAINNAME, INIT_EVENTS
+from libvmi.event import SingleStepEvent
+
+from pprint import pprint
+
+
+# catch SIGINT
+# we cannot rely on KeyboardInterrupt when we in
+# the call to vmi.listen()
+interrupted = False
+def signal_handler(signal, frame):
+    global interrupted
+    interrupted = True
+
+def callback(vmi, event):
+    pprint(event.to_dict())
+    # increment
+    event.data += 1
+
+
+def main(args):
+    if len(args) != 2:
+        print('./singlestep-event.py <vm_name>')
+        return 1
+
+    vm_name = args[1]
+
+    # register SIGINT
+    signal.signal(signal.SIGINT, signal_handler)
+
+    with Libvmi(vm_name, INIT_DOMAINNAME | INIT_EVENTS) as vmi:
+        num_vcpus = vmi.get_num_vcpus()
+        counter = 0
+        ss_event = SingleStepEvent(range(num_vcpus), callback, data=counter)
+        vmi.register_event(ss_event)
+        # listen
+        while not interrupted:
+            print("Waiting for events")
+            vmi.listen(500)
+        print("Stop listening")
+
+
+
+if __name__ == '__main__':
+    ret = main(sys.argv)
+    sys.exit(ret)

--- a/tools/pyvmi/libvmi/event.py
+++ b/tools/pyvmi/libvmi/event.py
@@ -1,0 +1,133 @@
+from builtins import object, super
+from enum import Enum
+
+from _libvmi import ffi, lib
+
+
+class EventType(Enum):
+    INVALID = lib.VMI_EVENT_INVALID
+    MEMORY  = lib.VMI_EVENT_MEMORY
+    REGISTER = lib.VMI_EVENT_REGISTER
+    SINGLESTEP = lib.VMI_EVENT_SINGLESTEP
+    INTERRUPT = lib.VMI_EVENT_INTERRUPT
+    GUEST_REQUEST = lib.VMI_EVENT_GUEST_REQUEST
+    CPUID = lib.VMI_EVENT_CPUID
+    DEBUG_EXCEPTION = lib.VMI_EVENT_DEBUG_EXCEPTION
+    PRIVILEGED_CALL = lib.VMI_EVENT_PRIVILEGED_CALL
+    DESCRIPTOR_ACCESS = lib.VMI_EVENT_DESCRIPTOR_ACCESS
+
+EVENTS_VERSION = lib.VMI_EVENTS_VERSION
+
+
+class MemAccess(Enum):
+    INVALID = lib.VMI_MEMACCESS_INVALID
+    N = lib.VMI_MEMACCESS_N
+    R = lib.VMI_MEMACCESS_R
+    W = lib.VMI_MEMACCESS_W
+    X = lib.VMI_MEMACCESS_X
+    RW = lib.VMI_MEMACCESS_RW
+    RX = lib.VMI_MEMACCESS_RX
+    WX = lib.VMI_MEMACCESS_WX
+    RWX = lib.VMI_MEMACCESS_RWX
+    W2X = lib.VMI_MEMACCESS_W2X
+    RWX2N = lib.VMI_MEMACCESS_RWX2N
+
+
+@ffi.def_extern()
+def generic_event_callback(cffi_vmi, cffi_event):
+    # get generic event data dict
+    generic_data = ffi.from_handle(cffi_event.data)
+    # get true callback
+    event = generic_data['event']
+    vmi = generic_data['vmi']
+    callback = event.get_callback()
+    # call callback with the right Python objects as args
+    event_response = callback(vmi, event)
+    if not event_response:
+        return 0
+    return event_response
+
+
+class Event(object):
+
+    def __init__(self, callback, slat_id=0, data=None):
+        self.version = EVENTS_VERSION
+        self.slat_id = slat_id
+        self.data = data
+        self.py_callback = callback
+        self.generic_data = {
+            'vmi': None,
+            'event': self,
+        }
+        self.cffi_event = ffi.new("vmi_event_t *")
+
+    def set_vmi_instance(self, vmi_instance):
+        self.generic_data['vmi'] = vmi_instance
+
+    def get_callback(self):
+        return self.py_callback
+
+    def to_cffi(self):
+        self.cffi_event.version = self.version
+        self.cffi_event.type = self.type.value
+        self.cffi_event.slat_id = self.slat_id
+        # convert our generic_data dict to a CFFI void* handle
+        # and keep a reference to the handle in self.generic_handle
+        self.generic_handle = ffi.new_handle(self.generic_data)
+        # assign the handle to the event data
+        self.cffi_event.data = self.generic_handle
+        self.cffi_event.callback = lib.generic_event_callback
+
+    def to_dict(self):
+        return {
+            'version': self.version,
+            'type': self.type.name,
+            'slat_id': self.slat_id,
+            'data': self.data,
+            'vcpu_id': self.cffi_event.vcpu_id,
+            'x86_regs': {
+                'rax': hex(self.cffi_event.x86_regs.rax),
+                'rsp': hex(self.cffi_event.x86_regs.rsp),
+                'rip': hex(self.cffi_event.x86_regs.rip),
+            }
+        }
+
+
+class MemEvent(Event):
+
+    def __init__(self, in_access, callback, gfn=None, generic=None, slat_id=0, data=None):
+        super().__init__(callback, slat_id, data)
+        self.type = EventType.MEMORY
+        self.in_access = in_access
+        self.generic = generic
+        self.gfn = gfn
+        if self.generic:
+            self.gfn = 0
+
+    def to_cffi(self):
+        super().to_cffi()
+        self.cffi_event.mem_event.in_access = self.in_access.value
+        self.cffi_event.mem_event.generic = self.generic
+        self.cffi_event.mem_event.gfn = self.gfn
+        return self.cffi_event
+
+
+class SingleStepEvent(Event):
+
+    def __init__(self, vcpus, callback, enable=True, slat_id=0, data=None):
+        super().__init__(callback, slat_id, data)
+        self.type = EventType.SINGLESTEP
+        self.vcpus = 0
+        for vcpu in vcpus:
+            mask = 1 << vcpu
+            self.vcpus |= mask
+        self.enable = enable
+
+    def to_cffi(self):
+        super().to_cffi()
+        self.cffi_event.ss_event.vcpus = self.vcpus
+        self.cffi_event.ss_event.enable = int(self.enable)
+        return self.cffi_event
+
+    def to_dict(self):
+        return super().to_dict()

--- a/tools/pyvmi/libvmi/events_cdef.h
+++ b/tools/pyvmi/libvmi/events_cdef.h
@@ -1,0 +1,130 @@
+#define VMI_EVENTS_VERSION 0x00000004
+
+typedef uint16_t vmi_event_type_t;
+
+#define VMI_EVENT_INVALID 0
+#define VMI_EVENT_MEMORY 1
+#define VMI_EVENT_REGISTER 2
+#define VMI_EVENT_SINGLESTEP 3
+#define VMI_EVENT_INTERRUPT 4
+#define VMI_EVENT_GUEST_REQUEST 5
+#define VMI_EVENT_CPUID 6
+#define VMI_EVENT_DEBUG_EXCEPTION 7
+#define VMI_EVENT_PRIVILEGED_CALL 8
+#define VMI_EVENT_DESCRIPTOR_ACCESS 9
+
+// reg_event_t
+typedef struct {
+    ...;
+} reg_event_t;
+
+typedef uint8_t vmi_mem_access_t;
+
+#define VMI_MEMACCESS_INVALID     ...
+#define VMI_MEMACCESS_N           ...
+#define VMI_MEMACCESS_R           ...
+#define VMI_MEMACCESS_W           ...
+#define VMI_MEMACCESS_X           ...
+#define VMI_MEMACCESS_RW          ...
+#define VMI_MEMACCESS_RX          ...
+#define VMI_MEMACCESS_WX          ...
+#define VMI_MEMACCESS_RWX         ...
+#define VMI_MEMACCESS_W2X         ...
+#define VMI_MEMACCESS_RWX2N       ...
+
+// mem_access_event_t
+typedef struct {
+    ...;
+} mem_access_event_t;
+
+// interrupt_event_t
+typedef struct {
+    ...;
+} interrupt_event_t;
+
+// single_step_event_t
+typedef struct {
+    uint32_t vcpus;
+    uint8_t enable;
+    ...;
+} single_step_event_t;
+
+// debug_event_t
+typedef struct {
+    ...;
+} debug_event_t;
+
+// cpuid_event_t
+typedef struct {
+    ...;
+} cpuid_event_t;
+
+// descriptor_event_t
+typedef struct desriptor_event {
+    ...;
+} descriptor_event_t;
+
+// vmi_event_t
+struct vmi_event;
+typedef struct vmi_event vmi_event_t;
+
+typedef uint32_t event_response_flags_t;
+
+#define VMI_EVENT_RESPONSE_NONE                 0
+#define VMI_EVENT_RESPONSE_EMULATE              ...
+#define VMI_EVENT_RESPONSE_EMULATE_NOWRITE      ...
+#define VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA   ...
+#define VMI_EVENT_RESPONSE_DENY                 ...
+#define VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP    ...
+#define VMI_EVENT_RESPONSE_SLAT_ID              ...
+#define VMI_EVENT_RESPONSE_VMM_PAGETABLE_ID     ...
+#define VMI_EVENT_RESPONSE_SET_REGISTERS        ...
+#define VMI_EVENT_RESPONSE_SET_EMUL_INSN        ...
+#define VMI_EVENT_RESPONSE_GET_NEXT_INTERRUPT   ...
+#define __VMI_EVENT_RESPONSE_MAX 9
+
+typedef uint32_t event_response_t;
+
+typedef event_response_t (*event_callback_t)(vmi_instance_t vmi, vmi_event_t *event);
+
+
+// vmi_event
+struct vmi_event {
+    uint32_t version;
+    vmi_event_type_t type;
+    uint16_t slat_id;
+    void *data;
+    event_callback_t callback;
+    uint32_t vcpu_id;
+    ...;
+    union {
+        reg_event_t reg_event;
+        mem_access_event_t mem_event;
+        single_step_event_t ss_event;
+        interrupt_event_t interrupt_event;
+        cpuid_event_t cpuid_event;
+        debug_event_t debug_event;
+        descriptor_event_t descriptor_event;
+    };
+    union {
+        union {
+            x86_registers_t *x86_regs;
+            arm_registers_t *arm_regs;
+        };
+        ...;
+    };
+};
+
+// functions
+status_t vmi_register_event(
+    vmi_instance_t vmi,
+    vmi_event_t *event);
+
+status_t vmi_events_listen(
+    vmi_instance_t vmi,
+    uint32_t timeout);
+
+// our generic callback
+extern "Python" event_response_t generic_event_callback(
+    vmi_instance_t vmi,
+    vmi_event_t *event);

--- a/tools/pyvmi/libvmi/libvmi.py
+++ b/tools/pyvmi/libvmi/libvmi.py
@@ -775,3 +775,14 @@ class Libvmi(object):
 
     def pidcache_add(self, pid, dtb):
         lib.vmi_pidcache_add(self.vmi, pid, dtb)
+
+    # events
+    def register_event(self, event):
+        event.set_vmi_instance(self)
+        cffi_event = event.to_cffi()
+        status = lib.vmi_register_event(self.vmi, cffi_event)
+        check(status)
+
+    def listen(self, timeout):
+        status = lib.vmi_events_listen(self.vmi, timeout)
+        check(status)

--- a/tools/pyvmi/libvmi/libvmi_build.py
+++ b/tools/pyvmi/libvmi/libvmi_build.py
@@ -4,7 +4,7 @@
 import os
 from cffi import FFI
 
-CDEF_FILE = 'libvmi_cdef.h'
+CDEF_FILES = ['libvmi_cdef.h', 'events_cdef.h']
 
 
 ffi = FFI()
@@ -12,15 +12,19 @@ ffi = FFI()
 ffi.set_source("_libvmi",
     """
     #include <libvmi/libvmi.h>
+    #include <libvmi/events.h>
     """,
     libraries=['vmi'])
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 # we read our C definitions from an external file
 # easier to maintain + C syntax highlighting
-with open(os.path.join(script_dir, CDEF_FILE)) as cdef_file:
-    cdef_content = cdef_file.read()
-ffi.cdef(cdef_content)
+ffi_cdef_content = ""
+for cdef_file in CDEF_FILES:
+    with open(os.path.join(script_dir, cdef_file)) as f:
+        ffi_cdef_content += '\n' + f.read()
+
+ffi.cdef(ffi_cdef_content)
 
 if __name__ == "__main__":
     ffi.compile(verbose=True)

--- a/tools/pyvmi/libvmi/libvmi_cdef.h
+++ b/tools/pyvmi/libvmi/libvmi_cdef.h
@@ -167,11 +167,48 @@ typedef uint64_t reg_t;
  * Commonly used x86 registers
  */
 typedef struct x86_regs {
-    ...;
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rbx;
+    uint64_t rsp;
+    uint64_t rbp;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t r8;
+    uint64_t r9;
+    uint64_t r10;
+    uint64_t r11;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t rflags;
+    uint64_t dr7;
+    uint64_t rip;
+    uint64_t cr0;
+    uint64_t cr2;
+    uint64_t cr3;
+    uint64_t cr4;
+    uint64_t sysenter_cs;
+    uint64_t sysenter_esp;
+    uint64_t sysenter_eip;
+    uint64_t msr_efer;
+    uint64_t msr_star;
+    uint64_t msr_lstar;
+    uint64_t fs_base;
+    uint64_t gs_base;
+    uint32_t cs_arbytes;
+    uint32_t _pad;
 } x86_registers_t;
 
 typedef struct arm_registers {
-    ...;
+    uint64_t ttbr0;
+    uint64_t ttbr1;
+    uint64_t ttbcr;
+    uint64_t pc;
+    uint32_t cpsr;
+    uint32_t _pad;
 } arm_registers_t;
 
 typedef struct registers {


### PR DESCRIPTION
This PR aims to add support for Python bindings to Libvmi's events API.

The status is a big WIP that i wrote in a few hours, but so far i managed to have SingleStep events working, with the Python callback !

Example:
~~~Python
from libvmi import Libvmi, INIT_DOMAINNAME, INIT_EVENTS
from libvmi.event import SingleStepEvent

from pprint import pprint


def callback(vmi, event):
    pprint(event.to_dict())
    # increment
    event.data += 1

def main(args):
    if len(args) != 2:
        print('./singlestep-event.py <vm_name>')
        return 1

    vm_name = args[1]

    # register SIGINT
    signal.signal(signal.SIGINT, signal_handler)

    with Libvmi(vm_name, INIT_DOMAINNAME | INIT_EVENTS) as vmi:
        num_vcpus = vmi.get_num_vcpus()
        counter = 0
        ss_event = SingleStepEvent(range(num_vcpus), callback, data=counter)
        vmi.register_event(ss_event)
        # listen
        while not interrupted:
            print("Waiting for events")
            vmi.listen(500)
        print("Stop listening")
~~~

# Events

I used a class hirarchy to create the Events, it was the most obvious thing to do for the implementation:

~~~Python

class Event(object)
    pass


class SingleStepEvent(Event)
    pass

class MemEvent(Event)
    pass
~~~

# Callback

This was the tricky part.
The problem with `CFFI` is that you can only call a callback that you have already defined and compiled in the C library:
https://cffi.readthedocs.io/en/latest/using.html#extern-python-new-style-callbacks

That's why i defined a generic callback
~~~Python
@ffi.def_extern()
def generic_event_callback(cffi_vmi, cffi_event):
~~~

in `events_cdef.h`
~~~C
// our generic callback
extern "Python" event_response_t generic_event_callback(
    vmi_instance_t vmi,
    vmi_event_t *event);
~~~

And i used the `event.data` to pass some extra data containing a handle to the Python `Event` object, which also contains the user defined Python callback:

Wrapping up into the `vmi_event.data`
~~~Python
class Event(object):

    def __init__(self,...):
        self.generic_data = {
            'vmi': None,
            'event': self,
        }
       self.py_callback = callback

   def get_callback(self):
       return self.py_callback

   def to_cffi(sell):
        # convert our generic_data dict to a CFFI void* handle
        # and keep a reference to the handle in self.generic_handle
        self.generic_handle = ffi.new_handle(self.generic_data)
        # assign the handle to the event data
        self.cffi_event.data = self.generic_handle
        self.cffi_event.callback = lib.generic_event_callback
~~~

This way i can get the handle back from the generic callback, and call the real callback:

~~~Python
@ffi.def_extern()
def generic_event_callback(cffi_vmi, cffi_event):
    # get generic event data dict
    generic_data = ffi.from_handle(cffi_event.data)
    # get true callback
    event = generic_data['event']
    vmi = generic_data['vmi']
    callback = event.get_callback()
    # call callback with the right Python objects as args
    event_response = callback(vmi, event)
    if not event_response:
        return 0
    return event_response
~~~

# Results

you can test the example at `examples/singlestep-event.py`:

~~~
Waiting for events
{'data': 1807,
 'slat_id': 0,
 'type': 'SINGLESTEP',
 'vcpu_id': 0,
 'version': 4,
 'x86_regs': {'rax': '0xa800013a8',
              'rip': '0xfffff80002e00efd',
              'rsp': '0xfffff80003be7c28'}}
Waiting for events
{'data': 1808,
 'slat_id': 0,
 'type': 'SINGLESTEP',
 'vcpu_id': 0,
 'version': 4,
 'x86_regs': {'rax': '0x19e',
              'rip': '0xfffff80002e00f04',
              'rsp': '0xfffff80003be7c28'}}
Waiting for events
{'data': 1809,
 'slat_id': 0,
 'type': 'SINGLESTEP',
 'vcpu_id': 0,
 'version': 4,
 'x86_regs': {'rax': '0x19e',
              'rip': '0xfffff80002e00f07',
              'rsp': '0xfffff80003be7c28'}}
Waiting for events
{'data': 1810,
 'slat_id': 0,
 'type': 'SINGLESTEP',
 'vcpu_id': 0,
 'version': 4,
 'x86_regs': {'rax': '0x19e',
              'rip': '0xfffff80002e00f09',
              'rsp': '0xfffff80003be7c28'}}
Waiting for events
{'data': 1811,
 ^C'type': 'SINGLESTEP',
 'vcpu_id': 0,
 'version': 4,
 'x86_regs': {'rax': '0x19e',
              'rip': '0xfffff80002e00f0e',
              'rsp': '0xfffff80003be7c28'}}
Stop listening
~~~

Thanks.