### PR TITLE
Add vmi_toggle_single_step_vcpu

### DIFF
--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -805,6 +805,8 @@ vmi_event_t *vmi_get_singlestep_event (vmi_instance_t vmi,
  * libvmi event object's bitfield position.
  * This does not disable single step for the whole domain.
  *
+ * DEPRECATED: prefer vmi_toggle_single_step_vcpu()
+ *
  * @param[in] vmi LibVMI instance
  * @param[in] event the event to disable the vcpu on
  * @param[in] vcpu the vcpu to stop single stepping on
@@ -814,6 +816,23 @@ status_t vmi_stop_single_step_vcpu(
     vmi_instance_t vmi,
     vmi_event_t* event,
     uint32_t vcpu);
+
+/**
+ * Toggles the MTF single step flag from a vcpu as well as the
+ * libvmi event object's bitfield position.
+ * This does not toggle single step for the whole domain.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] event the event to disable the vcpu on
+ * @param[in] vcpu the vcpu to stop single stepping on
+ * @param[in] enabled whether to enable or disable single stepping
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_toggle_single_step_vcpu(
+    vmi_instance_t vmi,
+    vmi_event_t* event,
+    uint32_t vcpu,
+    bool enabled);
 
 /**
  * Cleans up any domain wide single step settings.

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -822,6 +822,11 @@ status_t vmi_stop_single_step_vcpu(
  * libvmi event object's bitfield position.
  * This does not toggle single step for the whole domain.
  *
+ * You need to ensure that the VM is paused beforehand
+ * and clean the event ring with vmi_events_listen(vmi, 0)
+ * before stopping the singlestep, otherwise new events
+ * will be queued in the meantime.
+ *
  * @param[in] vmi LibVMI instance
  * @param[in] event the event to disable the vcpu on
  * @param[in] vcpu the vcpu to stop single stepping on


### PR DESCRIPTION
This PR replaces `vmi_stop_single_step_vcpu` by a new API: `vmi_toggle_single_step_vcpu`, adding a boolean parameter to toggle the singlestep on-demand.

Notes:
- the singlestep example has been updated to demonstrate how this API should be used, as well as make use of `atexit` to better handle errors and ensure `vmi_destroy()` has been called while keeping the example code minimal.
- the API description better reflects in which context it should be called
- `g_try_malloc0` is used instead of `g_malloc0`, since [it doesn't abort on failure](https://developer.gnome.org/glib/unstable/glib-Memory-Allocation.html#g-try-malloc0) and provide error recovery: 

It should fix #815