### PR TITLE
Implement fast singlestep

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -614,11 +614,15 @@ void process_response ( event_response_t response, vmi_event_t *event, vm_event_
                     case VMI_EVENT_RESPONSE_VMM_PAGETABLE_ID:
                         rsp->altp2m_idx = event->slat_id;
                         break;
-                    case VMI_EVENT_RESPONSE_EMULATE_NOWRITE:
+                    case VMI_EVENT_RESPONSE_FAST_SINGLESTEP:
+                        rsp->fast_singlestep.p2midx = event->next_slat_id;
+                        break;
+                    case VMI_EVENT_RESPONSE_EMULATE_NOWRITE: // TODO Remove redundant case
                         rsp->flags |= event_response_conversion[VMI_EVENT_RESPONSE_EMULATE];
                         break;
                     case VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA:
                         if ( event->emul_read ) {
+                            // TODO Remove redundant conversion
                             rsp->flags |= event_response_conversion[VMI_EVENT_RESPONSE_EMULATE];
 
                             if ( event->emul_read->size < sizeof(event->emul_read->data) )
@@ -636,6 +640,7 @@ void process_response ( event_response_t response, vmi_event_t *event, vm_event_
                         break;
                     case VMI_EVENT_RESPONSE_SET_EMUL_INSN:
                         if ( event->emul_insn ) {
+                            // TODO Remove redundant conversion
                             rsp->flags |= event_response_conversion[VMI_EVENT_RESPONSE_EMULATE];
 
                             memcpy(&rsp->data.emul.insn.data,
@@ -1882,6 +1887,9 @@ status_t process_requests_412(vmi_instance_t vmi, uint32_t *requests_processed)
         rsp->flags = vmec.flags;
         rsp->reason = vmec.reason;
         rsp->altp2m_idx = vmec.altp2m_idx;
+
+        if (rsp->flags & VM_EVENT_FLAG_FAST_SINGLESTEP)
+          rsp->u.fast_singlestep.p2midx = vmec.fast_singlestep.p2midx;
 
         if ( rsp->flags & VM_EVENT_FLAG_SET_EMUL_READ_DATA ) {
             rsp->data.emul.read.size = vmec.data.emul.read.size;

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -94,6 +94,7 @@ typedef enum {
 #define VM_EVENT_FLAG_SET_REGISTERS      (1 << 8)
 #define VM_EVENT_FLAG_SET_EMUL_INSN_DATA (1 << 9)
 #define VM_EVENT_FLAG_GET_NEXT_INTERRUPT (1 << 10)
+#define VM_EVENT_FLAG_FAST_SINGLESTEP    (1 << 11)
 
 #define VM_EVENT_REASON_UNKNOWN                 0
 #define VM_EVENT_REASON_MEM_ACCESS              1
@@ -315,6 +316,10 @@ struct vm_event_singlestep {
     uint64_t gfn;
 };
 
+struct vm_event_fast_singlestep {
+  uint16_t p2midx;
+};
+
 struct vm_event_debug {
     uint64_t gfn;
     uint32_t insn_length;
@@ -472,6 +477,7 @@ typedef struct vm_event_st_412 {
         struct vm_event_mov_to_msr_411        mov_to_msr;
         struct vm_event_desc_access           desc_access;
         struct vm_event_singlestep            singlestep;
+        struct vm_event_fast_singlestep       fast_singlestep;
         struct vm_event_debug                 software_breakpoint;
         struct vm_event_debug                 debug_exception;
         struct vm_event_cpuid                 cpuid;

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -82,6 +82,7 @@ typedef struct vm_event_compat {
         struct vm_event_mov_to_msr_411        mov_to_msr;
         struct vm_event_desc_access           desc_access;
         struct vm_event_singlestep            singlestep;
+        struct vm_event_fast_singlestep       fast_singlestep;
         struct vm_event_debug                 software_breakpoint;
         struct vm_event_debug                 debug_exception;
         struct vm_event_cpuid                 cpuid;
@@ -141,6 +142,7 @@ static const unsigned int event_response_conversion[] = {
     [VMI_EVENT_RESPONSE_EMULATE] = VM_EVENT_FLAG_EMULATE,
     [VMI_EVENT_RESPONSE_EMULATE_NOWRITE] = VM_EVENT_FLAG_EMULATE_NOWRITE,
     [VMI_EVENT_RESPONSE_TOGGLE_SINGLESTEP] = VM_EVENT_FLAG_TOGGLE_SINGLESTEP,
+    [VMI_EVENT_RESPONSE_FAST_SINGLESTEP] = VM_EVENT_FLAG_FAST_SINGLESTEP,
     [VMI_EVENT_RESPONSE_SET_EMUL_READ_DATA] = VM_EVENT_FLAG_SET_EMUL_READ_DATA,
     [VMI_EVENT_RESPONSE_DENY] = VM_EVENT_FLAG_DENY,
     [VMI_EVENT_RESPONSE_VMM_PAGETABLE_ID] = VM_EVENT_FLAG_ALTERNATE_P2M,

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -434,7 +434,8 @@ typedef uint32_t event_response_flags_t;
 #define VMI_EVENT_RESPONSE_SET_REGISTERS        (1u << 7)
 #define VMI_EVENT_RESPONSE_SET_EMUL_INSN        (1u << 8)
 #define VMI_EVENT_RESPONSE_GET_NEXT_INTERRUPT   (1u << 9)
-#define __VMI_EVENT_RESPONSE_MAX                9
+#define VMI_EVENT_RESPONSE_FAST_SINGLESTEP      (1u << 10)
+#define __VMI_EVENT_RESPONSE_MAX                10
 
 /**
  * Bitmap holding event_reponse_flags_t values returned by callback
@@ -472,6 +473,13 @@ struct vmi_event {
      * Note: on Xen this corresponds to the altp2m_idx.
      */
     uint16_t slat_id;
+
+    /**
+     * RESPONSE
+     *
+     * Can be specified when registering fast singlestep.
+     */
+    uint16_t next_slat_id;
 
     /**
      * CONST IN


### PR DESCRIPTION
On break point event eight context switches occures.

With fast single step it is possible to shorten path for two context switches
and gain 35% spead-up.