### PR TITLE
test installation of libvmi in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 # gcc compile test
 #
     - env:
-        - TEST="gcc compile"
+        - TEST="gcc compile and install"
       compiler: gcc
       addons:
         apt:
@@ -57,8 +57,9 @@ matrix:
                 - libfuse-dev
       script:
         - mkdir build && cd build
-        - cmake ..
+        - cmake -DCMAKE_INSTALL_PREFIX=../install ..
         - make
+        - make install
 
 #
 # clang compile test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ set(MAX_PAGE_CACHE_SIZE "512")
 #-----------------------------------------------------------------------------
 #                               SOURCES
 #-----------------------------------------------------------------------------
-configure_file(libvmi.pc.in libvmi.pc)
-install(FILES libvmi.pc DESTINATION "${INSTALL_LIB_DIR}/pkgconfig")
+configure_file(libvmi.pc.in ${PROJECT_BINARY_DIR}/libvmi.pc)
+install(FILES ${PROJECT_BINARY_DIR}/libvmi.pc DESTINATION "${INSTALL_LIB_DIR}/pkgconfig")
 
 configure_file(libvmi/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 # include <libvmi/libvmi.h> "config.h", "private.h" and <glib.h>


### PR DESCRIPTION
Test the installation of libvmi in Travis, as it might fail is something is misconfigured.
I just had a failure with the current version of the repo.