### PR TITLE
Fixes for VMI against Windows mem snapshot (file mode)

### DIFF
--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -1058,7 +1058,7 @@ init_core(vmi_instance_t vmi)
         goto done;
 
     dbprint(VMI_DEBUG_MISC, "** Retrying init from Rekall profile.\n");
-    (void) init_from_rekall_profile_real(vmi, (reg_t)0);
+    ret = init_from_rekall_profile_real(vmi, (reg_t)0);
 
 done:
     return ret;

--- a/libvmi/os/windows/process.c
+++ b/libvmi/os/windows/process.c
@@ -199,9 +199,7 @@ find_process_by_name(
     addr_t offset = 0;
     uint32_t value = 0;
 
-    /* Some compilers don't align this large buffer. Force alignment so
-     * the offsets match between physical mem and the buffer. */
-    unsigned char block_buffer[VMI_PS_4KB] __attribute__((aligned(VMI_PS_4KB)));
+    unsigned char block_buffer[VMI_PS_4KB];
 
     if (NULL == check) {
         check = get_check_magic_func(vmi);


### PR DESCRIPTION
Analysis against a Windows 7 Xen VM worked fine, but failed against a memory snapshot of that same VM. I traced this down to a couple of oddities, namely:
- The technique for finding the System process was incorrectly checking for a string match
- Structure offsets were not pulled from Rekall if the Rekall init failed. However, the overall libvmi init could still succeed, but without those offsets.