### PR TITLE
Conditionally unmask events for external events pollers

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -2385,7 +2385,7 @@ status_t xen_events_listen(vmi_instance_t vmi, uint32_t timeout)
                 return VMI_FAILURE;
             }
         } else
-            needs_unmasking = 1;
+            needs_unmasking = timeout;
     }
 
 #ifdef HAVE_LIBXENSTORE

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -760,6 +760,7 @@ status_t vmi_step_event(
  * Listen for events until one occurs or a timeout.
  * If the timeout is given as 0, it will process leftover events
  * in the ring-buffer (if there are any).
+ * If an external poller is used, timeout with 0 will also forgo unmasking events.
  *
  * @param[in] vmi LibVMI instance
  * @param[in] timeout Number of ms.


### PR DESCRIPTION
When an external poller is used and the user calls `vmi_events_listen` with 0 timeout, LibVMI may block during unmasking the Xen event channel if there were no new events reported via the event channel since last time. Allow the external poller to conditionally trigger unmasking depending on whether there were events received during polling.