### PR TITLE
debian: add dependency on libvirt-dev to libvmi0 package

### DIFF
--- a/libvmi/driver/kvm/libvirt_wrapper.c
+++ b/libvmi/driver/kvm/libvirt_wrapper.c
@@ -46,8 +46,13 @@ status_t create_libvirt_wrapper(kvm_instance_t *kvm)
     wrapper->handle = dlopen ("libvirt.so", RTLD_NOW | RTLD_GLOBAL);
 
     if ( !wrapper->handle ) {
-        dbprint(VMI_DEBUG_KVM, "--failed to open a handle to libvirt\n");
-        return VMI_FAILURE;
+        // fallback to libvirt.so.0
+        wrapper->handle = dlopen ("libvirt.so.0", RTLD_NOW | RTLD_GLOBAL);
+
+        if ( !wrapper->handle ) {
+            dbprint(VMI_DEBUG_KVM, "--failed to open a handle to libvirt\n");
+            return VMI_FAILURE;
+        }
     }
 
     wrapper->virConnectOpenAuth = dlsym(wrapper->handle, "virConnectOpenAuth");


### PR DESCRIPTION
`libvirt-dev` package provides the symlink:
`/usr/lib/x86_64-linux-gnu/libvirt.so`

which is required for the `KVM` driver initialization (`dlopen("libvirt.so")`:
https://github.com/libvmi/libvmi/blob/master/libvmi/driver/kvm/libvirt_wrapper.c#L44

