### PR TITLE
Fix cache bugs

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -35,6 +35,7 @@
 #include <time.h>
 #include <string.h>
 
+#include "libvmi.h"
 #include "private.h"
 #include "glib_compat.h"
 
@@ -733,10 +734,17 @@ vmi_rvacache_add(
     addr_t rva,
     char *sym)
 {
+    addr_t pgd = 0;
+
     if (!vmi)
         return;
 
-    return rva_cache_set(vmi, base_addr, pid, rva, sym);
+    if (VMI_SUCCESS != vmi_pid_to_dtb(vmi, pid, &pgd)) {
+        dbprint(VMI_DEBUG_SYMCACHE, "--SYM cache failed to find base for PID %u\n", pid);
+        return;
+    }
+
+    return rva_cache_set(vmi, base_addr, pgd, rva, sym);
 }
 
 void

--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -187,7 +187,6 @@ pid_cache_set(
 cleanup:
     g_free(key);
     g_free(entry);
-
 }
 
 status_t


### PR DESCRIPTION
The glib function `g_hash_table_insert()` does not return a success/failure code. Rather it returns whether the key was previously in the table. However, `cache.c` treats the return code as though it could indicate failure. This PR fixes that oversight.

For confirmation, see
https://developer.gnome.org/glib/stable/glib-Hash-Tables.html#g-hash-table-insert