### PR TITLE
Fix registering event for specific MSR

### DIFF
--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -218,7 +218,7 @@ status_t register_reg_event(vmi_instance_t vmi, vmi_event_t *event)
 
     status_t rc = VMI_FAILURE;
 
-    if ( MSR_UNDEFINED == event->reg_event.reg && event->reg_event.msr ) {
+    if ( MSR_ANY == event->reg_event.reg && event->reg_event.msr ) {
         return register_msr_event(vmi, event);
     }
 

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -332,9 +332,10 @@ typedef uint64_t reg_t;
 #define MSR_HYPERVISOR              152
 
 /**
- * Special generic case for specifying arbitrary MSRs not formally listed above.
+ * Special generic case for specifying arbitrary MSRs
  */
-#define MSR_UNDEFINED               153
+#define MSR_ANY                     153
+#define MSR_UNDEFINED MSR_ANY       /* deprecated */
 
 /**
  * Special generic case for handling MSRs, given their understandably


### PR DESCRIPTION
For specific MSR events an additional lookup is needed on `vmi->msr_events`. There is also some clean-up and renaming done to make it more sane.