### PR TITLE
xen: properly close xen dynamic library handles on error

### DIFF
--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -221,5 +221,12 @@ status_t create_libxc_wrapper(xen_instance_t *xen)
     wrapper->xc_get_hvm_param = dlsym(wrapper->handle, "xc_get_hvm_param");
     wrapper->xc_set_hvm_param = dlsym(wrapper->handle, "xc_set_hvm_param");
 
-    return sanity_check(xen);
+    if (VMI_FAILURE == sanity_check(xen)) {
+        // close libxenctrl handle
+        if (dlclose(wrapper->handle))
+            errprint("dlclose failed: %s", strerror(errno));
+        return VMI_FAILURE;
+    }
+
+    return VMI_SUCCESS;
 }

--- a/libvmi/driver/xen/libxs_wrapper.c
+++ b/libvmi/driver/xen/libxs_wrapper.c
@@ -59,5 +59,12 @@ status_t create_libxs_wrapper(xen_instance_t *xen)
     wrapper->xs_watch = dlsym(wrapper->handle, "xs_watch");
     wrapper->xs_unwatch = dlsym(wrapper->handle, "xs_unwatch");
 
-    return sanity_check(xen);
+    if (VMI_FAILURE == sanity_check(xen)) {
+        // closing libxenstore handle
+        if (dlclose(wrapper->handle))
+            errprint("dlclose failed: %s\n", strerror(errno));
+        return VMI_FAILURE;
+    }
+
+    return VMI_SUCCESS;
 }

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -687,7 +687,8 @@ xen_destroy(
     if ( xchandle )
         xen->libxcw.xc_interface_close(xchandle);
 
-    dlclose(xen->libxcw.handle);
+    if (dlclose(xen->libxcw.handle))
+        errprint("dlclose failed: %s\n", strerror(errno));
 
 #ifdef HAVE_LIBXENSTORE
     if (xen->xshandle) {
@@ -696,7 +697,8 @@ xen_destroy(
         xen->libxsw.xs_close(xen->xshandle);
     }
 
-    dlclose(xen->libxsw.handle);
+    if (dlclose(xen->libxsw.handle))
+        errprint("dlclose failed: %s\n", strerror(errno));
     g_tree_destroy(xen->domains);
 #endif
 


### PR DESCRIPTION
This PR closes the `libxenctrl/libxenstore` handles upon error.