### PR TITLE
Add VMI_INIT_DOMAINUUID to init_flags

### DIFF
--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -48,6 +48,9 @@ typedef struct driver_interface {
         vmi_instance_t,
         uint64_t,
         char **);
+    uint64_t (*get_id_from_uuid_ptr) (
+        vmi_instance_t vmi,
+        const char* uuid);
     uint64_t (*get_id_ptr) (
         vmi_instance_t);
     void (*set_id_ptr) (

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -79,6 +79,21 @@ driver_get_name_from_id(
 }
 
 static inline uint64_t
+driver_get_id_from_uuid(
+    vmi_instance_t vmi,
+    const char *uuid)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_id_from_uuid_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_id_from_uuid function not implemented.\n");
+        return 0;
+    }
+#endif
+
+    return vmi->driver.get_id_from_uuid_ptr(vmi, uuid);
+}
+
+static inline uint64_t
 driver_get_id(
     vmi_instance_t vmi)
 {

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -49,6 +49,9 @@ status_t xen_get_name_from_domainid(
     vmi_instance_t vmi,
     uint64_t domainid,
     char **name);
+uint64_t xen_get_domainid_from_uuid(
+    vmi_instance_t vmi,
+    const char *uuid);
 uint64_t xen_get_domainid(
     vmi_instance_t vmi);
 void xen_set_domainid(
@@ -122,6 +125,7 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.destroy_ptr = &xen_destroy;
     driver.get_id_from_name_ptr = &xen_get_domainid_from_name;
     driver.get_name_from_id_ptr = &xen_get_name_from_domainid;
+    driver.get_id_from_uuid_ptr = &xen_get_domainid_from_uuid;
     driver.get_id_ptr = &xen_get_domainid;
     driver.set_id_ptr = &xen_set_domainid;
     driver.check_id_ptr = &xen_check_domainid;

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -53,6 +53,8 @@ extern "C" {
 
 #define VMI_INIT_EVENTS     (1u << 2) /**< initialize events */
 
+#define VMI_INIT_DOMAINUUID (1u << 3) /**< initialize using domain uuid */
+
 typedef enum vmi_mode {
 
     VMI_XEN, /**< libvmi is monitoring a Xen VM */


### PR DESCRIPTION
This patch adds a new init param that is used to identify a domain by
its uuid

Signed-off-by: Alexandru Isaila <aisaila@bitdefender.com>