### PR TITLE
use CMAKE_CURRENT_SOURCE_DIR for module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 # set cmake module path, to search in cmake/modules first
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 #-----------------------------------------------------------------------------
 #                           GENERAL CONFIGURATION
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
CMAKE_SOURCE_DIR does not work well if libvmi is added to another cmake file as a sub project