### PR TITLE
set Gitter link to libvmi/Lobby (public room)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ the documentation included in the doc/ subdirectory of LibVMI, or view the
 documentation online at http://www.libvmi.com.
 
 .. image:: https://badges.gitter.im/Join%20Chat.svg
-   :alt: Join the chat at https://gitter.im/libvmi
-   :target: https://gitter.im/libvmi?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :alt: Join the chat at https://gitter.im/libvmi/Lobby
+   :target: https://gitter.im/libvmi/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 .. image:: https://travis-ci.org/libvmi/libvmi.svg?branch=master
     :target: https://travis-ci.org/libvmi/libvmi


### PR DESCRIPTION
The previous link was leading to a private room, for maintainers only.
That's not what we want.