### PR TITLE
make key_128_hash function return a 32 bit integer

### DIFF
--- a/libvmi/cache.c
+++ b/libvmi/cache.c
@@ -60,10 +60,11 @@ uint64_t hash128to64(
     return b;
 }
 
-guint64 key_128_hash(gconstpointer key)
+guint key_128_hash(gconstpointer key)
 {
     const key_128_t cache_key = (const key_128_t) key;
-    return hash128to64(cache_key->low, cache_key->high);
+    const uint64_t hash64 = hash128to64(cache_key->low, cache_key->high);
+    return g_int64_hash(&hash64);
 }
 
 gboolean key_128_equals(gconstpointer key1, gconstpointer key2)

--- a/libvmi/cache.h
+++ b/libvmi/cache.h
@@ -33,7 +33,7 @@ struct key_128 {
 typedef struct key_128 *key_128_t;
 
 uint64_t hash128to64(uint64_t low, uint64_t high);
-guint64 key_128_hash(gconstpointer key);
+guint key_128_hash(gconstpointer key);
 gboolean key_128_equals(gconstpointer key1, gconstpointer key2);
 void key_128_init(vmi_instance_t vmi, key_128_t key, uint64_t low, uint64_t high);
 key_128_t key_128_build (vmi_instance_t vmi, uint64_t low, uint64_t high);


### PR DESCRIPTION
This change addresses issue #780.