### PR TITLE
Add domain watcher

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(event-example vmi_shared)
 add_executable(interrupt-event-example interrupt-event-example.c)
 target_link_libraries(interrupt-event-example vmi_shared)
 
+add_executable(wait-for-domain-example wait-for-domain-example.c)
+target_link_libraries(wait-for-domain-example vmi_shared)
+
 add_executable(msr-event-example msr-event-example.c)
 target_link_libraries(msr-event-example vmi_shared)
 

--- a/examples/wait-for-domain-example.c
+++ b/examples/wait-for-domain-example.c
@@ -1,0 +1,85 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Alexandru Isaila (aisaila@bitdefender.com)
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <signal.h>
+#include <libvmi/libvmi.h>
+#include <libvmi/events.h>
+
+static int interrupted = 0;
+static void close_handler(int sig)
+{
+    interrupted = sig;
+}
+vmi_event_t watch_event = {0};
+
+event_response_t wait_for_domain(vmi_instance_t vmi, vmi_event_t *event)
+{
+
+    if ( event->watch_event.created )
+        printf("domain %d with uuid %s created\n", event->watch_event.domain, event->watch_event.uuid);
+    else
+        printf("domain %d with uuid %s deleted\n", event->watch_event.domain, event->watch_event.uuid);
+
+    return 1;
+}
+
+int main ()
+{
+    vmi_instance_t vmi;
+    struct sigaction act;
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    // Initialize the libvmi library.
+    if (VMI_FAILURE ==
+            vmi_init(&vmi, VMI_XEN, NULL, VMI_INIT_DOMAINWATCH, NULL, NULL)) {
+        printf("Failed to init LibVMI library.\n");
+        return 1;
+    }
+
+    printf("LibVMI init succeeded!\n");
+    watch_event.version = VMI_EVENTS_VERSION;
+    watch_event.type = VMI_EVENT_DOMAIN_WATCH;
+    watch_event.callback = wait_for_domain;
+
+    if (vmi_register_event(vmi, &watch_event) == VMI_FAILURE)
+        printf("Failed to register event\n");
+
+    printf("Wait for domains\n");
+
+    while (!interrupted) {
+        vmi_events_listen(vmi,500);
+    }
+
+    printf("Finished with test.\n");
+
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -544,6 +544,20 @@ status_t vmi_init(
     }
     dbprint(VMI_DEBUG_CORE, "--completed driver init.\n");
 
+    if (init_flags & VMI_INIT_DOMAINWATCH) {
+        if ( VMI_FAILURE == driver_domainwatch_init(_vmi, init_flags) ) {
+            if ( error )
+                *error = VMI_INIT_ERROR_DRIVER;
+            goto error_exit;
+        }
+
+        if ( init_flags == VMI_INIT_DOMAINWATCH ) {
+            /* we have all we need to wait for domains. Return if there is nothing else */
+            *vmi = _vmi;
+            return VMI_SUCCESS;
+        }
+    }
+
     /* resolve the id and name */
     if (VMI_FAILURE == set_id_and_name(_vmi, domain)) {
         if ( error )

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -152,3 +152,13 @@ status_t driver_init_vmi(vmi_instance_t vmi,
 
     return rc;
 }
+
+status_t driver_domainwatch_init(vmi_instance_t vmi,
+                                 uint32_t init_flags)
+{
+    status_t rc = VMI_FAILURE;
+    if (vmi->driver.domainwatch_init_ptr)
+        rc = vmi->driver.domainwatch_init_ptr(vmi, init_flags);
+
+    return rc;
+}

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -39,6 +39,9 @@ typedef struct driver_interface {
         vmi_instance_t,
         uint32_t init_flags,
         vmi_init_data_t *init_data);
+    status_t (*domainwatch_init_ptr) (
+        vmi_instance_t vmi,
+        uint32_t init_flags);
     void (*destroy_ptr) (
         vmi_instance_t);
     uint64_t (*get_id_from_name_ptr) (
@@ -158,6 +161,9 @@ typedef struct driver_interface {
     status_t (*set_failed_emulation_event_ptr)(
         vmi_instance_t,
         bool enabled);
+    status_t (*set_domain_watch_event_ptr)(
+        vmi_instance_t,
+        bool enabled);
     status_t (*slat_get_domain_state_ptr)(
         vmi_instance_t vmi,
         bool *state);
@@ -206,6 +212,10 @@ status_t driver_init_vmi(
     vmi_instance_t vmi,
     uint32_t init_flags,
     vmi_init_data_t *init_data);
+
+status_t driver_domainwatch_init(
+    vmi_instance_t vmi,
+    uint32_t init_flags);
 
 #endif /* DRIVER_INTERFACE_H */
 

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -586,6 +586,21 @@ driver_set_failed_emulation_event(
 }
 
 static inline status_t
+driver_set_watch_domain_event(
+    vmi_instance_t vmi,
+    bool enabled)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_domain_watch_event_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_watch_domain_event function not implemented.\n");
+        return VMI_FAILURE;
+    }
+#endif
+
+    return vmi->driver.set_domain_watch_event_ptr(vmi, enabled);
+}
+
+static inline status_t
 driver_slat_get_domain_state (
     vmi_instance_t vmi,
     bool *state )

--- a/libvmi/driver/xen/libxs_wrapper.c
+++ b/libvmi/driver/xen/libxs_wrapper.c
@@ -53,6 +53,11 @@ status_t create_libxs_wrapper(xen_instance_t *xen)
     wrapper->xs_close = dlsym(wrapper->handle, "xs_close");
     wrapper->xs_directory = dlsym(wrapper->handle, "xs_directory");
     wrapper->xs_read = dlsym(wrapper->handle, "xs_read");
+    wrapper->xs_fileno = dlsym(wrapper->handle, "xs_fileno");
+    wrapper->xs_is_domain_introduced = dlsym(wrapper->handle, "xs_is_domain_introduced");
+    wrapper->xs_read_watch = dlsym(wrapper->handle, "xs_read_watch");
+    wrapper->xs_watch = dlsym(wrapper->handle, "xs_watch");
+    wrapper->xs_unwatch = dlsym(wrapper->handle, "xs_unwatch");
 
     return sanity_check(xen);
 }

--- a/libvmi/driver/xen/libxs_wrapper.h
+++ b/libvmi/driver/xen/libxs_wrapper.h
@@ -53,6 +53,21 @@ typedef struct {
     void* (*xs_read)
     (struct xs_handle *h, xs_transaction_t t, const char *path, unsigned int *len);
 
+    bool (*xs_watch)
+    (struct xs_handle *h, const char *path, const char *token);
+
+    bool (*xs_unwatch)
+    (struct xs_handle *h, const char *path, const char *token);
+
+    char** (*xs_read_watch)
+    (struct xs_handle *h, unsigned int *num);
+
+    bool (*xs_is_domain_introduced)
+    (struct xs_handle *h, unsigned int domid);
+
+    int (*xs_fileno)
+    (struct xs_handle *h);
+
 } libxs_wrapper_t;
 
 status_t create_libxs_wrapper(struct xen_instance *xen);

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -32,6 +32,11 @@
 #include "driver/xen/xen_events.h"
 #endif
 
+#ifdef HAVE_LIBXENSTORE
+static const char RELEASE_TOKEN[] = "release";
+static const char INTRODUCE_TOKEN[] = "introduce";
+#endif
+
 struct hvm_hw_cpu_xsave_46 {
     uint64_t xfeature_mask;        /* Ignored */
     uint64_t xcr0;                 /* Updated by XSETBV */
@@ -69,6 +74,9 @@ status_t xen_init_vmi(
     vmi_instance_t vmi,
     uint32_t init_flags,
     vmi_init_data_t *init_data);
+status_t xen_domainwatch_init(
+    vmi_instance_t vmi,
+    uint32_t init_flags);
 void xen_destroy(
     vmi_instance_t vmi);
 uint64_t xen_get_domainid_from_name(
@@ -165,6 +173,7 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.initialized = true;
     driver.init_ptr = &xen_init;
     driver.init_vmi_ptr = &xen_init_vmi;
+    driver.domainwatch_init_ptr = &xen_domainwatch_init;
     driver.destroy_ptr = &xen_destroy;
     driver.get_id_from_name_ptr = &xen_get_domainid_from_name;
     driver.get_name_from_id_ptr = &xen_get_name_from_domainid;

--- a/libvmi/driver/xen/xen_events.h
+++ b/libvmi/driver/xen/xen_events.h
@@ -60,6 +60,9 @@ status_t xen_init_events(
     vmi_instance_t vmi,
     uint32_t init_flags,
     vmi_init_data_t *init_data);
+status_t xen_domainwatch_init_events(
+    vmi_instance_t vmi,
+    uint32_t init_flags);
 
 void xen_events_destroy(vmi_instance_t vmi);
 

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -109,7 +109,8 @@ typedef enum {
 #define VM_EVENT_REASON_INTERRUPT               12
 #define VM_EVENT_REASON_DESCRIPTOR_ACCESS       13
 #define VM_EVENT_REASON_EMUL_UNIMPLEMENTED      14
-#define __VM_EVENT_REASON_MAX                   15
+#define XS_EVENT_REASON_DOMAIN_WATCH            15
+#define __VM_EVENT_REASON_MAX                   16
 
 #define VM_EVENT_X86_CR0    0
 #define VM_EVENT_X86_CR3    1

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -104,7 +104,13 @@ typedef struct vm_event_compat {
 typedef struct {
     xc_evtchn* xce_handle;
     int port;
-    struct pollfd fd;
+#ifdef HAVE_LIBXENSTORE
+    struct pollfd fd[2];
+#else
+    struct pollfd fd[1];
+#endif
+
+    const uint16_t fd_size;
     uint32_t evtchn_port;
     bool external_poll;
     void *ring_page;

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -69,7 +69,18 @@ typedef struct xen_instance {
 
     uint64_t max_gpfn;    /**< result of xc_domain_maximum_gpfn/2() */
 
+    GTree *domains; /**< tree for running xen domains */
+
 } xen_instance_t;
+
+#ifdef HAVE_LIBXENSTORE
+typedef struct xen_check_domain {
+    xen_instance_t xen;
+    uint32_t domain;
+    char* uuid;
+    bool found;
+} xen_check_domain_t;
+#endif
 
 static inline
 xen_instance_t *xen_get_instance(

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -474,6 +474,19 @@ status_t register_failed_emulation_event(vmi_instance_t vmi, vmi_event_t *event)
     return rc;
 }
 
+status_t register_watch_domain_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( !vmi->watch_domain_event ) {
+        rc = driver_set_watch_domain_event(vmi, 1);
+        if ( VMI_SUCCESS == rc )
+            vmi->watch_domain_event = event;
+    };
+
+    return rc;
+}
+
 status_t clear_interrupt_event(vmi_instance_t vmi, vmi_event_t *event)
 {
 
@@ -769,7 +782,7 @@ vmi_register_event(
         dbprint(VMI_DEBUG_EVENTS, "LibVMI wasn't initialized!\n");
         return VMI_FAILURE;
     }
-    if (!(vmi->init_flags & VMI_INIT_EVENTS)) {
+    if (!(vmi->init_flags & (VMI_INIT_EVENTS | VMI_INIT_DOMAINWATCH))) {
         dbprint(VMI_DEBUG_EVENTS, "LibVMI wasn't initialized with events!\n");
         return VMI_FAILURE;
     }
@@ -828,6 +841,9 @@ vmi_register_event(
             break;
         case VMI_EVENT_FAILED_EMULATION:
             rc = register_failed_emulation_event(vmi, event);
+            break;
+        case VMI_EVENT_DOMAIN_WATCH:
+            rc = register_watch_domain_event(vmi, event);
             break;
         default:
             dbprint(VMI_DEBUG_EVENTS, "Unknown event type: %d\n", event->type);
@@ -1001,7 +1017,7 @@ status_t vmi_events_listen(vmi_instance_t vmi, uint32_t timeout)
     if (!vmi)
         return VMI_FAILURE;
 
-    if (!(vmi->init_flags & VMI_INIT_EVENTS))
+    if (!(vmi->init_flags & (VMI_INIT_EVENTS | VMI_INIT_DOMAINWATCH)))
         return VMI_FAILURE;
 #endif
 

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -64,6 +64,7 @@ typedef uint16_t vmi_event_type_t;
 #define VMI_EVENT_PRIVILEGED_CALL   8   /**< Privileged call (ie. SMC on ARM) */
 #define VMI_EVENT_DESCRIPTOR_ACCESS 9   /**< A descriptor table register was accessed */
 #define VMI_EVENT_FAILED_EMULATION  10  /**< Emulation failed when requested by VMI_EVENT_RESPONSE_EMULATE */
+#define VMI_EVENT_DOMAIN_WATCH      11  /**< Watch create/destroy events */
 
 /**
  * Max number of vcpus we can set single step on at one time for a domain
@@ -277,6 +278,12 @@ typedef struct {
     addr_t offset;
 
 } mem_access_event_t;
+
+typedef struct {
+    char* uuid; /**< Domain uuid */
+    uint32_t domain; /**< Domain id */
+    bool created; /**< created/deleted state */
+} watch_domain_event_t;
 
 /*
  * Xen allows for subscribing to interrupt events in two ways as of Xen 4.9.
@@ -503,6 +510,7 @@ struct vmi_event {
         cpuid_event_t cpuid_event;
         debug_event_t debug_event;
         descriptor_event_t descriptor_event;
+        watch_domain_event_t watch_event;
     };
 
     /*

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -46,6 +46,7 @@ extern "C" {
 #include <sys/mman.h>
 #include <errno.h>
 #include <string.h>
+#include <stdbool.h>
 
 #define VMI_INIT_DOMAINNAME (1u << 0) /**< initialize using domain name */
 
@@ -54,6 +55,8 @@ extern "C" {
 #define VMI_INIT_EVENTS     (1u << 2) /**< initialize events */
 
 #define VMI_INIT_DOMAINUUID (1u << 3) /**< initialize using domain uuid */
+
+#define VMI_INIT_DOMAINWATCH (1u << 4) /**< initialize using a domain watcher */
 
 typedef enum vmi_mode {
 

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -165,6 +165,8 @@ struct vmi_instance {
 
     vmi_event_t *failed_emulation_event; /**< Handler for failed emulation events */
 
+    vmi_event_t *watch_domain_event; /**< Handler for domain create/destroy events */
+
     GHashTable *interrupt_events; /**< interrupt event to function mapping (key: interrupt) */
 
     GHashTable *mem_events_on_gfn; /**< mem event to functions mapping (key: physical address) */


### PR DESCRIPTION
This patch adds a domain watcher that signals a new domain or if a domains was destroyed. The callback function returns a structure with domain id, uuid and if the domain was created or not.
    
After a domain is created it is inserted in a gTree so we can have
information about the destroy event.

Signed-off-by: Alexandru Isaila <aisaila@bitdefender.com>