### PR TITLE
cmake: use GNUInstallDirs module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 #-----------------------------------------------------------------------------
 project(LibVMI VERSION 0.13.0 LANGUAGES C ASM)
 set(VERSION "0.13.0")
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
-set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
-set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
 #-----------------------------------------------------------------------------
 #                              DEPENDENCIES
 #-----------------------------------------------------------------------------
@@ -23,6 +20,7 @@ find_package(Xen)
 find_package(Xenstore)
 include(DetectArchitecture)
 include(StaticAnalysis)
+include(GNUInstallDirs)
 #-----------------------------------------------------------------------------
 #                           BUILD TYPES & FLAGS
 #-----------------------------------------------------------------------------
@@ -64,7 +62,8 @@ set(MAX_PAGE_CACHE_SIZE "512")
 #                               SOURCES
 #-----------------------------------------------------------------------------
 configure_file(libvmi.pc.in ${PROJECT_BINARY_DIR}/libvmi.pc)
-install(FILES ${PROJECT_BINARY_DIR}/libvmi.pc DESTINATION "${INSTALL_LIB_DIR}/pkgconfig")
+install(FILES ${PROJECT_BINARY_DIR}/libvmi.pc DESTINATION
+    "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
 
 configure_file(libvmi/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 # include <libvmi/libvmi.h> "config.h", "private.h" and <glib.h>

--- a/libvmi.pc.in
+++ b/libvmi.pc.in
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@INSTALL_LIB_DIR@
-sharedlibdir=@INSTALL_LIB_DIR@
-includedir=@INSTALL_INC_DIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+sharedlibdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: LibVMI Library
 Description: A virtual machine introspection library for Xen and KVM.
 Requires:
 Version: @VERSION@
-Libs: -L@INSTALL_LIB_DIR@ -ldl -lglib-2.0 -lvmi
-Cflags: -I@INSTALL_INC_DIR@
+Libs: -L@CMAKE_INSTALL_FULL_LIBDIR@ -ldl -lglib-2.0 -lvmi
+Cflags: -I@CMAKE_INSTALL_FULL_INCLUDEDIR@

--- a/libvmi/CMakeLists.txt
+++ b/libvmi/CMakeLists.txt
@@ -159,18 +159,9 @@ if (REKALL_PROFILES)
     endif ()
 endif ()
 
-# install
-get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-
-if ("${LIB64}" STREQUAL "TRUE")
-    set(LIBSUFFIX 64)
-else()
-    set(LIBSUFFIX "")
-endif()
-
-install(TARGETS vmi_shared DESTINATION lib${LIBSUFFIX})
+install(TARGETS vmi_shared DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 if (ENABLE_STATIC)
-    install(TARGETS vmi_static DESTINATION lib${LIBSUFFIX})
+    install(TARGETS vmi_static DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
 endif ()
 install(FILES ${VMI_PUBLIC_HEADERS} DESTINATION include/libvmi)
 
@@ -188,4 +179,5 @@ file(GENERATE
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libvmi.la
     INPUT ${CMAKE_CURRENT_BINARY_DIR}/libtool_template.gen)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libvmi.la DESTINATION lib${LIBSUFFIX})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libvmi.la DESTINATION
+    ${CMAKE_INSTALL_FULL_LIBDIR})


### PR DESCRIPTION
the GnuInstallDirs module provide us with the right paths we needs to install libvmi on the system.
https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html


It also deals with lib and lib64 for example.
