### PR TITLE
Fix memory leak of xen->domains

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -696,6 +696,7 @@ xen_destroy(
     }
 
     dlclose(xen->libxsw.handle);
+    g_tree_destroy(xen->domains);
 #endif
 
     g_free(xen->name);


### PR DESCRIPTION
Spotted by Valgrind on DRAKVUF. It's a bit odd that Valgrind didn't catch it for LibVMI itself.