### PR TITLE
Make some functions explicitely take void as input

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -809,7 +809,7 @@ vmi_destroy(
 }
 
 vmi_arch_t
-vmi_get_library_arch()
+vmi_get_library_arch(void)
 {
 #ifdef I386
     return VMI_ARCH_X86;

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -1074,7 +1074,7 @@ status_t vmi_shutdown_single_step(vmi_instance_t vmi)
     return VMI_FAILURE;
 }
 
-uint32_t vmi_events_version()
+uint32_t vmi_events_version(void)
 {
     return VMI_EVENTS_VERSION;
 }

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -617,7 +617,7 @@ struct vmi_event {
  *
  * @return max supported events version
  */
-uint32_t vmi_events_version();
+uint32_t vmi_events_version(void);
 
 /**
  * Register to handle the event specified by the vmi_event object.

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -806,7 +806,7 @@ status_t vmi_destroy(
  * @param[in] vmi LibVMI instance
  * @return The architecture of the library
  */
-vmi_arch_t vmi_get_library_arch();
+vmi_arch_t vmi_get_library_arch(void);
 
 /**
  * Get full path of associated rekall profile


### PR DESCRIPTION
Fixes compiling with -Werror=strict-prototypes error:
```
error: function declaration isn’t a prototype 