### PR TITLE
xen: domain watcher feature depends on xenstore

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -659,12 +659,14 @@ _bail:
     return ret;
 }
 
+#ifdef HAVE_LIBXENSTORE
 status_t xen_domainwatch_init(
     vmi_instance_t vmi,
     uint32_t init_flags)
 {
     return xen_domainwatch_init_events(vmi, init_flags);
 }
+#endif
 
 void
 xen_destroy(

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -182,7 +182,9 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.initialized = true;
     driver.init_ptr = &xen_init;
     driver.init_vmi_ptr = &xen_init_vmi;
+#ifdef HAVE_LIBXENSTORE
     driver.domainwatch_init_ptr = &xen_domainwatch_init;
+#endif
     driver.destroy_ptr = &xen_destroy;
     driver.get_id_from_name_ptr = &xen_get_domainid_from_name;
     driver.get_name_from_id_ptr = &xen_get_name_from_domainid;

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -564,6 +564,7 @@ status_t xen_set_failed_emulation_event(vmi_instance_t vmi, bool enabled)
     return VMI_SUCCESS;
 }
 
+#ifdef HAVE_LIBXENSTORE
 status_t xen_set_domain_watch_event(vmi_instance_t vmi, bool enabled)
 {
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -589,6 +590,7 @@ status_t xen_set_domain_watch_event(vmi_instance_t vmi, bool enabled)
 
     return VMI_SUCCESS;
 }
+#endif
 
 /*
  * Event processing functions
@@ -2428,6 +2430,7 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
     return VMI_SUCCESS;
 }
 
+#ifdef HAVE_LIBXENSTORE
 status_t xen_domainwatch_init_events(
     vmi_instance_t vmi,
     uint32_t init_flags)
@@ -2465,6 +2468,7 @@ status_t xen_domainwatch_init_events(
 
     return VMI_SUCCESS;
 }
+#endif
 
 status_t xen_init_events(
     vmi_instance_t vmi,
@@ -2591,8 +2595,10 @@ status_t xen_init_events(
     vmi->driver.set_privcall_event_ptr = &xen_set_privcall_event;
     vmi->driver.set_desc_access_event_ptr = &xen_set_desc_access_event;
     vmi->driver.set_failed_emulation_event_ptr = &xen_set_failed_emulation_event;
+#ifdef HAVE_LIBXENSTORE
     if ( !vmi->driver.set_domain_watch_event_ptr )
         vmi->driver.set_domain_watch_event_ptr = &xen_set_domain_watch_event;
+#endif
 
     xen->libxcw.xc_monitor_get_capabilities(xch, dom, &xe->monitor_capabilities);
 


### PR DESCRIPTION
This PR fixes an issue found by #794 .

The domain watcher feature depends on `libxenstore` and shouldn't be compiled if this library is not found on the system.