### PR TITLE
Save kpgd offset in libvmi.conf for use with VM snapshots

### DIFF
--- a/examples/win-offsets.c
+++ b/examples/win-offsets.c
@@ -118,6 +118,7 @@ int main(int argc, char **argv)
     addr_t sysproc = 0;
     addr_t kpcr = 0;
     addr_t kdbg = 0;
+    addr_t kpgd = 0;
 
     if (VMI_FAILURE == vmi_get_offset(vmi, "win_ntoskrnl", &ntoskrnl))
         printf("Failed to read field \"ntoskrnl\"\n");
@@ -149,6 +150,9 @@ int main(int argc, char **argv)
     if (VMI_FAILURE == vmi_get_offset(vmi, "win_kdbg", &kdbg))
         printf("Failed to read field \"kdbg\"\n");
 
+    if (VMI_FAILURE == vmi_get_offset(vmi, "kpgd", &kpgd))
+        printf("Failed to read field \"kpgd\"\n");
+
     printf("win_ntoskrnl:0x%lx\n"
            "win_ntoskrnl_va:0x%lx\n"
            "win_tasks:0x%lx\n"
@@ -158,7 +162,8 @@ int main(int argc, char **argv)
            "win_kdvb:0x%lx\n"
            "win_sysproc:0x%lx\n"
            "win_kpcr:0x%lx\n"
-           "win_kdbg:0x%lx\n",
+           "win_kdbg:0x%lx\n"
+           "kpgd:0x%lx\n",
            ntoskrnl,
            ntoskrnl_va,
            tasks,
@@ -168,7 +173,13 @@ int main(int argc, char **argv)
            kdvb,
            sysproc,
            kpcr,
-           kdbg);
+           kdbg,
+           kpgd);
+
+    if (!ntoskrnl || !ntoskrnl_va || !sysproc || !pdbase || !kpgd) {
+        printf("Failed to get most essential fields\n");
+        goto done;
+    }
 
     rc = 0;
 

--- a/libvmi/config/grammar.y
+++ b/libvmi/config/grammar.y
@@ -268,6 +268,7 @@ int vmi_parse_config (const char *target_name)
 }
 
 %token<str>    NUM
+%token<str>    KPGD
 %token<str>    LINUX_TASKS
 %token<str>    LINUX_MM
 %token<str>    LINUX_PID
@@ -330,6 +331,8 @@ assignment:
         |
         ostype_assignment
         |
+        kpgd_assignment
+        |
         linux_tasks_assignment
         |
         linux_mm_assignment
@@ -373,6 +376,17 @@ assignment:
         freebsd_pmap_assignment
         |
         freebsd_pgd_assignment
+        ;
+
+kpgd_assignment:
+        KPGD EQUALS NUM
+        {
+            uint64_t tmp = strtoull($3, NULL, 0);
+            uint64_t *tmp_ptr = malloc(sizeof(uint64_t));
+            (*tmp_ptr) = tmp;
+            g_hash_table_insert(tmp_entry, $1, tmp_ptr);
+            free($3);
+        }
         ;
 
 linux_tasks_assignment:

--- a/libvmi/config/lexicon.l
+++ b/libvmi/config/lexicon.l
@@ -42,6 +42,7 @@ extern void BeginToken (char *t);
 %}
 
 %%
+kpgd                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return KPGD; }
 linux_tasks             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_TASKS; }
 linux_mm                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_MM; }
 linux_name              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_NAME; }

--- a/libvmi/os/freebsd/core.c
+++ b/libvmi/os/freebsd/core.c
@@ -199,6 +199,11 @@ void freebsd_read_config_ghashtable_entries(char* key, gpointer value,
         goto _done;
     }
 
+    if (strncmp(key, "kpgd", CONFIG_STR_LENGTH) == 0) {
+        vmi->kpgd = *(addr_t *)value;
+        goto _done;
+    }
+
     if (strncmp(key, "ostype", CONFIG_STR_LENGTH) == 0 || strncmp(key, "os_type", CONFIG_STR_LENGTH) == 0) {
         goto _done;
     }
@@ -250,6 +255,9 @@ status_t freebsd_get_offset(vmi_instance_t vmi, const char* offset_name, addr_t 
         return VMI_SUCCESS;
     } else if (strncmp(offset_name, "freebsd_pgd", max_length) == 0) {
         *offset = freebsd_instance->pgd_offset;
+        return VMI_SUCCESS;
+    } else if (strncmp(offset_name, "kpgd", max_length) == 0) {
+        *offset = vmi->kpgd;
         return VMI_SUCCESS;
     }
 

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -476,6 +476,11 @@ void linux_read_config_ghashtable_entries(char* key, gpointer value,
         goto _done;
     }
 
+    if (strncmp(key, "kpgd", CONFIG_STR_LENGTH) == 0) {
+        vmi->kpgd = *(addr_t*)value;
+        goto _done;
+    }
+
     if (strncmp(key, "ostype", CONFIG_STR_LENGTH) == 0 || strncmp(key, "os_type", CONFIG_STR_LENGTH) == 0) {
         goto _done;
     }
@@ -528,6 +533,9 @@ status_t linux_get_offset(vmi_instance_t vmi, const char* offset_name, addr_t *o
         return VMI_SUCCESS;
     } else if (strncmp(offset_name, "linux_pgd", max_length) == 0) {
         *offset = linux_instance->pgd_offset;
+        return VMI_SUCCESS;
+    } else if (strncmp(offset_name, "kpgd", max_length) == 0) {
+        *offset = vmi->kpgd;
         return VMI_SUCCESS;
     }
 


### PR DESCRIPTION
Thus we search for `kpgd` only once while building _libvmi.conf_. The use it many times with every instance of VM created from snapshot.