### PR TITLE
Add get_xsave_info

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -174,6 +174,19 @@ vmi_get_kernel_struct_offset(
     return vmi->os_interface->os_get_kernel_struct_offset(vmi, symbol, member, addr);
 }
 
+status_t vmi_get_xsave_info(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    xsave_area_t *xsave_info)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi || !xsave_info)
+        return 0;
+#endif
+
+    return driver_get_xsave_info(vmi, vcpu, xsave_info);
+}
+
 uint64_t
 vmi_get_memsize(
     vmi_instance_t vmi)

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -65,6 +65,10 @@ typedef struct driver_interface {
     void (*set_name_ptr) (
         vmi_instance_t,
         const char *);
+    status_t (*get_xsave_info_ptr) (
+        vmi_instance_t,
+        unsigned long,
+        xsave_area_t *);
     status_t (*get_memsize_ptr) (
         vmi_instance_t,
         uint64_t *,

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -168,6 +168,22 @@ driver_set_name(
 }
 
 static inline status_t
+driver_get_xsave_info(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    xsave_area_t *xsave_info)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_xsave_info_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_xsave_info function not implemented.\n");
+        return VMI_FAILURE;
+    }
+#endif
+
+    return vmi->driver.get_xsave_info_ptr(vmi, vcpu, xsave_info);
+}
+
+static inline status_t
 driver_get_memsize(
     vmi_instance_t vmi,
     uint64_t *allocated_ram_size,

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -32,6 +32,35 @@
 #include "driver/xen/xen_events.h"
 #endif
 
+struct hvm_hw_cpu_xsave_46 {
+    uint64_t xfeature_mask;        /* Ignored */
+    uint64_t xcr0;                 /* Updated by XSETBV */
+    uint64_t xcr0_accum;           /* Updated by XSETBV */
+    struct {
+        struct { char x[512]; } fpu_sse;
+
+        struct hvm_hw_cpu_xsave_hdr_46 {
+            uint64_t xstate_bv;         /* Updated by XRSTOR */
+            uint64_t reserved[7];
+        } xsave_hdr;                    /* The 64-byte header */
+    } save_area;
+};
+
+struct hvm_hw_cpu_xsave_412 {
+    uint64_t xfeature_mask;        /* Ignored */
+    uint64_t xcr0;                 /* Updated by XSETBV */
+    uint64_t xcr0_accum;           /* Updated by XSETBV */
+    struct {
+        struct { char x[512]; } fpu_sse;
+
+        struct hvm_hw_cpu_xsave_hdr_412 {
+            uint64_t xstate_bv;         /* Updated by XRSTOR */
+            uint64_t xcomp_bv;          /* Updated by XRSTOR{C,S} */
+            uint64_t reserved[6];
+        } xsave_hdr;                    /* The 64-byte header */
+    } save_area;
+};
+
 status_t xen_init(
     vmi_instance_t vmi,
     uint32_t init_flags,
@@ -76,6 +105,10 @@ status_t xen_get_tsc_info(
     uint64_t *elapsed_nsec,
     uint32_t *gtsc_khz,
     uint32_t *incarnation);
+status_t xen_get_xsave_info(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    xsave_area_t *xsave_info);
 status_t xen_get_vcpumtrr(
     vmi_instance_t vmi,
     mtrr_regs_t *hwMtrr,
@@ -141,6 +174,7 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.check_id_ptr = &xen_check_domainid;
     driver.get_name_ptr = &xen_get_domainname;
     driver.set_name_ptr = &xen_set_domainname;
+    driver.get_xsave_info_ptr = &xen_get_xsave_info;
     driver.get_memsize_ptr = &xen_get_memsize;
     driver.get_tsc_info_ptr = &xen_get_tsc_info;
     driver.get_vcpumtrr_ptr = &xen_get_vcpumtrr;

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -572,6 +572,12 @@ typedef struct registers {
     };
 } registers_t;
 
+typedef struct xsave_area {
+    char fpu_sse[512];
+    uint64_t xstate_bv;         /* Updated by XRSTOR */
+    uint64_t xcomp_bv;          /* Updated by XRSTOR{C,S} */
+} xsave_area_t;
+
 /**
  * typedef for forward compatibility with 64-bit guests
  */
@@ -2059,6 +2065,20 @@ status_t vmi_get_kernel_struct_offset(
     const char* struct_name,
     const char* member,
     addr_t *addr);
+
+/**
+ * Gets the current value for a VCPU xsave info.When LibVMI is accessing a raw
+ * memory file or KVM, this function will fail.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] vcpu The index of the VCPU to access, use 0 for single VCPU systems
+ * @param[out] xsave_info Returned value of the xsave_info
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_get_xsave_info(
+    vmi_instance_t vmi,
+    unsigned long vcpu,
+    xsave_area_t *xsave_info);
 
 /**
  * Gets the memory size of the guest or file that LibVMI is currently


### PR DESCRIPTION
This patch adds a new function to extract the cpu xsave info.
    
Signed-off-by: Alexandru Isaila <aisaila@bitdefender.com>