### PR TITLE
Don't check VM pause-state in Xen driver during pause

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -2709,29 +2709,8 @@ xen_pause_vm(
 {
     xen_instance_t *xen = xen_get_instance(vmi);
 
-    xc_dominfo_t info = {0};
-    if (-1 == xen->libxcw.xc_domain_getinfo(xen->xchandle,
-                                            xen->domainid,
-                                            1,
-                                            &info)) {
-        return VMI_FAILURE;
-    }
-
-    if (info.domid != xen_get_instance(vmi)->domainid) {
-        return VMI_FAILURE;
-    }
-
-    /* Don't pause if it's already paused. */
-    if (info.paused) {
-        return VMI_SUCCESS;
-    }
-
-    if (-1 == xen->libxcw.xc_domain_pause(xen->xchandle,
-                                          xen->domainid)) {
-        return VMI_FAILURE;
-    }
-
-    return VMI_SUCCESS;
+    return -1 == xen->libxcw.xc_domain_pause(xen->xchandle, xen->domainid) ?
+           VMI_FAILURE : VMI_SUCCESS;
 }
 
 status_t
@@ -2740,11 +2719,8 @@ xen_resume_vm(
 {
     xen_instance_t *xen = xen_get_instance(vmi);
 
-    if (-1 == xen->libxcw.xc_domain_unpause(xen->xchandle, xen->domainid)) {
-        return VMI_FAILURE;
-    }
-
-    return VMI_SUCCESS;
+    return -1 == xen->libxcw.xc_domain_unpause(xen->xchandle, xen->domainid) ?
+           VMI_FAILURE : VMI_SUCCESS;
 }
 
 status_t


### PR DESCRIPTION
Currently calling vmi_pause_vm in an event callback for single vCPU VMs will bail because the VMs' state is already reported as paused. However, that prevents the callback from leaving the VM in a paused state, since the VM will be automatically resumed once the event callback is processed.

Remove the pause-state check from the Xen driver. It was originally introduced to avoid triggering Xen's reference counter of pauses, which could make resume operations more involved. However, in light of recent tests that optimization is not feasible. 