### PR TITLE
Fix error in initializing vmi->kpgd from CR3 for Windows

### DIFF
--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -1017,6 +1017,8 @@ windows_init(vmi_instance_t vmi, GHashTable *config)
         } else {
             real_kpgd_found = VMI_SUCCESS;
         }
+    } else {
+        real_kpgd_found = VMI_SUCCESS;
     }
 
     if (VMI_FAILURE == init_core(vmi))


### PR DESCRIPTION
Because of the error the check `if (VMI_SUCCESS == real_kpgd_found)` fails every time. So other methods (`get_kpgd_from_rekall_profile`, `get_kpgd_method0`, `get_kpgd_method1`, `get_kpgd_method2`) has to be called to get it.