### PR TITLE
fix memory leaks and improper free() in kvm driver

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -620,13 +620,15 @@ kvm_init(
     vmi_init_data_t* UNUSED(init_data))
 {
     kvm_instance_t *kvm = g_try_malloc0(sizeof(kvm_instance_t));
-    if ( VMI_FAILURE == create_libvirt_wrapper(kvm) )
+    if ( VMI_FAILURE == create_libvirt_wrapper(kvm) ) {
+        g_free(kvm);
         return VMI_FAILURE;
+    }
 
     virConnectPtr conn = kvm->libvirt.virConnectOpenAuth("qemu:///system", kvm->libvirt.virConnectAuthPtrDefault, 0);
     if (NULL == conn) {
         dbprint(VMI_DEBUG_KVM, "--no connection to kvm hypervisor\n");
-        free(kvm);
+        g_free(kvm);
         return VMI_FAILURE;
     }
 
@@ -748,6 +750,7 @@ kvm_destroy(
     }
 
     dlclose(kvm->libvirt.handle);
+    g_free(kvm);
 }
 
 uint64_t


### PR DESCRIPTION
Leaks were detected in the KVM driver using Google's AddressSanitizer:
https://github.com/google/sanitizers/wiki/AddressSanitizer

Flags used to build our software (not libvmi): -g3 -fsanitize=address -fno-omit-frame-pointer

Conditions:
I am using LibVMI for malware unpacking research, with the host system based on Xen.

After program startup failed, due to stale/stuck VMs, ASAN reported the leaks in kvm_init(), which I wasn't even using. After a quick code inspection, I noticed the failure to g_free(kvm) where appropriate, and one use of free(kvm), which I believe fails on something allocated by g_malloc*() family.

Project Reference:
https://github.com/carter-yagemann/vmi-unpack