### PR TITLE
cmake: strip symbols in library in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3 -O0")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Werror -O2")
 
-# strip binary in release mode
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-    set(CMAKE_EXE_LINKER_FLAGS "-s")
-endif ()
+# strip library in release mode
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "-s")
 #-----------------------------------------------------------------------------
 #                             BUILD OPTIONS
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This strips the library in release mode.