### PR TITLE
add missing stdbool header in slat.h

### DIFF
--- a/libvmi/slat.h
+++ b/libvmi/slat.h
@@ -33,6 +33,8 @@
 #ifndef LIBVMI_SLAT_H
 #define LIBVMI_SLAT_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Some `slat.h` functions cannot be compiled !

~~~C
#include <libvmi/libvmi.h>
#include <libvmi/slat.h>

int main (int argc, char **argv)
{
    vmi_instance_t vmi;
    status_t status;


    char *name = NULL;
    char *symbol = NULL;

    // Arg 1 is the VM name.
    name = argv[1];
    symbol = argv[2];


    /* initialize the libvmi library */
    if (VMI_FAILURE == vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, NULL, VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, NULL)) {
        printf("Failed to init LibVMI library.\n");
        return 1;
    }

    printf("LibVMI init succeeded!\n");

    bool state = false;
    vmi_slat_get_domain_state(vmi, &state);

    return 0;
}
~~~

~~~
In file included from slat.c:2:0:
/usr/include/libvmi/slat.h:51:5: error: unknown type name ‘bool’
     bool *state);
     ^
/usr/include/libvmi/slat.h:62:5: error: unknown type name ‘bool’
     bool state);
     ^
slat.c: In function ‘main’:
slat.c:26:5: error: unknown type name ‘bool’
     bool state = false;
     ^
slat.c:26:18: error: ‘false’ undeclared (first use in this function)
     bool state = false;
                  ^
slat.c:26:18: note: each undeclared identifier is reported only once for each function it appears in
slat.c:27:5: warning: implicit declaration of function ‘vmi_slat_get_domain_state’ [-Wimplicit-function-declaration]
     vmi_slat_get_domain_state(vmi, &state);
~~~

Add missing `stdbool.h`