### PR TITLE
add fix for calculating kaslr (meltdown)

### DIFF
--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -368,6 +368,8 @@ status_t linux_init(vmi_instance_t vmi, GHashTable *config)
 #elif defined(I386) || defined(X86_64)
     rc = driver_get_vcpureg(vmi, &vmi->kpgd, CR3, 0);
 #endif
+    /* fix for meltdown patches*/
+    vmi->kpgd &= ~0x1fff;
 
     /*
      * The driver failed to get us a pagetable.


### PR DESCRIPTION
Hi,

based on issue #656 . When there is a process in the guest VM that doing tight loop, VMI initialization will be failed due to unable to calculate the kaslr.
