### PR TITLE
Revert "xen: domain watcher feature depends on xenstore"

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -659,14 +659,12 @@ _bail:
     return ret;
 }
 
-#ifdef HAVE_LIBXENSTORE
 status_t xen_domainwatch_init(
     vmi_instance_t vmi,
     uint32_t init_flags)
 {
     return xen_domainwatch_init_events(vmi, init_flags);
 }
-#endif
 
 void
 xen_destroy(

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -182,9 +182,7 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.initialized = true;
     driver.init_ptr = &xen_init;
     driver.init_vmi_ptr = &xen_init_vmi;
-#ifdef HAVE_LIBXENSTORE
     driver.domainwatch_init_ptr = &xen_domainwatch_init;
-#endif
     driver.destroy_ptr = &xen_destroy;
     driver.get_id_from_name_ptr = &xen_get_domainid_from_name;
     driver.get_name_from_id_ptr = &xen_get_name_from_domainid;

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -564,7 +564,6 @@ status_t xen_set_failed_emulation_event(vmi_instance_t vmi, bool enabled)
     return VMI_SUCCESS;
 }
 
-#ifdef HAVE_LIBXENSTORE
 status_t xen_set_domain_watch_event(vmi_instance_t vmi, bool enabled)
 {
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -590,7 +589,6 @@ status_t xen_set_domain_watch_event(vmi_instance_t vmi, bool enabled)
 
     return VMI_SUCCESS;
 }
-#endif
 
 /*
  * Event processing functions
@@ -2430,7 +2428,6 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
     return VMI_SUCCESS;
 }
 
-#ifdef HAVE_LIBXENSTORE
 status_t xen_domainwatch_init_events(
     vmi_instance_t vmi,
     uint32_t init_flags)
@@ -2468,7 +2465,6 @@ status_t xen_domainwatch_init_events(
 
     return VMI_SUCCESS;
 }
-#endif
 
 status_t xen_init_events(
     vmi_instance_t vmi,
@@ -2595,10 +2591,8 @@ status_t xen_init_events(
     vmi->driver.set_privcall_event_ptr = &xen_set_privcall_event;
     vmi->driver.set_desc_access_event_ptr = &xen_set_desc_access_event;
     vmi->driver.set_failed_emulation_event_ptr = &xen_set_failed_emulation_event;
-#ifdef HAVE_LIBXENSTORE
     if ( !vmi->driver.set_domain_watch_event_ptr )
         vmi->driver.set_domain_watch_event_ptr = &xen_set_domain_watch_event;
-#endif
 
     xen->libxcw.xc_monitor_get_capabilities(xch, dom, &xe->monitor_capabilities);
 


### PR DESCRIPTION
Reverts libvmi/libvmi#795 due to compilation errors