### PR TITLE
Update rekall finder

### DIFF
--- a/tools/windows-offset-finder/README.md
+++ b/tools/windows-offset-finder/README.md
@@ -5,18 +5,39 @@
 
 # Method 1 - Using Rekall
 
-The [Rekall](https://github.com/google/rekall) framework already integrate an
-address space to work on top of [LibVMI](https://github.com/libvmi/libvmi).
+The [Rekall](https://github.com/google/rekall) framework can find the right GUID,
+download the PDBs and extract the right offsets for us, given a memory dump.
 
-Rekall will find the right GUID, download the PDBs and extract the right offsets for us.
 
 ## Requirements
 
 - `LibVMI` C library
-- [`libvmi` Python bindings](https://github.com/libvmi/python)
+- `python3-docopt`
+- `python3-libvirt`
+- [`libvmi` Python bindings](https://github.com/libvmi/python) (optional)
 - `cabextract`
 
-## Installing Rekall from source
+## Usage
+
+The `rekall_offset_finder` script can extract the offsets in multiple ways.
+
+Given a libvirt domain, it will take a temporary memory dump,
+and extract the offsets:
+~~~
+(venv) ./rekall_offset_finder.py windows7
+~~~
+
+You can also specify your own memory dump:
+~~~
+(venv) ./rekall_offset_finder.py windows7 ~/tmp/win7.raw
+~~~
+
+Look at the help to see the possible options. `./rekall_offset_finder.py -h`
+
+### VMI address space
+
+Rekall can work directly on top of LibVMI, and extract the offsets by reading
+and parsing the physical memory of a VM.
 
 At the time of this writing, there is no release of Rekall available which integrates
 the new address space. Therefore you must install Rekall from source:
@@ -30,25 +51,23 @@ the new address space. Therefore you must install Rekall from source:
     (venv) pip install --editable rekall/rekall-agent
     (venv) pip install --editable rekall
 
-## Usage
+The `url` argument should be of the form `vmi://(xen|kvm)?/domain`
 
-The script `rekall_offset_finder.py` takes one argument, the `URL`, indicating how
-Rekall should access the domain.
 Examples:
 
-    (venv) ./rekall_offset_finder.py vmi:///windows_7
+    (venv) ./rekall_offset_finder.py windows7 vmi:///windows7
 
 You can specify the hypervisor if you want
 
-    (venv) ./rekall_offset_finder.py vmi://kvm/windows_7
-    (venv) ./rekall_offset_finder.py vmi://xen/windows_7
+    (venv) ./rekall_offset_finder.py windows7 vmi://kvm/windows7
+    (venv) ./rekall_offset_finder.py windows7 vmi://xen/windows7
 
 
 Running the script should extract the offset and display a config entry to copy paste.
 Example run:
 
 
-    (venv) ./rekall_offset_finder.py vmi://kvm/win7x64
+    (venv) ./rekall_offset_finder.py win7x64 vmi://kvm/win7x64
     LibVMI Version 0.11.0
     LibVMI Driver Mode 1
     --completed driver init.
@@ -77,7 +96,7 @@ is more complete.
 
 Note: In the case of `Xen`, you must run the script as `root`:
 
-    sudo venv/bin/python rekall_offset_finder.py vmi://xen/windows_7
+    sudo venv/bin/python rekall_offset_finder.py windows7 vmi://xen/windows7
 
 # Method 2 - Custom scripts
 

--- a/tools/windows-offset-finder/rekall_offset_finder.py
+++ b/tools/windows-offset-finder/rekall_offset_finder.py
@@ -1,26 +1,46 @@
 #!/usr/bin/env python3
 
+"""
+Rekall offset finder.
+
+Usage:
+    rekall_offset_finder.py [options] <domain> [<url>]
+
+Options:
+    -d --debug              Enable debug output
+    -u URI, --uri=URI       Specify Libvirt URI [Default: qemu:///system]
+    -o --old                Use the old config format
+    -h --help               Show this screen.
+    --version               Show version.
+"""
 
 import sys
 import os
 import logging
-import re
 import json
+import stat
 from io import StringIO
 from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
+import libvirt
+from docopt import docopt
 from rekall import plugins, session
 
-NT_KRNL_PDB = 'ntkrnlmp.pdb'
-SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+NT_KRNL_PDB = ['ntkrnlmp.pdb', 'ntkrpamp.pdb']
+SCRIPT_DIR = str(Path(__file__).resolve().parent)
 
 def find_ntoskrnl(version_modules):
     for entry in version_modules:
-        e_type, e_data = entry[0], entry[1]
-        if e_type == 'r' and e_data['pdb'] == NT_KRNL_PDB:
-            return (e_data['pdb'], e_data['guid'])
+        e_type = entry[0]
+        if e_type == 'r':
+            e_data = entry[1]
+            if e_data['pdb'] in NT_KRNL_PDB:
+                return (e_data['pdb'], e_data['guid'])
     raise RuntimeError('Cannot find {} with version_modules '
                        'plugin'.format(NT_KRNL_PDB))
+
 
 def extract_offsets(domain, url):
     s = session.Session(
@@ -74,45 +94,85 @@ def extract_offsets(domain, url):
 
     return config
 
-def format_config(domain, config):
-    formatted_config = """
+
+def format_config(domain, config, old_format=False):
+    if not old_format:
+        formatted_config = """
 %s {
     ostype = "Windows";
     rekall_profile = "%s";
 }
 """ % (domain, config['rekall_profile'])
-
-    # uncomment this if you want to use the old
-    # config format, instead of the rekall profile
-#     formatted_config = """
-# %s {
-#     ostype = "Windows";
-#     win_pdbase = %s;
-#     win_pid = %s;
-#     win_tasks = %s;
-#     win_pname = %s;
-# }
-# """ % (domain,
-#         hex(config['win_pdbase']),
-#         hex(config['win_pid']),
-#         hex(config['win_tasks']),
-#         hex(config['win_pname'])
-#       )
+    else:
+        formatted_config = """
+%s {
+    ostype = "Windows";
+    win_pdbase = %s;
+    win_pid = %s;
+    win_tasks = %s;
+    win_pname = %s;
+}
+""" % (domain,
+        hex(config['win_pdbase']),
+        hex(config['win_pid']),
+        hex(config['win_tasks']),
+        hex(config['win_pname'])
+      )
     return formatted_config
 
 
+def main(args):
+    # delete rekall's BasicConfig
+    # we want to configure the root logger
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+    debug = args['--debug']
+    # configure root logger
+    log_level = logging.INFO
+    if debug:
+        log_level = logging.DEBUG
+    logging.basicConfig(level=log_level)
+    logging.debug(args)
+
+    domain_name = args['<domain>']
+    uri = args['--uri']
+    old_format = args['--old']
+    url = args['<url>']
+
+
+    config = None
+    if not url:
+        # take temporary memory dump
+        # we need to create our own tmp_dir
+        # otherwise the dumpfile will be owned by libvirt
+        # and we don't have the permission to remove it in /tmp
+        with TemporaryDirectory() as tmp_dir:
+            with NamedTemporaryFile(dir=tmp_dir) as ram_dump:
+                # chmod to be r/w by everyone
+                # before libvirt takes ownership
+                os.chmod(ram_dump.name,
+                         stat.S_IRUSR | stat.S_IWUSR |
+                         stat.S_IRGRP | stat.S_IWGRP |
+                         stat.S_IROTH | stat.S_IWOTH)
+                con = libvirt.open(uri)
+                domain = con.lookupByName(domain_name)
+                # take dump
+                logging.info('Dumping %s physical memory to %s', domain.name(),
+                             ram_dump.name)
+                flags = libvirt.VIR_DUMP_MEMORY_ONLY
+                dumpformat = libvirt.VIR_DOMAIN_CORE_DUMP_FORMAT_RAW
+                domain.coreDumpWithFormat(ram_dump.name, dumpformat, flags)
+                ram_dump.flush()
+                # extract offsets
+                config = extract_offsets(domain.name(), ram_dump.name)
+
+    else:
+        config = extract_offsets(domain_name, url)
+    formatted_config = format_config(domain_name, config, old_format)
+    logging.info(formatted_config)
+
 
 if __name__ == '__main__':
-    # check args
-    if len(sys.argv) != 2:
-        print('Usage: ./auto_config.py vmi:///domain')
-        print('(alt) Usage: ./auto_config.py vmi://kvm|xen/domain')
-        sys.exit(1)
-
-    url = sys.argv[1]
-    pattern = 'vmi://((?P<hypervisor>xen|kvm))?/(?P<domain>.*)'
-    m = re.match(pattern, url)
-    domain = m.group('domain')
-    config = extract_offsets(domain, url)
-    formatted_config = format_config(domain, config)
-    print(formatted_config)
+    args = docopt(__doc__)
+    exit_code = main(args)
+    sys.exit(exit_code)


### PR DESCRIPTION
This PR updates the `rekall_offset_finder` script and extends its possibilities:
- take a memory dump using libvirt API and extract the offsets
- specify a memory dump
- add support for windows XP (`ntkrpamp.pdb`)
- add command line switch to specify old libvmi config format

I added `python3-docopt` for the maintainability of the command line and `python3-libvirt` as new dependencies.
It shouldn't be a trouble as they are available via `pip`, and we are using a `virtualenv` anyway.

New command line:
~~~
Rekall offset finder.

Usage:
    rekall_offset_finder.py [options] <domain> [<url>]

Options:
    -d --debug              Enable debug output
    -u URI, --uri=URI       Specify Libvirt URI [Default: qemu:///system]
    -o --old                Use the old config format
    -h --help               Show this screen.
    --version               Show version.
~~~