### PR TITLE
readme: set minimum required CMake version to 3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Dependencies
 ------------
 The following libraries are used in building this code:
 
-- ``CMake``
+- ``CMake`` (``>= 3.1``)
 
 - ``libtool`` Generic library support script
 


### PR DESCRIPTION
as https://github.com/libvmi/libvmi/pull/735 is not moving, i opened a new one and fixed the trailing whitespace.