### PR TITLE
Make safety checks optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -274,3 +274,27 @@ matrix:
       script:
         - ./configure --disable-rekall-profiles
         - make
+
+#
+# disable safety checks
+#
+    - env:
+        - TEST="disable safety checks"
+      addons:
+        apt:
+            sources:
+                - ubuntu-toolchain-r-test
+            packages:
+                - bison
+                - flex
+                - check
+                - libjson-c-dev
+                - autoconf-archive
+                - libvirt-dev
+                - libxen-dev
+                - libfuse-dev
+      install:
+        - ./autogen.sh
+      script:
+        - ./configure --disable-safety-checks
+        - make

--- a/configure.ac
+++ b/configure.ac
@@ -70,105 +70,111 @@ dnl Check package options
 dnl -----------------------------------------------
 AC_ARG_ENABLE([xen],
       [AS_HELP_STRING([--disable-xen],
-         [Support memory introspection with live Xen domains (default is yes)])],
+         [Disable support for memory introspection with live Xen domains @<:@no@:>@])],
       [enable_xen=$enableval],
       [enable_xen=yes])
 AM_CONDITIONAL([WITH_XEN], [test x"$enable_xen" = xyes])
 
 AC_ARG_WITH([xenstore],
       [AS_HELP_STRING([--without-xenstore],
-         [Build LibVMI without Xenstore])],
+         [Build LibVMI without Xenstore @<:@no@:>@])],
       [with_xenstore=$withval],
       [with_xenstore=yes])
 AM_CONDITIONAL([XENSTORE], [test x"$with_xenstore" = xyes])
 
 AC_ARG_ENABLE([kvm],
       [AS_HELP_STRING([--disable-kvm],
-         [Support memory introspection with live KVM VMs (default is yes)])],
+         [Disable support for memory introspection with live KVM VMs @<:@no@:>@])],
       [enable_kvm=$enableval],
       [enable_kvm=yes])
 AM_CONDITIONAL([WITH_KVM], [test x"$enable_kvm" = xyes])
 
 AC_ARG_ENABLE([shm_snapshot],
       [AS_HELP_STRING([--disable-shm-snapshot],
-         [Support shm-snapshot with KVM VMs (Xen is pending) (default is no)])],
+         [Disable support for shm-snapshot with KVM VMs (Xen is pending) @<:@yes@:>@])],
       [enable_shm_snapshot=$enableval],
       [enable_shm_snapshot=no])
 AM_CONDITIONAL([SHM], [test x"$enable_shm_snapshot" = xyes])
 
 AC_ARG_ENABLE([file],
       [AS_HELP_STRING([--disable-file],
-         [Support memory introspection with physical memory dumps in a file (default is yes)])],
+         [Disable support for memory introspection with physical memory dumps in a file @<:@no@:>@])],
       [enable_file=$enableval],
       [enable_file=yes])
 AM_CONDITIONAL([WITH_FILE], [test x"$enable_file" = xyes])
 
 AC_ARG_ENABLE([windows],
       [AS_HELP_STRING([--disable-windows],
-         [Support introspecting Windows (XP - 8)])],
+         [Disable support for introspecting Windows (XP - 10) @<:@no@:>@])],
       [enable_windows=$enableval],
       [enable_windows=yes])
 AM_CONDITIONAL([WINDOWS], [test x"$enable_windows" = xyes])
 
 AC_ARG_ENABLE([linux],
       [AS_HELP_STRING([--disable-linux],
-         [Support introspecting Linux])],
+         [Disable support for introspecting Linux @<:@no@:>@])],
       [enable_linux=$enableval],
       [enable_linux=yes])
 AM_CONDITIONAL([LINUX], [test x"$enable_linux" = xyes])
 
 AC_ARG_ENABLE([freebsd],
       [AS_HELP_STRING([--disable-freebsd],
-         [Support introspecting FreeBSD])],
+         [Disable support for introspecting FreeBSD @<:@no@:>@])],
       [enable_freebsd=$enableval],
       [enable_freebsd=yes])
 AM_CONDITIONAL([FREEBSD], [test x"$enable_freebsd" = xyes])
 
 AC_ARG_ENABLE([vmifs],
       [AS_HELP_STRING([--disable-vmifs],
-         [Build VMIFS tool: maps memory to a file through FUSE])],
+         [Disable building VMIFS tool: maps memory to a file through FUSE @<:@no@:>@])],
       [enable_vmifs=$enableval],
       [enable_vmifs=yes])
 AM_CONDITIONAL([VMIFS], [test x"$enable_vmifs" = xyes])
 
 AC_ARG_ENABLE([address_cache],
       [AS_HELP_STRING([--disable-address-cache],
-         [Cache addresses (v2p, pid, etc)])],
+         [Disable caching addresses (v2p, pid, etc) @<:@no@:>@])],
       [enable_address_cache=$enableval],
       [enable_address_cache=yes])
 AM_CONDITIONAL([ENABLE_ADDRESS_CACHE], [test x"$enable_address_cache" = "xyes"])
 
 AC_ARG_ENABLE([page_cache],
       [AS_HELP_STRING([--disable-page-cache],
-         [Cache pages])],
+         [Disable caching pages @<:@no@:>@])],
       [enable_page_cache=$enableval],
       [enable_page_cache=512])
 
 AC_ARG_ENABLE([examples],
       [AS_HELP_STRING([--disable-examples],
-         [Build LibVMI examples (default is yes)])],
+         [Disable building LibVMI examples @<:@yes@:>@])],
       [enable_examples=$enableval],
       [enable_examples=yes])
 
 AC_ARG_ENABLE([debug],
-  [AS_HELP_STRING([--enable-debug],
-    [Enable strict compiler checks @<:@no@:>@])],
-  [debug="$enableval"],
-  [debug="no"])
+      [AS_HELP_STRING([--enable-debug],
+         [Enable strict compiler checks @<:@no@:>@])],
+      [debug="$enableval"],
+      [debug="no"])
 AM_CONDITIONAL([DEBUG], [test x$debug = xyes])
 
 AC_ARG_ENABLE([rekall_profiles],
-  [AS_HELP_STRING([--enable-rekall-profiles],
-    [Enable using Rekall's JSON profiles])],
-  [rekall="$enableval"],
-  [rekall="yes"])
+      [AS_HELP_STRING([--disable-rekall-profiles],
+         [Disable using Rekall's JSON profiles @<:@no@:>@])],
+      [rekall="$enableval"],
+      [rekall="yes"])
 
 AC_ARG_ENABLE([config-file],
-  [AS_HELP_STRING([--disable-config-file],
-    [Disable using LibVMI config files @<:@no@:>@])],
-  [configfile="$enableval"],
-  [configfile="yes"])
+      [AS_HELP_STRING([--disable-config-file],
+         [Disable using LibVMI config files @<:@no@:>@])],
+      [configfile="$enableval"],
+      [configfile="yes"])
 AM_CONDITIONAL([CONFIGFILE], [test x$configfile = xyes])
+
+AC_ARG_ENABLE([safety-checks],
+      [AS_HELP_STRING([--disable-safety-checks],
+         [Disable API safety checks @<:@no@:>@])],
+      [enable_safety_checks=$enableval],
+      [enable_safety_checks=yes])
 
 dnl -----------------------------------------------
 dnl Checks for programs, libraries, etc.
@@ -324,7 +330,7 @@ missing='no'
 [fi]
 AM_CONDITIONAL([REKALL_PROFILES], [test x"$rekall" = xyes])
 
-[if test "$enable_address_cache" = "yes"]
+[if test x"$enable_address_cache" = "xyes"]
 [then]
         AC_DEFINE([ENABLE_ADDRESS_CACHE], [1], [Enable or disable the address cache (v2p, pid, etc)])
 [fi]
@@ -333,6 +339,11 @@ AM_CONDITIONAL([REKALL_PROFILES], [test x"$rekall" = xyes])
 [then]
         AC_DEFINE([ENABLE_PAGE_CACHE], [1], [Enable or disable the page cache])
         AC_DEFINE_UNQUOTED([MAX_PAGE_CACHE_SIZE], [$enable_page_cache], [Max number of pages held in page cache])
+[fi]
+
+[if test x"$enable_safety_checks" = "xyes"]
+[then]
+        AC_DEFINE([ENABLE_SAFETY_CHECKS], [1], [Enable API safety checks])
 [fi]
 
 dnl -----------------------------------------------

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -33,8 +33,10 @@
 uint8_t vmi_get_address_width(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return 0;
+#endif
 
     switch (vmi->page_mode) {
         case VMI_PM_AARCH64:
@@ -53,7 +55,11 @@ os_t
 vmi_get_ostype(
     vmi_instance_t vmi)
 {
-    return (NULL == vmi) ? VMI_OS_UNKNOWN : vmi->os_type;
+    return
+#ifdef ENABLE_SAFETY_CHECKS
+        (NULL == vmi) ? VMI_OS_UNKNOWN :
+#endif
+        vmi->os_type;
 }
 
 win_ver_t
@@ -66,6 +72,7 @@ vmi_get_winver(
 #else
     windows_instance_t windows_instance = NULL;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return VMI_OS_WINDOWS_NONE;
 
@@ -75,6 +82,7 @@ vmi_get_winver(
     if (!vmi->os_data) {
         return VMI_OS_WINDOWS_NONE;
     }
+#endif
 
     windows_instance = vmi->os_data;
 
@@ -90,8 +98,11 @@ const char *
 vmi_get_winver_str(
     vmi_instance_t vmi)
 {
+
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return "VMI_OS_WINDOWS_NONE";
+#endif
 
     win_ver_t ver = vmi_get_winver(vmi);
 
@@ -136,11 +147,13 @@ vmi_get_offset(
     const char *offset_name,
     addr_t *offset)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return VMI_FAILURE;
 
     if ( !vmi->os_interface || !vmi->os_interface->os_get_offset )
         return VMI_FAILURE;
+#endif
 
     return vmi->os_interface->os_get_offset(vmi, offset_name, offset);
 }
@@ -152,8 +165,11 @@ vmi_get_kernel_struct_offset(
     const char* member,
     addr_t *addr)
 {
+
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !addr)
         return 0;
+#endif
 
     return vmi->os_interface->os_get_kernel_struct_offset(vmi, symbol, member, addr);
 }
@@ -162,8 +178,10 @@ uint64_t
 vmi_get_memsize(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return 0;
+#endif
 
     if ( VMI_FAILURE == driver_get_memsize(vmi, &vmi->allocated_ram_size, &vmi->max_physical_address) )
         return 0;
@@ -175,8 +193,10 @@ addr_t
 vmi_get_max_physical_address(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return 0;
+#endif
 
     if ( VMI_FAILURE == driver_get_memsize(vmi, &vmi->allocated_ram_size, &vmi->max_physical_address) )
         return 0;
@@ -188,8 +208,10 @@ unsigned int
 vmi_get_num_vcpus(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return 0;
+#endif
 
     return vmi->num_vcpus;
 }
@@ -201,8 +223,10 @@ vmi_get_vcpureg(
     reg_t reg,
     unsigned long vcpu)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return VMI_FAILURE;
+#endif
 
     return driver_get_vcpureg(vmi, value, reg, vcpu);
 }
@@ -213,8 +237,10 @@ vmi_get_vcpuregs(
     registers_t *regs,
     unsigned long vcpu)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !regs)
         return VMI_FAILURE;
+#endif
 
     return driver_get_vcpuregs(vmi, regs, vcpu);
 }
@@ -226,8 +252,10 @@ vmi_set_vcpureg(
     reg_t reg,
     unsigned long vcpu)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return VMI_FAILURE;
+#endif
 
     return driver_set_vcpureg(vmi, value, reg, vcpu);
 }
@@ -238,8 +266,10 @@ vmi_set_vcpuregs(
     registers_t *regs,
     unsigned long vcpu)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !regs)
         return VMI_FAILURE;
+#endif
 
     return driver_set_vcpuregs(vmi, regs, vcpu);
 }
@@ -248,8 +278,10 @@ status_t
 vmi_pause_vm(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return VMI_FAILURE;
+#endif
 
     return driver_pause_vm(vmi);
 }
@@ -258,8 +290,10 @@ status_t
 vmi_resume_vm(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return VMI_FAILURE;
+#endif
 
     return driver_resume_vm(vmi);
 }
@@ -271,8 +305,10 @@ vmi_get_name(
     /* memory for name is allocated at the driver level */
     char *name = NULL;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return NULL;
+#endif
 
     if (VMI_FAILURE == driver_get_name(vmi, &name)) {
         return NULL;
@@ -285,8 +321,10 @@ const char *
 vmi_get_rekall_path(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return NULL;
+#endif
 
     switch (vmi_get_ostype(vmi)) {
         case VMI_OS_LINUX:
@@ -304,8 +342,10 @@ vmi_get_vmid(
 {
     uint64_t domid = VMI_INVALID_DOMID;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return 0;
+#endif
 
     if (VMI_INVALID_DOMID == (domid = driver_get_id(vmi))) {
         char *name = vmi_get_name(vmi);
@@ -326,8 +366,10 @@ vmi_translate_ksym2v(
     status_t status = VMI_FAILURE;
     addr_t address = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !symbol || !vaddr)
         return VMI_FAILURE;
+#endif
 
     status = sym_cache_get(vmi, 0, 0, symbol, &address);
 
@@ -359,8 +401,10 @@ vmi_translate_sym2v(
     addr_t address = 0;
     addr_t dtb = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !ctx || !symbol || !vaddr)
         return VMI_FAILURE;
+#endif
 
     switch (ctx->translate_mechanism) {
         case VMI_TM_PROCESS_PID:
@@ -400,8 +444,10 @@ vmi_translate_v2sym(
     char *ret = NULL;
     addr_t dtb = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !ctx)
         return NULL;
+#endif
 
     switch (ctx->translate_mechanism) {
         case VMI_TM_PROCESS_PID:
@@ -439,8 +485,10 @@ vmi_translate_v2ksym(
     char *ret = NULL;
     addr_t dtb = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !ctx)
         return NULL;
+#endif
 
     switch (ctx->translate_mechanism) {
         case VMI_TM_PROCESS_PID:
@@ -478,11 +526,13 @@ vmi_pid_to_dtb(
     status_t ret = VMI_FAILURE;
     addr_t _dtb = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !dtb)
         return VMI_FAILURE;
 
     if (!vmi->os_interface)
         return VMI_FAILURE;
+#endif
 
     if ( !pid ) {
         *dtb = vmi->kpgd;
@@ -512,8 +562,10 @@ vmi_dtb_to_pid(
     status_t ret = VMI_FAILURE;
     vmi_pid_t _pid = -1;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !pid)
         return VMI_FAILURE;
+#endif
 
     if (vmi->os_interface && vmi->os_interface->os_pgd_to_pid)
         ret = vmi->os_interface->os_pgd_to_pid(vmi, dtb, &_pid);
@@ -524,23 +576,27 @@ vmi_dtb_to_pid(
 
 void* vmi_read_page (vmi_instance_t vmi, addr_t frame_num)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return NULL;
+#endif
 
     return driver_read_page(vmi, frame_num);
 }
 
 GSList* vmi_get_va_pages(vmi_instance_t vmi, addr_t dtb)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi)
         return NULL;
 
-    if (vmi->arch_interface && vmi->arch_interface->get_va_pages) {
-        return vmi->arch_interface->get_va_pages(vmi, dtb);
-    } else {
+    if (!vmi->arch_interface || !vmi->arch_interface->get_va_pages) {
         dbprint(VMI_DEBUG_PTLOOKUP, "Invalid or not supported paging mode during get_va_pages\n");
         return NULL;
     }
+#endif
+
+    return vmi->arch_interface->get_va_pages(vmi, dtb);
 }
 
 status_t
@@ -550,8 +606,10 @@ vmi_pagetable_lookup(
     addr_t vaddr,
     addr_t *paddr)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !paddr)
         return VMI_FAILURE;
+#endif
 
     return vmi_pagetable_lookup_cache(vmi, dtb, vaddr, paddr);
 }
@@ -573,7 +631,10 @@ status_t vmi_pagetable_lookup_cache(
                          .dtb = dtb
                        };
 
-    if (!vmi || !paddr) return ret;
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi || !paddr)
+        return ret;
+#endif
 
     *paddr = 0;
 
@@ -615,7 +676,10 @@ status_t vmi_pagetable_lookup_extended(
 {
     status_t ret = VMI_FAILURE;
 
-    if (!vmi || !info) return ret;
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi || !info)
+        return ret;
+#endif
 
     memset(info, 0, sizeof(page_info_t));
     info->vaddr = vaddr;
@@ -641,6 +705,7 @@ vmi_translate_kv2p(
     addr_t virt_address,
     addr_t *paddr)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !paddr)
         return VMI_FAILURE;
 
@@ -648,6 +713,7 @@ vmi_translate_kv2p(
         dbprint(VMI_DEBUG_PTLOOKUP, "--early bail on v2p lookup because the kernel page global directory is unknown\n");
         return VMI_FAILURE;
     }
+#endif
 
     return vmi_pagetable_lookup(vmi, vmi->kpgd, virt_address, paddr);
 }
@@ -662,9 +728,11 @@ vmi_translate_uv2p(
     status_t ret = VMI_FAILURE;
     addr_t dtb = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi || !paddr) {
         return VMI_FAILURE;
     }
+#endif
 
     if ( VMI_FAILURE == vmi_pid_to_dtb(vmi, pid, &dtb) || !dtb ) {
         dbprint(VMI_DEBUG_PTLOOKUP, "--early bail on v2p lookup because dtb not found\n");
@@ -697,17 +765,16 @@ vmi_get_linux_sysmap(
 {
     linux_instance_t linux_instance = NULL;
 
-    if (!vmi) {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi)
         return NULL;
-    }
 
-    if (VMI_OS_LINUX != vmi->os_type) {
+    if (VMI_OS_LINUX != vmi->os_type)
         return NULL;
-    }
 
-    if (!vmi->os_data) {
+    if (!vmi->os_data)
         return NULL;
-    }
+#endif
 
     linux_instance = vmi->os_data;
 
@@ -721,17 +788,16 @@ vmi_get_freebsd_sysmap(
 {
     freebsd_instance_t freebsd_instance = NULL;
 
-    if (!vmi) {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi)
         return NULL;
-    }
 
-    if (VMI_OS_FREEBSD != vmi->os_type) {
+    if (VMI_OS_FREEBSD != vmi->os_type)
         return NULL;
-    }
 
-    if (!vmi->os_data) {
+    if (!vmi->os_data)
         return NULL;
-    }
+#endif
 
     freebsd_instance = vmi->os_data;
 

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -39,7 +39,9 @@ static inline void
 driver_destroy(
     vmi_instance_t vmi)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (vmi->driver.initialized && vmi->driver.destroy_ptr)
+#endif
         vmi->driver.destroy_ptr(vmi);
 
     bzero(&vmi->driver, sizeof(driver_interface_t));
@@ -50,13 +52,14 @@ driver_get_id_from_name(
     vmi_instance_t vmi,
     const char *name)
 {
-    if (vmi->driver.initialized && vmi->driver.get_id_from_name_ptr) {
-        return vmi->driver.get_id_from_name_ptr(vmi, name);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_get_id_from_name function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_id_from_name_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_id_from_name function not implemented.\n");
         return 0;
     }
+#endif
+
+    return vmi->driver.get_id_from_name_ptr(vmi, name);
 }
 
 static inline status_t
@@ -65,25 +68,28 @@ driver_get_name_from_id(
     uint64_t domid,
     char **name)
 {
-    if (vmi->driver.initialized && vmi->driver.get_name_from_id_ptr) {
-        return vmi->driver.get_name_from_id_ptr(vmi, domid, name);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_get_name_from_id function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_name_from_id_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_name_from_id function not implemented.\n");
         return 0;
     }
+#endif
+
+    return vmi->driver.get_name_from_id_ptr(vmi, domid, name);
 }
 
 static inline uint64_t
 driver_get_id(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.get_id_ptr) {
-        return vmi->driver.get_id_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_id_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_id function not implemented.\n");
         return 0;
     }
+#endif
+
+    return vmi->driver.get_id_ptr(vmi);
 }
 
 static inline void
@@ -91,12 +97,14 @@ driver_set_id(
     vmi_instance_t vmi,
     uint64_t id)
 {
-    if (vmi->driver.initialized && vmi->driver.set_id_ptr) {
-        return vmi->driver.set_id_ptr(vmi, id);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_id_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_id function not implemented.\n");
         return;
     }
+#endif
+
+    return vmi->driver.set_id_ptr(vmi, id);
 }
 
 static inline status_t
@@ -104,12 +112,14 @@ driver_check_id(
     vmi_instance_t vmi,
     uint64_t id)
 {
-    if (vmi->driver.initialized && vmi->driver.check_id_ptr) {
-        return vmi->driver.check_id_ptr(vmi, id);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.check_id_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_check_id function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.check_id_ptr(vmi, id);
 }
 
 static inline status_t
@@ -117,12 +127,14 @@ driver_get_name(
     vmi_instance_t vmi,
     char **name)
 {
-    if (vmi->driver.initialized && vmi->driver.get_name_ptr) {
-        return vmi->driver.get_name_ptr(vmi, name);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_name_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_name function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.get_name_ptr(vmi, name);
 }
 
 static inline void
@@ -130,12 +142,14 @@ driver_set_name(
     vmi_instance_t vmi,
     const char *name)
 {
-    if (vmi->driver.initialized && vmi->driver.set_name_ptr) {
-        return vmi->driver.set_name_ptr(vmi, name);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_name_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_name function not implemented.\n");
         return;
     }
+#endif
+
+    return vmi->driver.set_name_ptr(vmi, name);
 }
 
 static inline status_t
@@ -144,13 +158,14 @@ driver_get_memsize(
     uint64_t *allocated_ram_size,
     addr_t *max_physical_address)
 {
-    if (vmi->driver.initialized && vmi->driver.get_memsize_ptr) {
-        return vmi->driver.get_memsize_ptr(vmi, allocated_ram_size, max_physical_address);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_get_memsize function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_memsize_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_memsize function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.get_memsize_ptr(vmi, allocated_ram_size, max_physical_address);
 }
 
 static inline status_t
@@ -160,13 +175,14 @@ driver_get_vcpureg(
     reg_t reg,
     unsigned long vcpu)
 {
-    if (vmi->driver.initialized && vmi->driver.get_vcpureg_ptr) {
-        return vmi->driver.get_vcpureg_ptr(vmi, value, reg, vcpu);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_get_vcpureg function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_vcpureg_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_vcpureg function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.get_vcpureg_ptr(vmi, value, reg, vcpu);
 }
 
 static inline status_t
@@ -175,13 +191,14 @@ driver_get_vcpuregs(
     registers_t* regs,
     unsigned long vcpu)
 {
-    if (vmi->driver.initialized && vmi->driver.get_vcpuregs_ptr) {
-        return vmi->driver.get_vcpuregs_ptr(vmi, regs, vcpu);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_get_vcpuregs function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_vcpuregs_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_vcpuregs function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.get_vcpuregs_ptr(vmi, regs, vcpu);
 }
 
 static inline status_t
@@ -191,12 +208,14 @@ driver_set_vcpureg(
     reg_t reg,
     unsigned long vcpu)
 {
-    if (vmi->driver.initialized && vmi->driver.set_vcpureg_ptr) {
-        return vmi->driver.set_vcpureg_ptr(vmi, value, reg, vcpu);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_vcpureg_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_vcpureg function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_vcpureg_ptr(vmi, value, reg, vcpu);
 }
 
 static inline status_t
@@ -205,12 +224,14 @@ driver_set_vcpuregs(
     registers_t *regs,
     unsigned long vcpu)
 {
-    if (vmi->driver.initialized && vmi->driver.set_vcpuregs_ptr) {
-        return vmi->driver.set_vcpuregs_ptr(vmi, regs, vcpu);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_vcpuregs_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_vcpuregs function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_vcpuregs_ptr(vmi, regs, vcpu);
 }
 
 static inline void *
@@ -218,13 +239,14 @@ driver_read_page(
     vmi_instance_t vmi,
     addr_t page)
 {
-    if (vmi->driver.initialized && vmi->driver.read_page_ptr) {
-        return vmi->driver.read_page_ptr(vmi, page);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_read_page function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.read_page_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_read_page function not implemented.\n");
         return NULL;
     }
+#endif
+
+    return vmi->driver.read_page_ptr(vmi, page);
 }
 
 static inline status_t
@@ -234,73 +256,84 @@ driver_write(
     void *buf,
     uint32_t length)
 {
-    if (vmi->driver.initialized && vmi->driver.write_ptr) {
-        return vmi->driver.write_ptr(vmi, paddr, buf, length);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.write_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_write function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.write_ptr(vmi, paddr, buf, length);
 }
 
 static inline int
 driver_is_pv(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.is_pv_ptr) {
-        return vmi->driver.is_pv_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.is_pv_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_is_pv function not implemented.\n");
         return 0;
     }
+#endif
+
+    return vmi->driver.is_pv_ptr(vmi);
 }
 
 static inline status_t
 driver_pause_vm(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.pause_vm_ptr) {
-        return vmi->driver.pause_vm_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.pause_vm_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_pause_vm function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.pause_vm_ptr(vmi);
 }
 
 static inline status_t
 driver_resume_vm(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.resume_vm_ptr) {
-        return vmi->driver.resume_vm_ptr(vmi);
-    } else {
-        dbprint
-        (VMI_DEBUG_DRIVER, "WARNING: driver_resume_vm function not implemented.\n");
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.resume_vm_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_resume_vm function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.resume_vm_ptr(vmi);
 }
 
 static inline status_t
 driver_shm_snapshot_vm(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.create_shm_snapshot_ptr) {
-        return vmi->driver.create_shm_snapshot_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.create_shm_snapshot_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_shm_snapshot_vm function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.create_shm_snapshot_ptr(vmi);
 }
 
 static inline status_t
 driver_destroy_shm_snapshot_vm(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.destroy_shm_snapshot_ptr) {
-        return vmi->driver.destroy_shm_snapshot_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.destroy_shm_snapshot_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_destroy_shm_snapshot_vm function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.destroy_shm_snapshot_ptr(vmi);
 }
 
 static inline size_t
@@ -310,13 +343,14 @@ driver_get_dgpma(
     void **medial_addr_ptr,
     size_t count)
 {
-    if (vmi->driver.initialized && vmi->driver.get_dgpma_ptr) {
-        return vmi->driver.get_dgpma_ptr(vmi, paddr, medial_addr_ptr, count);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_dgpma_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: get_dgpma_ptr function not implemented.\n");
         return 0;
     }
-    return 0;
+#endif
+
+    return vmi->driver.get_dgpma_ptr(vmi, paddr, medial_addr_ptr, count);
 }
 
 static inline size_t
@@ -327,13 +361,14 @@ driver_get_dgvma(
     void** medial_addr_ptr,
     size_t count)
 {
-    if (vmi->driver.initialized && vmi->driver.get_dgvma_ptr) {
-        return vmi->driver.get_dgvma_ptr(vmi, vaddr, pid, medial_addr_ptr, count);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_dgvma_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: get_dgvma_ptr function not implemented.\n");
         return 0;
     }
-    return 0;
+#endif
+
+    return vmi->driver.get_dgvma_ptr(vmi, vaddr, pid, medial_addr_ptr, count);
 }
 
 static inline status_t
@@ -341,24 +376,28 @@ driver_events_listen(
     vmi_instance_t vmi,
     uint32_t timeout)
 {
-    if (vmi->driver.initialized && vmi->driver.events_listen_ptr) {
-        return vmi->driver.events_listen_ptr(vmi, timeout);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.events_listen_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_events_listen function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.events_listen_ptr(vmi, timeout);
 }
 
 static inline int
 driver_are_events_pending(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.are_events_pending_ptr) {
-        return vmi->driver.are_events_pending_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.are_events_pending_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_are_events_pending function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.are_events_pending_ptr(vmi);
 }
 
 static inline status_t
@@ -366,12 +405,14 @@ driver_set_reg_access(
     vmi_instance_t vmi,
     reg_event_t *event)
 {
-    if (vmi->driver.initialized && vmi->driver.set_reg_access_ptr) {
-        return vmi->driver.set_reg_access_ptr(vmi, event);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_reg_access_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_reg_w_access function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_reg_access_ptr(vmi, event);
 }
 
 static inline status_t
@@ -380,12 +421,14 @@ driver_set_intr_access(
     interrupt_event_t *event,
     uint8_t enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_intr_access_ptr) {
-        return vmi->driver.set_intr_access_ptr(vmi, event, enabled);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_intr_access_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_intr_access function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_intr_access_ptr(vmi, event, enabled);
 }
 
 static inline status_t
@@ -395,12 +438,14 @@ driver_set_mem_access(
     vmi_mem_access_t page_access_flag,
     uint16_t vmm_pagetable_id)
 {
-    if (vmi->driver.initialized && vmi->driver.set_mem_access_ptr) {
-        return vmi->driver.set_mem_access_ptr(vmi, gpfn, page_access_flag, vmm_pagetable_id);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_mem_access_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_mem_access function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_mem_access_ptr(vmi, gpfn, page_access_flag, vmm_pagetable_id);
 }
 
 static inline status_t
@@ -408,12 +453,14 @@ driver_start_single_step(
     vmi_instance_t vmi,
     single_step_event_t *event)
 {
-    if (vmi->driver.initialized && vmi->driver.start_single_step_ptr) {
-        return vmi->driver.start_single_step_ptr(vmi, event);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.start_single_step_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_start_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.start_single_step_ptr(vmi, event);
 }
 
 static inline status_t
@@ -421,24 +468,28 @@ driver_stop_single_step(
     vmi_instance_t vmi,
     unsigned long vcpu)
 {
-    if (vmi->driver.initialized && vmi->driver.stop_single_step_ptr) {
-        return vmi->driver.stop_single_step_ptr(vmi, vcpu);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.stop_single_step_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_stop_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.stop_single_step_ptr(vmi, vcpu);
 }
 
 static inline status_t
 driver_shutdown_single_step(
     vmi_instance_t vmi)
 {
-    if (vmi->driver.initialized && vmi->driver.shutdown_single_step_ptr) {
-        return vmi->driver.shutdown_single_step_ptr(vmi);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.shutdown_single_step_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_shutdown_single_step function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.shutdown_single_step_ptr(vmi);
 }
 
 static inline status_t
@@ -446,12 +497,14 @@ driver_set_guest_requested_event(
     vmi_instance_t vmi,
     bool enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_guest_requested_ptr)
-        return vmi->driver.set_guest_requested_ptr(vmi, enabled);
-    else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_guest_requested_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_guest_requested function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_guest_requested_ptr(vmi, enabled);
 }
 
 static inline status_t
@@ -459,12 +512,14 @@ driver_set_cpuid_event(
     vmi_instance_t vmi,
     bool enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_cpuid_event_ptr)
-        return vmi->driver.set_cpuid_event_ptr(vmi, enabled);
-    else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_cpuid_event_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_cpuid_event function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_cpuid_event_ptr(vmi, enabled);
 }
 
 static inline status_t
@@ -472,12 +527,14 @@ driver_set_debug_event(
     vmi_instance_t vmi,
     bool enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_debug_event_ptr)
-        return vmi->driver.set_debug_event_ptr(vmi, enabled);
-    else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_debug_event_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_debug_event function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_debug_event_ptr(vmi, enabled);
 }
 
 static inline status_t
@@ -485,12 +542,14 @@ driver_set_privcall_event(
     vmi_instance_t vmi,
     bool enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_privcall_event_ptr)
-        return vmi->driver.set_privcall_event_ptr(vmi, enabled);
-    else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_privcall_event_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_privcall_event function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_privcall_event_ptr(vmi, enabled);
 }
 
 static inline status_t
@@ -498,12 +557,14 @@ driver_set_desc_access_event(
     vmi_instance_t vmi,
     bool enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_desc_access_event_ptr)
-        return vmi->driver.set_desc_access_event_ptr(vmi, enabled);
-    else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_desc_access_event_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_desc_access_event function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_desc_access_event_ptr(vmi, enabled);
 }
 
 static inline status_t
@@ -511,12 +572,14 @@ driver_set_failed_emulation_event(
     vmi_instance_t vmi,
     bool enabled)
 {
-    if (vmi->driver.initialized && vmi->driver.set_failed_emulation_event_ptr)
-        return vmi->driver.set_failed_emulation_event_ptr(vmi, enabled);
-    else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_failed_emulation_event_ptr) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_failed_emulation_event function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_failed_emulation_event_ptr(vmi, enabled);
 }
 
 static inline status_t
@@ -524,12 +587,14 @@ driver_slat_get_domain_state (
     vmi_instance_t vmi,
     bool *state )
 {
-    if (vmi->driver.initialized && vmi->driver.slat_get_domain_state_ptr ) {
-        return vmi->driver.slat_get_domain_state_ptr (vmi, state);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.slat_get_domain_state_ptr ) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_get_domain_state function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.slat_get_domain_state_ptr (vmi, state);
 }
 
 static inline status_t
@@ -537,12 +602,14 @@ driver_slat_set_domain_state (
     vmi_instance_t vmi,
     bool state )
 {
-    if (vmi->driver.initialized && vmi->driver.slat_set_domain_state_ptr ) {
-        return vmi->driver.slat_set_domain_state_ptr (vmi, state);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.slat_set_domain_state_ptr ) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_set_domain_state function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.slat_set_domain_state_ptr (vmi, state);
 }
 
 static inline status_t
@@ -550,12 +617,14 @@ driver_slat_create (
     vmi_instance_t vmi,
     uint16_t *slat_idx )
 {
-    if (vmi->driver.initialized && vmi->driver.slat_create_ptr) {
-        return vmi->driver.slat_create_ptr (vmi, slat_idx);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.slat_create_ptr) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_create function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.slat_create_ptr (vmi, slat_idx);
 }
 
 static inline status_t
@@ -563,12 +632,14 @@ driver_slat_destroy (
     vmi_instance_t vmi,
     uint16_t slat_idx )
 {
-    if (vmi->driver.initialized && vmi->driver.slat_destroy_ptr) {
-        return vmi->driver.slat_destroy_ptr (vmi, slat_idx);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.slat_destroy_ptr) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_destroy function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.slat_destroy_ptr (vmi, slat_idx);
 }
 
 static inline status_t
@@ -576,12 +647,14 @@ driver_slat_switch (
     vmi_instance_t vmi,
     uint16_t slat_idx )
 {
-    if (vmi->driver.initialized && vmi->driver.slat_switch_ptr) {
-        return vmi->driver.slat_switch_ptr (vmi, slat_idx);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.slat_switch_ptr) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_switch function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.slat_switch_ptr (vmi, slat_idx);
 }
 
 static inline status_t
@@ -591,12 +664,14 @@ driver_slat_change_gfn (
     addr_t old_gfn,
     addr_t new_gfn)
 {
-    if (vmi->driver.initialized && vmi->driver.slat_change_gfn_ptr) {
-        return vmi->driver.slat_change_gfn_ptr (vmi, slat_idx, old_gfn, new_gfn);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.slat_change_gfn_ptr) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_change_gfn function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.slat_change_gfn_ptr (vmi, slat_idx, old_gfn, new_gfn);
 }
 
 static inline status_t
@@ -604,12 +679,14 @@ driver_set_access_listener_required(
     vmi_instance_t vmi,
     bool required)
 {
-    if (vmi->driver.initialized && vmi->driver.set_access_required_ptr) {
-        return vmi->driver.set_access_required_ptr (vmi, required);
-    } else {
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_access_required_ptr) {
         dbprint (VMI_DEBUG_DRIVER, "WARNING: driver_slat_change_gfn function not implemented.\n");
         return VMI_FAILURE;
     }
+#endif
+
+    return vmi->driver.set_access_required_ptr (vmi, required);
 }
 
 #endif /* DRIVER_WRAPPER_H */

--- a/libvmi/driver/xen/xen_events_48.c
+++ b/libvmi/driver/xen/xen_events_48.c
@@ -299,8 +299,10 @@ status_t process_register(vmi_instance_t vmi,
     gint lookup = reg;
     vmi_event_t * event = g_hash_table_lookup(vmi->reg_events, &lookup);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event )
         return VMI_FAILURE;
+#endif
 
     switch ( reg ) {
         case MSR_ALL:
@@ -433,10 +435,12 @@ status_t process_single_step_event(vmi_instance_t vmi,
     gint lookup = req->vcpu_id;
     vmi_event_t * event = g_hash_table_lookup(vmi->ss_events, &lookup);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no singlestep handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     event->ss_event.gfn = req->u.singlestep.gfn;
     event->ss_event.offset = req->data.regs.x86.rip & VMI_BIT_MASK(0,11);
@@ -458,10 +462,12 @@ static status_t process_guest_requested_event(vmi_instance_t vmi,
 {
     vmi_event_t * event = vmi->guest_requested_event;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no guest requested event handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
 #if defined(I386) || defined(X86_64)
     event->x86_regs = (x86_registers_t *)&req->data.regs.x86;
@@ -485,10 +491,12 @@ status_t process_cpuid_event(vmi_instance_t vmi,
 {
     vmi_event_t * event = vmi->cpuid_event;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no CPUID event handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     event->x86_regs = (x86_registers_t *)&req->data.regs.x86;
     event->slat_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
@@ -515,10 +523,12 @@ status_t process_debug_event(vmi_instance_t vmi,
 {
     vmi_event_t * event = vmi->debug_event;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no debug event handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     event->x86_regs = (x86_registers_t *)&req->data.regs.x86;
     event->slat_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
@@ -566,10 +576,12 @@ status_t process_privcall_event(vmi_instance_t vmi,
 {
     vmi_event_t * event = vmi->privcall_event;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no privileged call event handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     event->arm_regs = (arm_registers_t *)&req->data.regs.arm;
     event->slat_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
@@ -603,10 +615,12 @@ status_t process_desc_access_event(vmi_instance_t vmi,
 {
     vmi_event_t * event = vmi->descriptor_access_event;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no descriptor access event handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     event->x86_regs = (x86_registers_t *)&req->data.regs.x86;
     event->slat_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
@@ -631,10 +645,12 @@ status_t process_unimplemented_emul(vmi_instance_t vmi,
 {
     vmi_event_t * event = vmi->failed_emulation_event;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !event ) {
         errprint("%s error: no unimplemented emulation event handler is registered in LibVMI\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     event->x86_regs = (x86_registers_t *)&req->data.regs.x86;
     event->slat_id = (req->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ? req->altp2m_idx : 0;
@@ -785,6 +801,7 @@ status_t xen_set_reg_access_48(vmi_instance_t vmi, reg_event_t *event)
     xen_instance_t * xen = xen_get_instance(vmi);
     bool sync = !event->async;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         goto done;
@@ -794,6 +811,7 @@ status_t xen_set_reg_access_48(vmi_instance_t vmi, reg_event_t *event)
         errprint("%s error: invalid domid\n", __FUNCTION__);
         goto done;
     }
+#endif
 
     switch ( event->reg ) {
         case CR0:
@@ -926,21 +944,19 @@ status_t xen_set_mem_access_48(vmi_instance_t vmi, addr_t gpfn,
     xenmem_access_t access;
     xen_instance_t *xen = xen_get_instance(vmi);
     xc_interface * xch = xen_get_xchandle(vmi);
-    xen_events_t * xe = xen_get_events(vmi);
     domid_t dom = xen_get_domainid(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( !xe ) {
-        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
         return VMI_FAILURE;
     }
     if ( dom == (domid_t)VMI_INVALID_DOMID ) {
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
+
     if ( VMI_FAILURE == convert_vmi_flags_to_xenmem(page_access_flag, &access) )
         return VMI_FAILURE;
 
@@ -964,6 +980,7 @@ static status_t xen_set_int3_access(vmi_instance_t vmi, bool enable)
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xen ) {
         errprint("%s error: invalid xen_instance_t handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -977,13 +994,14 @@ static status_t xen_set_int3_access(vmi_instance_t vmi, bool enable)
         return VMI_FAILURE;
     }
 
+    if ( enable == xe->vm_event.monitor_intr_on )
+        return VMI_FAILURE;
+#endif
+
     if ( !(xe->vm_event.monitor_capabilities & (1u << XEN_DOMCTL_MONITOR_EVENT_SOFTWARE_BREAKPOINT)) ) {
         errprint("%s error: no system support for event type\n", __FUNCTION__);
         return VMI_FAILURE;
     }
-
-    if ( enable == xe->vm_event.monitor_intr_on )
-        return VMI_FAILURE;
 
     if ( xen->libxcw.xc_monitor_software_breakpoint(xch, dom, enable) )
         return VMI_FAILURE;
@@ -1104,7 +1122,7 @@ status_t xen_set_guest_requested_event_48(vmi_instance_t vmi, bool enabled)
     int rc;
     xen_instance_t *xen = xen_get_instance(vmi);
 
-    if ( xen->major_version != 4 || xen->minor_version < 5 )
+    if ( xen->major_version != 4 || xen->minor_version < 8 )
         return VMI_FAILURE;
 
     if ( !enabled && !vmi->guest_requested_event )
@@ -1176,9 +1194,7 @@ status_t xen_set_privcall_event_48(vmi_instance_t vmi, bool enabled)
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
 
-    if ( xen->major_version != 4 || xen->minor_version < 8 )
-        return VMI_FAILURE;
-
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -1188,6 +1204,10 @@ status_t xen_set_privcall_event_48(vmi_instance_t vmi, bool enabled)
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
+
+    if ( xen->major_version != 4 || xen->minor_version < 8 )
+        return VMI_FAILURE;
 
     if ( !(xe->vm_event.monitor_capabilities & (1u << XEN_DOMCTL_MONITOR_EVENT_PRIVILEGED_CALL)) ) {
         errprint("%s error: no system support for event type\n", __FUNCTION__);
@@ -1260,10 +1280,12 @@ int xen_are_events_pending_48(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xe ) {
         errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
         return -1;
     }
+#endif
 
     return RING_HAS_UNCONSUMED_REQUESTS(&xe->vm_event.back_ring_48);
 
@@ -1271,7 +1293,6 @@ int xen_are_events_pending_48(vmi_instance_t vmi)
 
 status_t xen_events_listen_48(vmi_instance_t vmi, uint32_t timeout)
 {
-    xc_interface *xch = xen_get_xchandle(vmi);
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
     vm_event_48_request_t req;
@@ -1280,18 +1301,16 @@ status_t xen_events_listen_48(vmi_instance_t vmi, uint32_t timeout)
     int rc = -1;
     status_t vrc = VMI_SUCCESS;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xen ) {
         errprint("%s error: invalid xen_instance_t handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( !xch ) {
-        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return VMI_FAILURE;
     }
     if ( !xe ) {
         errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     if (!vmi->shutting_down && timeout > 0) {
         dbprint(VMI_DEBUG_XEN, "--Waiting for xen events...(%"PRIu32" ms)\n", timeout);
@@ -1348,6 +1367,7 @@ void xen_events_destroy_48(vmi_instance_t vmi)
     xen_events_t * xe = xen_get_events(vmi);
     domid_t dom = xen_get_domainid(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xen ) {
         errprint("%s error: invalid xen_instance_t handle\n", __FUNCTION__);
         return;
@@ -1364,7 +1384,7 @@ void xen_events_destroy_48(vmi_instance_t vmi)
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return;
     }
-
+#endif
 
     xc_dominfo_t info = {0};
     rc = xen->libxcw.xc_domain_getinfo(xch, dom, 1, &info);
@@ -1440,6 +1460,7 @@ status_t xen_init_events_48(
     domid_t dom = xen_get_domainid(vmi);
     int rc;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xen ) {
         errprint("%s error: invalid xen_instance_t handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -1452,6 +1473,7 @@ status_t xen_init_events_48(
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     // Wire up the functions
     vmi->driver.events_listen_ptr = &xen_events_listen_48;

--- a/libvmi/driver/xen/xen_events_legacy.c
+++ b/libvmi/driver/xen/xen_events_legacy.c
@@ -163,6 +163,7 @@ status_t process_interrupt_event(vmi_instance_t vmi, interrupts_t intr,
     xen_instance_t *xen         = xen_get_instance(vmi);
 
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -171,6 +172,7 @@ status_t process_interrupt_event(vmi_instance_t vmi, interrupts_t intr,
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     if (event) {
         event->interrupt_event.gfn = gfn;
@@ -326,21 +328,6 @@ status_t process_mem(vmi_instance_t vmi, bool access_r, bool access_w, bool acce
                      uint64_t gfn, uint64_t offset, bool gla_valid, uint64_t gla,
                      uint32_t vcpu_id, uint32_t *rsp_flags)
 {
-
-    xc_interface * xch;
-    unsigned long dom;
-    xch = xen_get_xchandle(vmi);
-    dom = xen_get_domainid(vmi);
-
-    if ( !xch ) {
-        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( dom == VMI_INVALID_DOMID ) {
-        errprint("%s error: invalid domid\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-
     vmi_event_t *event;
     vmi_mem_access_t out_access = VMI_MEMACCESS_INVALID;
     if (access_r) out_access |= VMI_MEMACCESS_R;
@@ -404,20 +391,6 @@ status_t process_mem(vmi_instance_t vmi, bool access_r, bool access_w, bool acce
 static
 status_t process_single_step_event(vmi_instance_t vmi, uint64_t gfn, uint64_t gla, uint32_t vcpu_id, uint32_t *rsp_flags)
 {
-    xc_interface * xch;
-    unsigned long dom;
-    xch = xen_get_xchandle(vmi);
-    dom = xen_get_domainid(vmi);
-
-    if ( !xch ) {
-        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( dom == VMI_INVALID_DOMID ) {
-        errprint("%s error: invalid domid\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-
     vmi_event_t * event = g_hash_table_lookup(vmi->ss_events, &vcpu_id);
 
     if (event) {
@@ -443,6 +416,7 @@ static status_t xen_set_int3_access(vmi_instance_t vmi, bool enabled)
     unsigned long dom = xen_get_domainid(vmi);
     int param = HVMPME_mode_disabled;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -452,6 +426,7 @@ static status_t xen_set_int3_access(vmi_instance_t vmi, bool enabled)
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     if ( enabled ) {
         param = HVMPME_mode_sync;
@@ -471,6 +446,7 @@ status_t xen_set_reg_access_legacy(vmi_instance_t vmi, reg_event_t *event)
     int value = HVMPME_mode_disabled;
     int hvm_param;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -479,6 +455,7 @@ status_t xen_set_reg_access_legacy(vmi_instance_t vmi, reg_event_t *event)
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     switch (event->in_access) {
         case VMI_REGACCESS_N:
@@ -537,22 +514,19 @@ xen_set_mem_access_legacy(vmi_instance_t vmi, addr_t gpfn,
 {
     int rc;
     xc_interface * xch = xen_get_xchandle(vmi);
-    xen_events_t * xe = xen_get_events(vmi);
     unsigned long dom = xen_get_domainid(vmi);
     xen_instance_t * xen = xen_get_instance(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( !xe ) {
-        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
         return VMI_FAILURE;
     }
     if ( dom == VMI_INVALID_DOMID ) {
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     /*
      * Convert betwen vmi_mem_access_t and mem_access_t
@@ -677,10 +651,12 @@ int xen_are_events_pending_42(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xe ) {
         errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
         return -1;
     }
+#endif
 
     return RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring_42);
 
@@ -690,38 +666,25 @@ int xen_are_events_pending_45(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xe ) {
         errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
         return -1;
     }
+#endif
 
     return RING_HAS_UNCONSUMED_REQUESTS(&xe->mem_event.back_ring_45);
 }
 
 status_t xen_events_listen_42(vmi_instance_t vmi, uint32_t timeout)
 {
-    xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t * xe = xen_get_events(vmi);
-    unsigned long dom = xen_get_domainid(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
     mem_event_42_request_t req;
     mem_event_42_response_t rsp;
 
     int rc = -1;
     status_t vrc = VMI_SUCCESS;
-
-    if ( !xch ) {
-        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( !xe ) {
-        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( dom == VMI_INVALID_DOMID ) {
-        errprint("%s error: invalid domid\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
 
     if (!vmi->shutting_down && timeout > 0) {
         dbprint(VMI_DEBUG_XEN, "--Waiting for xen events...(%"PRIu32" ms)\n", timeout);
@@ -923,9 +886,7 @@ process_requests_45(vmi_instance_t vmi, mem_event_45_request_t *req, mem_event_4
 
 status_t xen_events_listen_45(vmi_instance_t vmi, uint32_t timeout)
 {
-    xc_interface * xch = xen_get_xchandle(vmi);
     xen_events_t *xe = xen_get_events(vmi);
-    unsigned long dom = xen_get_domainid(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
 
     mem_event_45_request_t req;
@@ -933,19 +894,6 @@ status_t xen_events_listen_45(vmi_instance_t vmi, uint32_t timeout)
 
     int rc = -1;
     status_t vrc = VMI_SUCCESS;
-
-    if ( !xch ) {
-        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( !xe ) {
-        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
-    if ( dom == VMI_INVALID_DOMID ) {
-        errprint("%s error: invalid domid\n", __FUNCTION__);
-        return VMI_FAILURE;
-    }
 
     if (!vmi->shutting_down && timeout > 0) {
         dbprint(VMI_DEBUG_XEN, "--Waiting for xen events...(%"PRIu32" ms)\n", timeout);
@@ -997,6 +945,7 @@ void xen_events_destroy_legacy(vmi_instance_t vmi)
     xe = xen_get_events(vmi);
     xen = xen_get_instance(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return;
@@ -1009,6 +958,7 @@ void xen_events_destroy_legacy(vmi_instance_t vmi)
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return;
     }
+#endif
 
     vmi_pause_vm(vmi);
 
@@ -1117,6 +1067,7 @@ status_t xen_init_events_legacy(
     xch = xen_get_xchandle(vmi);
     dom = xen_get_domainid(vmi);
 
+#ifdef ENABLE_SAFETY_CHECKS
     if ( !xch ) {
         errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
         return VMI_FAILURE;
@@ -1125,6 +1076,7 @@ status_t xen_init_events_legacy(
         errprint("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     // Allocate memory
     xe = calloc(1, sizeof(xen_events_t));

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -50,6 +50,7 @@ vmi_read(
     addr_t dtb = 0;
     size_t buf_offset = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (NULL == vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL, returning without read\n", __FUNCTION__);
         goto done;
@@ -64,22 +65,26 @@ vmi_read(
         dbprint(VMI_DEBUG_READ, "--%s: buf passed as NULL, returning without read\n", __FUNCTION__);
         goto done;
     }
+#endif
 
     switch (ctx->translate_mechanism) {
         case VMI_TM_NONE:
             start_addr = ctx->addr;
             break;
         case VMI_TM_KERNEL_SYMBOL:
+#ifdef ENABLE_SAFETY_CHECKS
             if (!vmi->arch_interface || !vmi->os_interface || !vmi->kpgd)
                 goto done;
-
+#endif
             dtb = vmi->kpgd;
             if ( VMI_FAILURE == vmi_translate_ksym2v(vmi, ctx->ksym, &start_addr) )
                 goto done;
             break;
         case VMI_TM_PROCESS_PID:
+#ifdef ENABLE_SAFETY_CHECKS
             if (!vmi->arch_interface || !vmi->os_interface)
                 goto done;
+#endif
 
             if ( !ctx->pid )
                 dtb = vmi->kpgd;
@@ -94,8 +99,10 @@ vmi_read(
             start_addr = ctx->addr;
             break;
         case VMI_TM_PROCESS_DTB:
+#ifdef ENABLE_SAFETY_CHECKS
             if (!vmi->arch_interface)
                 goto done;
+#endif
 
             dtb = ctx->dtb;
             start_addr = ctx->addr;
@@ -244,10 +251,12 @@ vmi_read_addr(
 {
     status_t ret = VMI_FAILURE;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL", __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     switch (vmi->page_mode) {
         case VMI_PM_AARCH64:// intentional fall-through
@@ -289,6 +298,7 @@ vmi_read_str(
 
     rtnval = NULL;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL, returning without read",
                 __FUNCTION__);
@@ -299,6 +309,7 @@ vmi_read_str(
                 __FUNCTION__);
         return NULL;
     }
+#endif
 
     switch (ctx->translate_mechanism) {
         case VMI_TM_NONE:
@@ -381,15 +392,17 @@ vmi_read_unicode_str(
     vmi_instance_t vmi,
     const access_context_t *ctx)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL, returning without read",
                 __FUNCTION__);
         return NULL;
     }
-    if (vmi->os_interface && vmi->os_interface->os_read_unicode_struct)
-        return vmi->os_interface->os_read_unicode_struct(vmi, ctx);
+    if (!vmi->os_interface || !vmi->os_interface->os_read_unicode_struct)
+        return NULL;
+#endif
 
-    return NULL;
+    return vmi->os_interface->os_read_unicode_struct(vmi, ctx);
 }
 
 ///////////////////////////////////////////////////////////
@@ -438,11 +451,13 @@ vmi_read_addr_pa(
 {
     status_t ret = VMI_FAILURE;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL, returning without read",
                 __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     switch (vmi->page_mode) {
         case VMI_PM_AARCH64:// intentional fall-through
@@ -532,11 +547,13 @@ vmi_read_addr_va(
 {
     status_t ret = VMI_FAILURE;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL, returning without read",
                 __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     switch (vmi->page_mode) {
         case VMI_PM_AARCH64:// intentional fall-through
@@ -635,11 +652,13 @@ vmi_read_addr_ksym(
 {
     status_t ret = VMI_FAILURE;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_READ, "--%s: vmi passed as NULL, returning without read",
                 __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     switch (vmi->page_mode) {
         case VMI_PM_AARCH64:// intentional fall-through

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -44,6 +44,7 @@ vmi_write(
     addr_t offset = 0;
     size_t buf_offset = 0;
 
+#ifdef ENABLE_SAFETY_CHECKS
     if (NULL == vmi) {
         dbprint(VMI_DEBUG_WRITE, "--%s: vmi passed as NULL, returning without write\n",
                 __FUNCTION__);
@@ -61,14 +62,17 @@ vmi_write(
                 __FUNCTION__);
         goto done;
     }
+#endif
 
     switch (ctx->translate_mechanism) {
         case VMI_TM_NONE:
             start_addr = ctx->addr;
             break;
         case VMI_TM_KERNEL_SYMBOL:
+#ifdef ENABLE_SAFETY_CHECKS
             if (!vmi->arch_interface || !vmi->os_interface || !vmi->kpgd)
                 goto done;
+#endif
 
             dtb = vmi->kpgd;
             if ( VMI_FAILURE == vmi_translate_ksym2v(vmi, ctx->ksym, &start_addr) )
@@ -76,8 +80,10 @@ vmi_write(
 
             break;
         case VMI_TM_PROCESS_PID:
+#ifdef ENABLE_SAFETY_CHECKS
             if (!vmi->arch_interface || !vmi->os_interface)
                 goto done;
+#endif
 
             if (!ctx->pid)
                 dtb = vmi->kpgd;
@@ -92,8 +98,10 @@ vmi_write(
             start_addr = ctx->addr;
             break;
         case VMI_TM_PROCESS_DTB:
+#ifdef ENABLE_SAFETY_CHECKS
             if (!vmi->arch_interface)
                 goto done;
+#endif
 
             dtb = ctx->dtb;
             start_addr = ctx->addr;
@@ -236,11 +244,13 @@ vmi_write_addr(
     const access_context_t *ctx,
     addr_t * value)
 {
+#ifdef ENABLE_SAFETY_CHECKS
     if (!vmi) {
         dbprint(VMI_DEBUG_WRITE, "--%s: vmi passed as NULL, returning without write\n",
                 __FUNCTION__);
         return VMI_FAILURE;
     }
+#endif
 
     switch (vmi->page_mode) {
         case VMI_PM_AARCH64:// intentional fall-through


### PR DESCRIPTION
LibVMI incorporates a large number of error checking calls that is
intended to catch errors during development of VMI applications. However,
for production applications these checks only add overhead. By making
it configurable whether the checks should be present (enabled by default)
LibVMI can be better tuned for different use-cases.