### PR TITLE
fix cmakedefines

### DIFF
--- a/libvmi/cache.h
+++ b/libvmi/cache.h
@@ -38,7 +38,7 @@ gboolean key_128_equals(gconstpointer key1, gconstpointer key2);
 void key_128_init(vmi_instance_t vmi, key_128_t key, uint64_t low, uint64_t high);
 key_128_t key_128_build (vmi_instance_t vmi, uint64_t low, uint64_t high);
 
-#if ENABLE_ADDRESS_CACHE == 1
+#ifdef ENABLE_ADDRESS_CACHE
 
 void pid_cache_init(vmi_instance_t vmi);
 void pid_cache_destroy(vmi_instance_t vmi);

--- a/libvmi/config.h.in
+++ b/libvmi/config.h.in
@@ -11,70 +11,55 @@
 #cmakedefine X86_64
 
 /* Enable or disable the address cache (v2p, pid, etc) */
-#cmakedefine01 ENABLE_ADDRESS_CACHE
+#cmakedefine ENABLE_ADDRESS_CACHE
 
 /* Enable libvmi.conf */
-#cmakedefine01 ENABLE_CONFIGFILE
+#cmakedefine ENABLE_CONFIGFILE
 
-/* Define to 1 to enable file support. */
-#cmakedefine01 ENABLE_FILE
+/* Define to enable file support. */
+#cmakedefine ENABLE_FILE
 
-/* Define to 1 to FreeBSD support. */
-#cmakedefine01 ENABLE_FREEBSD
+/* Define to FreeBSD support. */
+#cmakedefine ENABLE_FREEBSD
 
-/* Define to 1 to enable KVM support. */
-#cmakedefine01 ENABLE_KVM
+/* Define to enable KVM support. */
+#cmakedefine ENABLE_KVM
 
-/* Define to 1 to Linux support. */
-#cmakedefine01 ENABLE_LINUX
+/* Define to Linux support. */
+#cmakedefine ENABLE_LINUX
 
 /* Enable or disable the page cache */
-#cmakedefine01 ENABLE_PAGE_CACHE
+#cmakedefine ENABLE_PAGE_CACHE
 
 /* Enable API safety checks */
-#cmakedefine01 ENABLE_SAFETY_CHECKS
+#cmakedefine ENABLE_SAFETY_CHECKS
 
-/* #undef ENABLE_SHM_SNAPSHOT */
-#cmakedefine01 ENABLE_SHM_SNAPSHOT
+/* Define to Windows support. */
+#cmakedefine ENABLE_WINDOWS
 
-/* Define to 1 to build VMIFS. */
-#cmakedefine01 ENABLE_VMIFS
+/* Define to enable Xen support. */
+#cmakedefine ENABLE_XEN
 
-/* Define to 1 to Windows support. */
-#cmakedefine01 ENABLE_WINDOWS
+/* Define to enable Bareflank support. */
+#cmakedefine ENABLE_BAREFLANK
 
-/* Define to 1 to enable Xen support. */
-#cmakedefine01 ENABLE_XEN
+/* Define if you have <qemu/libvmi_request.h>. */
+#cmakedefine HAVE_LIBVMI_REQUEST
 
-/* Define to 1 to enable Bareflank support. */
-#cmakedefine01 ENABLE_BAREFLANK
+/* Define if we have Xenstore support. */
+#cmakedefine HAVE_LIBXENSTORE
 
-/* Define to 1 if you have <qemu/libvmi_request.h>. */
-#cmakedefine01 HAVE_LIBVMI_REQUEST
+/* Define if you have the <xenstore.h> header file. */
+#cmakedefine HAVE_XENSTORE_H
 
-/* Define to 1 to enable Xenstore support. */
-#cmakedefine01 ENABLE_XENSTORE
-
-/* Define to 1 if you have the <xenctrl.h> header file. */
-#cmakedefine01 HAVE_XENCTRL_H
-
-/* Define to 1 if you have the <xen/io/ring.h> header file. */
-#cmakedefine01 HAVE_XEN_IO_RING_H
-
-/* Define to 1 if we have Xenstore support. */
-#cmakedefine01 HAVE_LIBXENSTORE
-
-/* Define to 1 if you have the <xenstore.h> header file. */
-#cmakedefine01 HAVE_XENSTORE_H
-
-/* Define to 1 if you have the <xs.h> header file. */
-#cmakedefine01 HAVE_XS_H
+/* Define if you have the <xs.h> header file. */
+#cmakedefine HAVE_XS_H
 
 /* xen headers define hvmmem_access_t */
