### PR TITLE
xen: Fix setting RIP with vmi_set_vcpuregs()

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -1452,6 +1452,7 @@ xen_set_vcpuregs_hvm(
     cpu->r13 = regs->x86.r13;
     cpu->r14 = regs->x86.r14;
     cpu->r15 = regs->x86.r15;
+    cpu->rip = regs->x86.rip;
     cpu->rflags = regs->x86.rflags;
     cpu->cr0 = regs->x86.cr0;
     cpu->cr2 = regs->x86.cr2;


### PR DESCRIPTION
Commit 992619cd0ed2 ("Get and set multiple registers on Xen") added the
funtion xen_set_vcpuregs_hvm() which sets all vcpu registers at the
same time. Unfortunately, it missed setting the RIP register.

Add setting cpu->rip in function xen_set_vcpuregs_hvm().