### PR TITLE
This is a fix for systems without meltdown patches

### DIFF
--- a/libvmi/os/linux/memory.c
+++ b/libvmi/os/linux/memory.c
@@ -128,6 +128,10 @@ linux_get_taskstruct_addr_from_pgd(
                 task_pgd == pgd)
             return next_process;
 
+        task_pgd &= ~0x1fff;
+        if (task_pgd == pgd)
+            return next_process;
+
         vmi_read_addr_va(vmi, next_process + tasks_offset, 0, &next_process);
         next_process -= tasks_offset;
 


### PR DESCRIPTION
After masking the last bits of pgd of the CR3 register
it can occur that it's different to the PGD of the task struct.
Not sure if this will fix all problems.