-#cmakedefine01 HAVE_HVMMEM_ACCESS_T
+#cmakedefine HAVE_HVMMEM_ACCESS_T
 
 /* xen headers define xenmem_access_t */
-#cmakedefine01 HAVE_XENMEM_ACCESS_T
+#cmakedefine HAVE_XENMEM_ACCESS_T
 
 /* Max number of pages held in page cache */
 #cmakedefine MAX_PAGE_CACHE_SIZE ${MAX_PAGE_CACHE_SIZE}
@@ -103,9 +88,9 @@
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "${PROJECT_VERSION}"
 
-/* Defined to 1 when working JSON-C library was found to parse Rekall
+/* Defined when working JSON-C library was found to parse Rekall
    profiles. */
-#cmakedefine01 REKALL_PROFILES
+#cmakedefine REKALL_PROFILES
 
 /* Version number of package */
 #define VERSION "${PROJECT_VERSION}"

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -458,22 +458,22 @@ static inline status_t driver_sanity_check(vmi_mode_t mode)
 {
     switch ( mode ) {
         case VMI_XEN:
-#if ENABLE_XEN != 1
+#ifndef ENABLE_XEN
             return VMI_FAILURE;
 #endif
             break;
         case VMI_KVM:
-#if ENABLE_KVM != 1
+#ifndef ENABLE_KVM
             return VMI_FAILURE;
 #endif
             break;
         case VMI_FILE:
-#if ENABLE_FILE != 1
+#ifndef ENABLE_FILE
             return VMI_FAILURE;
 #endif
             break;
         case VMI_BAREFLANK:
-#if ENABLE_BAREFLANK != 1
+#ifndef ENABLE_BAREFLANK
             return VMI_FAILURE;
 #endif
             break;

--- a/libvmi/driver/driver_interface.c
+++ b/libvmi/driver/driver_interface.c
@@ -31,19 +31,19 @@
 #include "private.h"
 #include "driver/driver_interface.h"
 
-#if ENABLE_FILE == 1
+#ifdef ENABLE_FILE
 #include "driver/file/file.h"
 #endif
 
-#if ENABLE_XEN == 1
+#ifdef ENABLE_XEN
 #include "driver/xen/xen.h"
 #endif
 
-#if ENABLE_KVM == 1
+#ifdef ENABLE_KVM
 #include "driver/kvm/kvm.h"
 #endif
 
-#if ENABLE_BAREFLANK == 1
+#ifdef ENABLE_BAREFLANK
 #include "driver/bareflank/bareflank.h"
 #endif
 
@@ -56,28 +56,28 @@ status_t driver_init_mode(const char *name,
     unsigned long count = 0;
 
     /* see what systems are accessable */
-#if ENABLE_XEN == 1
+#ifdef ENABLE_XEN
     if (VMI_SUCCESS == xen_test(domainid, name, init_flags, init_data)) {
         dbprint(VMI_DEBUG_DRIVER, "--found Xen\n");
         *mode = VMI_XEN;
         count++;
     }
 #endif
-#if ENABLE_KVM == 1
+#ifdef ENABLE_KVM
     if (VMI_SUCCESS == kvm_test(domainid, name, init_flags, init_data)) {
         dbprint(VMI_DEBUG_DRIVER, "--found KVM\n");
         *mode = VMI_KVM;
         count++;
     }
 #endif
-#if ENABLE_FILE == 1
+#ifdef ENABLE_FILE
     if (VMI_SUCCESS == file_test(domainid, name, init_flags, init_data)) {
         dbprint(VMI_DEBUG_DRIVER, "--found file\n");
         *mode = VMI_FILE;
         count++;
     }
 #endif
-#if ENABLE_BAREFLANK == 1
+#ifdef ENABLE_BAREFLANK
     if (VMI_SUCCESS == bareflank_test(domainid, name)) {
         dbprint(VMI_DEBUG_DRIVER, "--found Bareflank\n");
         *mode = VMI_BAREFLANK;
@@ -112,22 +112,22 @@ status_t driver_init(vmi_instance_t vmi,
     bzero(&vmi->driver, sizeof(driver_interface_t));
 
     switch (vmi->mode) {
-#if ENABLE_XEN == 1
+#ifdef ENABLE_XEN
         case VMI_XEN:
             rc = driver_xen_setup(vmi);
             break;
 #endif
-#if ENABLE_KVM == 1
+#ifdef ENABLE_KVM
         case VMI_KVM:
             rc = driver_kvm_setup(vmi);
             break;
 #endif
-#if ENABLE_FILE == 1
+#ifdef ENABLE_FILE
         case VMI_FILE:
             rc = driver_file_setup(vmi);
             break;
 #endif
-#if ENABLE_BAREFLANK == 1
+#ifdef ENABLE_BAREFLANK
         case VMI_BAREFLANK:
             rc = driver_bareflank_setup(vmi);
             break;

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -52,7 +52,7 @@
 
 #define QMP_CMD_LENGTH 256
 
-#if HAVE_LIBVMI_REQUEST == 1
+#ifdef HAVE_LIBVMI_REQUEST
 # include <qemu/libvmi_request.h>
 #else
 
@@ -671,7 +671,7 @@ kvm_init_vmi(
     }
     vmi->num_vcpus = info.nrVirtCpu;
 
-#if HAVE_LIBVMI_REQUEST == 0
+#ifndef HAVE_LIBVMI_REQUEST
     struct json_object *qemu_version_obj = exec_info_version(kvm);
     dbprint(VMI_DEBUG_KVM, "--Checking QEMU version string...\n");
     // qemu_version JSON string :

--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -50,7 +50,7 @@ void *get_memory_data(
     return vmi->get_data_callback(vmi, paddr, length);
 }
 
-#if ENABLE_PAGE_CACHE == 1
+#ifdef ENABLE_PAGE_CACHE
 //---------------------------------------------------------
 // Internal implementation functions
 

--- a/libvmi/driver/xen/libxs_wrapper.h
+++ b/libvmi/driver/xen/libxs_wrapper.h
@@ -23,9 +23,9 @@
 #include <config.h>
 #include <dlfcn.h>
 
-#if HAVE_XENSTORE_H == 1
+#ifdef HAVE_XENSTORE_H
 #include <xenstore.h>
-#elif HAVE_XS_H == 1
+#elif defined(HAVE_XS_H)
 #include <xs.h>
 #endif
 
@@ -33,7 +33,7 @@
 
 struct xen_instance;
 
-#if HAVE_LIBXENSTORE == 0
+#ifndef HAVE_LIBXENSTORE
 struct xs_handle;
 typedef struct xs_transaction xs_transaction_t;
 #endif

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -37,7 +37,7 @@
 #define X86_TRAP_INT3   3
 #define X86_TRAP_page_fault 14
 
-#if HAVE_XENMEM_ACCESS_T == 1
+#ifdef HAVE_XENMEM_ACCESS_T
 #include <xen/memory.h>
 
 typedef enum {
@@ -55,7 +55,7 @@ typedef enum {
 } hvmmem_access_t;
 #endif
 
-#if HAVE_HVMMEM_ACCESS_T == 1
+#ifdef HAVE_HVMMEM_ACCESS_T
 typedef enum {
     XENMEM_access_n,
     XENMEM_access_r,

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -137,7 +137,7 @@ struct vmi_instance {
 
     GHashTable *v2p_cache;  /**< hash table to hold the v2p cache data */
 
-#if ENABLE_PAGE_CACHE == 1
+#ifdef ENABLE_PAGE_CACHE
     GHashTable *memory_cache;  /**< hash table for memory cache */
 
     GQueue *memory_cache_lru;  /**< queue holding the most recently used pages */

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -41,7 +41,7 @@ START_TEST (test_libvmi_cache)
     v2p_cache_flush(vmi, ~0ull);
     v2p_cache_set(vmi, 0x400000, 0xabcde, 0x3b40a000);
 
-#if ENABLE_ADDRESS_CACHE == 1
+#ifdef ENABLE_ADDRESS_CACHE
     addr_t pa = 0;
     status_t ret = v2p_cache_get(vmi, 0x880000400000ull, 0xabcde, &pa);
     fail_if(ret == VMI_SUCCESS, "hit a wrong cache");


### PR DESCRIPTION
There are quite a few cmake variables defined with `#cmakedefine01` which expands to either `VAR = 1` or `VAR = 0`. This means that these are always defined resulting in `#ifdef` macros always evaluating to true.