### PR TITLE
fix clang static analyzer warning in step_and_reg_events

### DIFF
--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -257,7 +257,7 @@ event_response_t step_and_reg_events(vmi_instance_t vmi, vmi_event_t *singlestep
         step_and_reg_event_wrapper_t *wrap =
             (step_and_reg_event_wrapper_t *) reg_list->data;
 
-        if (wrap->vcpu_id == singlestep_event->vcpu_id) {
+        if (singlestep_event && wrap->vcpu_id == singlestep_event->vcpu_id) {
             wrap->steps--;
         }
 
@@ -272,6 +272,7 @@ event_response_t step_and_reg_events(vmi_instance_t vmi, vmi_event_t *singlestep
             if (!vmi->step_vcpus[wrap->vcpu_id]) {
                 // No more events on this vcpu need registering
                 vmi_clear_event(vmi, singlestep_event, step_event_free);
+                singlestep_event = NULL;
             }
 
             free(wrap);


### PR DESCRIPTION
This PR fixes a warning generated by clang static analyzer on the `step_and_reg_events` function.

Related to #674, #708 , #699.
Warning:
![screenshot_20190121_191840](https://user-images.githubusercontent.com/964610/51492233-699fad80-1db1-11e9-960d-7613e37cd539.png)

Basically the `singlestep_event` memory is freed by `vmi_clear_event` call at line `274`, and the analyzer assumes that the `while` condition is still `true` after that.
So it enters into a test against a previously freed memory, therefore the warning.

I assume that I just have to put a `break` there, but i would be glad to have your comments on this function, that I don't know the internals.

Is this a good enough fix for you @tklengyel ?