### PR TITLE
cmake: set default build type to debug if not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,17 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 #-----------------------------------------------------------------------------
 project(LibVMI VERSION 0.13.0 LANGUAGES C ASM)
 set(VERSION "0.13.0")
+
+# build type
+set(default_build_type "Debug")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+        STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+        STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 #-----------------------------------------------------------------------------
 #                              DEPENDENCIES
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The default CMake build type is empty, leading to binaries without debug symbols.

This forces the debug type to be `Debug` build, if not specified.
