### PR TITLE
Pass init_flags and init_data to driver_test() functions

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -438,7 +438,7 @@ vmi_get_access_mode(
     vmi_instance_t vmi,
     void *domain,
     uint64_t init_flags,
-    void* UNUSED(init_data),
+    void* init_data,
     vmi_mode_t *mode)
 {
     if ( vmi ) {
@@ -458,7 +458,7 @@ vmi_get_access_mode(
             (name && id != VMI_INVALID_DOMID) )
         return VMI_FAILURE;
 
-    return driver_init_mode(name, id, mode);
+    return driver_init_mode(name, id, init_flags, init_data, mode);
 }
 
 static inline status_t driver_sanity_check(vmi_mode_t mode)

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -43,7 +43,11 @@
 #include "driver/kvm/kvm.h"
 #endif
 
-status_t driver_init_mode(const char *name, uint64_t domainid, vmi_mode_t *mode)
+status_t driver_init_mode(const char *name,
+                          uint64_t domainid,
+                          uint64_t UNUSED(init_flags),
+                          void* UNUSED(init_data),
+                          vmi_mode_t *mode)
 {
     unsigned long count = 0;
 

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -45,29 +45,29 @@
 
 status_t driver_init_mode(const char *name,
                           uint64_t domainid,
-                          uint64_t UNUSED(init_flags),
-                          void* UNUSED(init_data),
+                          uint64_t init_flags,
+                          void* init_data,
                           vmi_mode_t *mode)
 {
     unsigned long count = 0;
 
     /* see what systems are accessable */
 #if ENABLE_XEN == 1
-    if (VMI_SUCCESS == xen_test(domainid, name)) {
+    if (VMI_SUCCESS == xen_test(domainid, name, init_flags, init_data)) {
         dbprint(VMI_DEBUG_DRIVER, "--found Xen\n");
         *mode = VMI_XEN;
         count++;
     }
 #endif
 #if ENABLE_KVM == 1
-    if (VMI_SUCCESS == kvm_test(domainid, name)) {
+    if (VMI_SUCCESS == kvm_test(domainid, name, init_flags, init_data)) {
         dbprint(VMI_DEBUG_DRIVER, "--found KVM\n");
         *mode = VMI_KVM;
         count++;
     }
 #endif
 #if ENABLE_FILE == 1
-    if (VMI_SUCCESS == file_test(domainid, name)) {
+    if (VMI_SUCCESS == file_test(domainid, name, init_flags, init_data)) {
         dbprint(VMI_DEBUG_DRIVER, "--found file\n");
         *mode = VMI_FILE;
         count++;

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -188,6 +188,8 @@ typedef struct driver_interface {
 status_t driver_init_mode(
     const char *name,
     uint64_t domainid,
+    uint64_t init_flags,
+    void* init_data,
     vmi_mode_t *mode);
 
 status_t driver_init(

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -298,7 +298,9 @@ file_is_pv(
 status_t
 file_test(
     uint64_t UNUSED(id),
-    const char *name)
+    const char *name,
+    uint64_t UNUSED(init_flags),
+    void* UNUSED(init_data))
 {
     status_t ret = VMI_FAILURE;
     FILE *f = NULL;

--- a/libvmi/driver/file/file.h
+++ b/libvmi/driver/file/file.h
@@ -60,7 +60,9 @@ int file_is_pv(
     vmi_instance_t vmi);
 status_t file_test(
     uint64_t id,
-    const char *name);
+    const char *name,
+    uint64_t init_flags,
+    void* init_data);
 status_t file_pause_vm(
     vmi_instance_t vmi);
 status_t file_resume_vm(

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -1956,7 +1956,9 @@ kvm_is_pv(
 status_t
 kvm_test(
     uint64_t domainid,
-    const char *name)
+    const char *name,
+    uint64_t UNUSED(init_flags),
+    void* UNUSED(init_data))
 {
     struct vmi_instance _vmi = {0};
     vmi_instance_t vmi = &_vmi;

--- a/libvmi/driver/kvm/kvm.h
+++ b/libvmi/driver/kvm/kvm.h
@@ -83,7 +83,9 @@ int kvm_is_pv(
     vmi_instance_t vmi);
 status_t kvm_test(
     uint64_t domainid,
-    const char *name);
+    const char *name,
+    uint64_t init_flags,
+    void* init_data);
 status_t kvm_pause_vm(
     vmi_instance_t vmi);
 status_t kvm_resume_vm(

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -2262,7 +2262,9 @@ xen_is_pv(
 status_t
 xen_test(
     uint64_t domainid,
-    const char *name)
+    const char *name,
+    uint64_t UNUSED(init_flags),
+    void* UNUSED(init_data))
 {
     struct vmi_instance _vmi = {0};
     vmi_instance_t vmi = &_vmi;

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -97,7 +97,9 @@ int xen_is_pv(
     vmi_instance_t vmi);
 status_t xen_test(
     uint64_t domainid,
-    const char *name);
+    const char *name,
+    uint64_t init_flags,
+    void* init_data);
 status_t xen_pause_vm(
     vmi_instance_t vmi);
 status_t xen_resume_vm(


### PR DESCRIPTION
Minor modification of driver_init_mode to pass init_flags and init_data parameters down to the driver test function, e.g., xen_test(). 

Preparatory work for a) a new driver that needs to perform sanity checking during init, b) enhanced tests for existing drivers.