### PR TITLE
ARM: improved support for privcall traps

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -492,7 +492,12 @@ xen_init_vmi(
     if ( VMI_FAILURE == ret )
         goto _bail;
 
-    if (vmi->vm_type == HVM && (vmi->init_flags & VMI_INIT_EVENTS)) {
+#if defined(I386) || defined(X86_64)
+    if ( vmi->vm_type == HVM && (vmi->init_flags & VMI_INIT_EVENTS) )
+#elif defined(ARM32) || defined(ARM64)
+    if ( vmi->init_flags & VMI_INIT_EVENTS )
+#endif
+    {
         ret = xen_init_events(vmi, init_flags, init_data);
 
         if ( VMI_FAILURE == ret )
@@ -513,8 +518,14 @@ xen_destroy(
 
     if (!xen) return;
 
-    if (vmi->vm_type == HVM && (vmi->init_flags & VMI_INIT_EVENTS))
+#if defined(I386) || defined(X86_64)
+    if ( vmi->vm_type == HVM && (vmi->init_flags & VMI_INIT_EVENTS) )
+#elif defined(ARM32) || defined(ARM64)
+    if ( vmi->init_flags & VMI_INIT_EVENTS )
+#endif
+    {
         xen_events_destroy(vmi);
+    }
 
     xc_interface *xchandle = xen_get_xchandle(vmi);
     if ( xchandle )
@@ -2256,7 +2267,11 @@ int
 xen_is_pv(
     vmi_instance_t vmi)
 {
+#if defined(I386) || defined (X86_64)
     return !(vmi->vm_type == HVM);
+#elif defined(ARM32) || defined(ARM64)
+    return 0;
+#endif
 }
 
 status_t

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -150,6 +150,7 @@ typedef enum {
 #define XEN_DOMCTL_MONITOR_EVENT_GUEST_REQUEST         4
 #define XEN_DOMCTL_MONITOR_EVENT_DEBUG_EXCEPTION       5
 #define XEN_DOMCTL_MONITOR_EVENT_CPUID                 6
+#define XEN_DOMCTL_MONITOR_EVENT_PRIVILEGED_CALL       7
 
 typedef struct mem_event_st_42 {
     uint32_t flags;

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -94,6 +94,7 @@ typedef struct {
     bool monitor_cr4_on;
     bool monitor_xcr0_on;
     bool monitor_msr_on;
+    bool monitor_privcall_on;
 } xen_vm_event_t;
 
 /* Conversion matrix from LibVMI flags to Xen vm_event flags */

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -338,6 +338,15 @@ typedef struct {
 } interrupt_event_t;
 
 typedef struct {
+    int8_t reinject;
+
+    /* OUT */
+    addr_t gla;         /**< (Global Linear Address) == PC of the trapped instruction */
+    addr_t gfn;         /**< (Guest Frame Number) == 'physical' page where trap occurred */
+    addr_t offset;      /**< Offset in bytes (relative to GFN) */
+} privcall_event_t;
+
+typedef struct {
     /* CONST IN */
     uint32_t vcpus;     /**< A bitfield corresponding to VCPU IDs. */
     uint8_t enable;     /**< Set to true to immediately turn vCPU to singlestep. */
@@ -593,6 +602,14 @@ struct vmi_event {
             (_event)->version = VMI_EVENTS_VERSION; \
             (_event)->type = VMI_EVENT_INTERRUPT; \
             (_event)->interrupt_event.intr = INT3; \
+            (_event)->interrupt_event.reinject = _reinject; \
+            (_event)->callback = _callback; \
+        } while(0)
+
+#define SETUP_PRIVCALL_EVENT(_event, _reinject, _callback) \
+        do { \
+            (_event)->version = VMI_EVENTS_VERSION; \
+            (_event)->type = VMI_EVENT_PRIVILEGED_CALL; \
             (_event)->interrupt_event.reinject = _reinject; \
             (_event)->callback = _callback; \
         } while(0)

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -338,8 +338,6 @@ typedef struct {
 } interrupt_event_t;
 
 typedef struct {
-    int8_t reinject;
-
     /* OUT */
     addr_t gla;         /**< (Global Linear Address) == PC of the trapped instruction */
     addr_t gfn;         /**< (Guest Frame Number) == 'physical' page where trap occurred */
@@ -501,6 +499,7 @@ struct vmi_event {
         mem_access_event_t mem_event;
         single_step_event_t ss_event;
         interrupt_event_t interrupt_event;
+        privcall_event_t privcall_event;
         cpuid_event_t cpuid_event;
         debug_event_t debug_event;
         descriptor_event_t descriptor_event;
@@ -606,11 +605,10 @@ struct vmi_event {
             (_event)->callback = _callback; \
         } while(0)
 
-#define SETUP_PRIVCALL_EVENT(_event, _reinject, _callback) \
+#define SETUP_PRIVCALL_EVENT(_event, _callback) \
         do { \
             (_event)->version = VMI_EVENTS_VERSION; \
             (_event)->type = VMI_EVENT_PRIVILEGED_CALL; \
-            (_event)->interrupt_event.reinject = _reinject; \
             (_event)->callback = _callback; \
         } while(0)
 


### PR DESCRIPTION
The current implementation does not return event details to the event callback.

This patch extends process_privcall_event to return more informations of the event.
This adds better error handling to xen_set_privcall_event_48.
xen_events_destroy_48 now also disables privcall events.