### PR TITLE
Xen altp2m_idx setting correct value

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -1114,7 +1114,9 @@ status_t process_request(vmi_instance_t vmi, vm_event_compat_t *vmec)
         return VMI_FAILURE;
 #endif
 
-    vmec->altp2m_idx = (vmec->flags & VM_EVENT_FLAG_ALTERNATE_P2M) ?: 0;
+    if ( !(vmec->flags & VM_EVENT_FLAG_ALTERNATE_P2M) )
+        vmec->altp2m_idx = 0;
+
     return xe->process_event[vmec->reason](vmi, vmec);
 }
 


### PR DESCRIPTION
While playing with drakvuf @sergej-proskurin and I stumbled upon this issue.

This commit fixes an issue in process_request in the xen_driver. When altp2m is active vmec->altp2m_idx does not remain unchanged as would be expected, but instead is set to 128. This commits fixes that.