### PR TITLE
Add support to toggle debug output using an env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ option(BUILD_EXAMPLES "Build the examples" ON)
 option(VMI_DEBUG "Debug output level" OFF)
 # hardening flags that causes overhead, disabled by default
 option(HARDENING "Enable hardening flags (with overhead)" OFF)
+option(ENV_DEBUG "Toggle the debug output via LIBVMI_DEBUG environment variable" OFF)
 
 # default values
 set(MAX_PAGE_CACHE_SIZE "512")

--- a/libvmi/config.h.in
+++ b/libvmi/config.h.in
@@ -10,6 +10,9 @@
 /* Define for the AMD x86-64 architecture. */
 #cmakedefine X86_64
 
+/* Toggle debugging via environment variable LIBVMI_DEBUG */
+#cmakedefine ENV_DEBUG
+
 /* Enable or disable the address cache (v2p, pid, etc) */
 #cmakedefine ENABLE_ADDRESS_CACHE
 

--- a/libvmi/convenience.c
+++ b/libvmi/convenience.c
@@ -31,6 +31,12 @@
 
 #include "private.h"
 
+#ifdef ENV_DEBUG
+# define ENV_DEBUG_COND getenv("LIBVMI_DEBUG")
+#else
+# define ENV_DEBUG_COND true
+#endif
+
 #ifndef VMI_DEBUG
 /* Nothing */
 #else
@@ -40,7 +46,7 @@ dbprint(
     char *format,
     ...)
 {
-    if (category & VMI_DEBUG) {
+    if ((category & VMI_DEBUG) && ENV_DEBUG_COND) {
         va_list args;
 
         va_start(args, format);


### PR DESCRIPTION
This implements the idea discussed in #649.

Disabled by default, so no performance impact for regular users.