### PR TITLE
Unmask properly for external events

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -2302,38 +2302,7 @@ status_t init_events_413(vmi_instance_t vmi)
 /*
  * Main event functions
  */
-
-static
-status_t unmask_event(xen_instance_t *xen, xen_events_t *xe)
-{
-    int rc, port = xen->libxcw.xc_evtchn_pending(xe->xce_handle);
-
-    if ( -1 == port ) {
-        dbprint(VMI_DEBUG_XEN, "No event channel port is pending.\n");
-        return VMI_FAILURE;
-    }
-
-#ifdef ENABLE_SAFETY_CHECKS
-    if ( port != xe->port ) {
-        errprint("Event received for invalid port %i, Expected port is %i\n",
-                 port, xe->port);
-        return VMI_FAILURE;
-    }
-#endif
-
-    rc = xen->libxcw.xc_evtchn_unmask(xe->xce_handle, port);
-
-#ifdef ENABLE_SAFETY_CHECKS
-    if ( rc ) {
-        errprint("Failed to unmask event channel port\n");
-        return VMI_FAILURE;
-    }
-#endif
-
-    return VMI_SUCCESS;
-}
-
-static
+static inline
 status_t wait_for_event_or_timeout(vmi_instance_t vmi, unsigned long ms, bool *needs_unmasking)
 {
     xen_events_t *xe = xen_get_events(vmi);
@@ -2441,10 +2410,13 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
      * all requests that were on the ring.
      */
     if ( needs_unmasking ) {
-        vrc = unmask_event(xen, xe);
+        rc = xen->libxcw.xc_evtchn_unmask(xe->xce_handle, xe->port);
+
 #ifdef ENABLE_SAFETY_CHECKS
-        if ( VMI_FAILURE == vrc )
+        if ( rc ) {
+            errprint("Error unmasking event channel.\n");
             return VMI_FAILURE;
+        }
 #endif
     }
 


### PR DESCRIPTION
Forgo calling `xc_evtchn_pending` since it can block for no reason when an external poller is processing events. The port returned by this API is one we already know.