### PR TITLE
address implicit fallthrough warnings

### DIFF
--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -109,6 +109,7 @@ win_ver_t pe2version(vmi_instance_t vmi, addr_t kernbase_pa)
                 case 2:
                     return VMI_OS_WINDOWS_2003;
             };
+            break;
         case 6:
             switch (minor_os_version) {
                 case 0:
@@ -118,11 +119,13 @@ win_ver_t pe2version(vmi_instance_t vmi, addr_t kernbase_pa)
                 case 2:
                     return VMI_OS_WINDOWS_8;
             };
+            break;
         case 10:
             switch (minor_os_version) {
                 case 0:
                     return VMI_OS_WINDOWS_10;
             };
+            break;
     };
 
     return VMI_OS_WINDOWS_NONE;


### PR DESCRIPTION
Clang 8.0.0 complains about implicit fallthroughs. This should get the compiler off our backs.