### PR TITLE
Add support to vm_event version 6

### DIFF
--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -1266,15 +1266,15 @@ status_t process_request(vmi_instance_t vmi, vm_event_compat_t *vmec)
 }
 
 /*
- * Xen 4.6 ring functions
+ * VM_EVENT_VERSION 1 ring functions
  */
 
 static inline
-void ring_get_request_and_response_46(xen_events_t *xe,
-                                      vm_event_46_request_t **req,
-                                      vm_event_46_request_t **rsp)
+void ring_get_request_and_response_1(xen_events_t *xe,
+                                     vm_event_1_request_t **req,
+                                     vm_event_1_request_t **rsp)
 {
-    vm_event_46_back_ring_t *back_ring = &xe->back_ring_46;
+    vm_event_1_back_ring_t *back_ring = &xe->back_ring_1;
     RING_IDX req_cons = back_ring->req_cons;
     RING_IDX rsp_prod = back_ring->rsp_prod_pvt;
 
@@ -1289,10 +1289,10 @@ void ring_get_request_and_response_46(xen_events_t *xe,
 }
 
 static
-status_t process_requests_46(vmi_instance_t vmi, uint32_t *requests_processed)
+status_t process_requests_1(vmi_instance_t vmi, uint32_t *requests_processed)
 {
-    vm_event_46_request_t *req;
-    vm_event_46_response_t *rsp;
+    vm_event_1_request_t *req;
+    vm_event_1_response_t *rsp;
     vm_event_compat_t vmec =  { 0 };
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -1300,9 +1300,9 @@ status_t process_requests_46(vmi_instance_t vmi, uint32_t *requests_processed)
     status_t vrc = VMI_SUCCESS;
     uint32_t processed = 0;
 
-    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_46) ) {
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_1) ) {
 
-        ring_get_request_and_response_46(xe, &req, &rsp);
+        ring_get_request_and_response_1(xe, &req, &rsp);
 
         if ( req->version != 0x00000001 ) {
             errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that doesn't match what we expected (0x00000001)!\n");
@@ -1365,7 +1365,7 @@ status_t process_requests_46(vmi_instance_t vmi, uint32_t *requests_processed)
                 break;
 
             case VM_EVENT_REASON_SINGLESTEP:
-                memcpy(&vmec.singlestep, &req->u.singlestep, sizeof(vmec.singlestep));
+                vmec.singlestep.gfn = req->u.singlestep.gfn;
                 break;
 
             case VM_EVENT_REASON_SOFTWARE_BREAKPOINT:
@@ -1429,7 +1429,7 @@ status_t process_requests_46(vmi_instance_t vmi, uint32_t *requests_processed)
         }
 
         processed++;
-        RING_PUSH_RESPONSES(&xe->back_ring_46);
+        RING_PUSH_RESPONSES(&xe->back_ring_1);
 
         /*
          * Send notification to Xen that response(s) were placed on the ring
@@ -1454,7 +1454,7 @@ status_t process_requests_46(vmi_instance_t vmi, uint32_t *requests_processed)
     return vrc;
 }
 
-int xen_are_events_pending_46(vmi_instance_t vmi)
+int xen_are_events_pending_1(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
@@ -1465,35 +1465,35 @@ int xen_are_events_pending_46(vmi_instance_t vmi)
     }
 #endif
 
-    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_46);
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_1);
 }
 
 static
-status_t init_events_46(vmi_instance_t vmi)
+status_t init_events_1(vmi_instance_t vmi)
 {
     xen_events_t * xe = xen_get_events(vmi);
 
-    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_46;
-    xe->process_requests = &process_requests_46;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_1;
+    xe->process_requests = &process_requests_1;
 
-    SHARED_RING_INIT((vm_event_46_sring_t *)xe->ring_page);
-    BACK_RING_INIT(&xe->back_ring_46,
-                   (vm_event_46_sring_t *)xe->ring_page,
+    SHARED_RING_INIT((vm_event_1_sring_t *)xe->ring_page);
+    BACK_RING_INIT(&xe->back_ring_1,
+                   (vm_event_1_sring_t *)xe->ring_page,
                    XC_PAGE_SIZE);
 
     return VMI_SUCCESS;
 }
 
 /*
- * Xen 4.8 ring functions
+ * VM_EVENT_VERSION 2 ring functions
  */
 
 static inline
-void ring_get_request_and_response_48(xen_events_t *xe,
-                                      vm_event_48_request_t **req,
-                                      vm_event_48_request_t **rsp)
+void ring_get_request_and_response_2(xen_events_t *xe,
+                                     vm_event_2_request_t **req,
+                                     vm_event_2_request_t **rsp)
 {
-    vm_event_48_back_ring_t *back_ring = &xe->back_ring_48;
+    vm_event_2_back_ring_t *back_ring = &xe->back_ring_2;
     RING_IDX req_cons = back_ring->req_cons;
     RING_IDX rsp_prod = back_ring->rsp_prod_pvt;
 
@@ -1507,10 +1507,10 @@ void ring_get_request_and_response_48(xen_events_t *xe,
     back_ring->rsp_prod_pvt++;
 }
 
-status_t process_requests_48(vmi_instance_t vmi, uint32_t *requests_processed)
+status_t process_requests_2(vmi_instance_t vmi, uint32_t *requests_processed)
 {
-    vm_event_48_request_t *req;
-    vm_event_48_response_t *rsp;
+    vm_event_2_request_t *req;
+    vm_event_2_response_t *rsp;
     vm_event_compat_t vmec = { 0 };
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -1518,12 +1518,248 @@ status_t process_requests_48(vmi_instance_t vmi, uint32_t *requests_processed)
     status_t vrc = VMI_SUCCESS;
     uint32_t processed = 0;
 
-    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_48) ) {
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_2) ) {
 
-        ring_get_request_and_response_48(xe, &req, &rsp);
+        ring_get_request_and_response_2(xe, &req, &rsp);
 
-        if ( req->version > 0x00000003 ) {
-            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is newer then what we understand (0x%x > 0x%x)!\n",
+        if ( req->version != 0x00000002 ) {
+            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is different then what we expect (0x%x != 0x%x)!\n",
+                     req->version, 0x00000002);
+            return VMI_FAILURE;
+        }
+
+        vmec.version = req->version;
+        vmec.flags = req->flags;
+        vmec.reason = req->reason;
+        vmec.vcpu_id = req->vcpu_id;
+        vmec.altp2m_idx = req->altp2m_idx;
+
+#if defined(ARM32) || defined(ARM64)
+        memcpy(&vmec.data.regs.arm, &req->data.regs.arm, sizeof(vmec.data.regs.arm));
+#elif defined(I386) || defined(X86_64)
+        vmec.data.regs.x86.rax = req->data.regs.x86.rax;
+        vmec.data.regs.x86.rcx = req->data.regs.x86.rcx;
+        vmec.data.regs.x86.rdx = req->data.regs.x86.rdx;
+        vmec.data.regs.x86.rbx = req->data.regs.x86.rbx;
+        vmec.data.regs.x86.rsp = req->data.regs.x86.rsp;
+        vmec.data.regs.x86.rbp = req->data.regs.x86.rbp;
+        vmec.data.regs.x86.rsi = req->data.regs.x86.rsi;
+        vmec.data.regs.x86.rdi = req->data.regs.x86.rdi;
+        vmec.data.regs.x86.r8 = req->data.regs.x86.r8;
+        vmec.data.regs.x86.r9 = req->data.regs.x86.r9;
+        vmec.data.regs.x86.r10 = req->data.regs.x86.r10;
+        vmec.data.regs.x86.r11 = req->data.regs.x86.r11;
+        vmec.data.regs.x86.r12 = req->data.regs.x86.r12;
+        vmec.data.regs.x86.r13 = req->data.regs.x86.r13;
+        vmec.data.regs.x86.r14 = req->data.regs.x86.r14;
+        vmec.data.regs.x86.r15 = req->data.regs.x86.r15;
+        vmec.data.regs.x86.rflags = req->data.regs.x86.rflags;
+        vmec.data.regs.x86.dr7 = req->data.regs.x86.dr7;
+        vmec.data.regs.x86.rip = req->data.regs.x86.rip;
+        vmec.data.regs.x86.cr0 = req->data.regs.x86.cr0;
+        vmec.data.regs.x86.cr2 = req->data.regs.x86.cr2;
+        vmec.data.regs.x86.cr3 = req->data.regs.x86.cr3;
+        vmec.data.regs.x86.cr4 = req->data.regs.x86.cr4;
+        vmec.data.regs.x86.sysenter_cs = req->data.regs.x86.sysenter_cs;
+        vmec.data.regs.x86.sysenter_esp = req->data.regs.x86.sysenter_esp;
+        vmec.data.regs.x86.sysenter_eip = req->data.regs.x86.sysenter_eip;
+        vmec.data.regs.x86.msr_efer = req->data.regs.x86.msr_efer;
+        vmec.data.regs.x86.msr_star = req->data.regs.x86.msr_star;
+        vmec.data.regs.x86.msr_lstar = req->data.regs.x86.msr_lstar;
+        vmec.data.regs.x86.fs_base = req->data.regs.x86.fs_base;
+        vmec.data.regs.x86.gs_base = req->data.regs.x86.gs_base;
+        vmec.data.regs.x86.cs_arbytes = req->data.regs.x86.cs_arbytes;
+#endif
+
+        switch ( vmec.reason ) {
+            case VM_EVENT_REASON_MEM_ACCESS:
+                memcpy(&vmec.mem_access, &req->u.mem_access, sizeof(vmec.mem_access));
+                break;
+
+            case VM_EVENT_REASON_WRITE_CTRLREG:
+                memcpy(&vmec.write_ctrlreg, &req->u.write_ctrlreg, sizeof(vmec.write_ctrlreg));
+                break;
+
+            case VM_EVENT_REASON_MOV_TO_MSR:
+                vmec.mov_to_msr.msr = req->u.mov_to_msr_1.msr;
+                vmec.mov_to_msr.new_value = req->u.mov_to_msr_1.value;
+                break;
+
+            case VM_EVENT_REASON_SINGLESTEP:
+                memcpy(&vmec.singlestep, &req->u.singlestep, sizeof(vmec.singlestep));
+                break;
+
+            case VM_EVENT_REASON_SOFTWARE_BREAKPOINT:
+                memcpy(&vmec.software_breakpoint, &req->u.software_breakpoint, sizeof(vmec.software_breakpoint));
+                break;
+
+            case VM_EVENT_REASON_INTERRUPT:
+                memcpy(&vmec.x86_interrupt, &req->u.interrupt.x86, sizeof(vmec.x86_interrupt));
+                break;
+
+            case VM_EVENT_REASON_DEBUG_EXCEPTION:
+                memcpy(&vmec.debug_exception, &req->u.debug_exception, sizeof(vmec.debug_exception));
+                break;
+
+            case VM_EVENT_REASON_CPUID:
+                memcpy(&vmec.cpuid, &req->u.cpuid, sizeof(vmec.cpuid));
+                break;
+        }
+
+        vrc = process_request(vmi, &vmec);
+#ifdef ENABLE_SAFETY_CHECKS
+        if ( VMI_FAILURE == vrc )
+            break;
+#endif
+
+        rsp->version = vmec.version;
+        rsp->vcpu_id = vmec.vcpu_id;
+        rsp->flags = vmec.flags;
+        rsp->reason = vmec.reason;
+        rsp->altp2m_idx = vmec.altp2m_idx;
+
+        if ( rsp->flags & VM_EVENT_FLAG_SET_EMUL_READ_DATA ) {
+            rsp->data.emul.read.size = vmec.data.emul.read.size;
+            memcpy(&rsp->data.emul.read.data, &vmec.data.emul.read.data, vmec.data.emul.read.size);
+        }
+
+        if ( rsp->flags & VM_EVENT_FLAG_SET_EMUL_INSN_DATA )
+            memcpy(&rsp->data.emul.insn, &vmec.data.emul.insn, sizeof(rsp->data.emul.insn));
+
+        if ( rsp->flags & VM_EVENT_FLAG_SET_REGISTERS ) {
+#if defined(ARM32) || defined(ARM64)
+            memcpy(&rsp->data.regs.arm, &vmec.data.regs.arm, sizeof(rsp->data.regs.arm));
+#elif defined(I386) || defined(X86_64)
+            rsp->data.regs.x86.rax = vmec.data.regs.x86.rax;
+            rsp->data.regs.x86.rcx = vmec.data.regs.x86.rcx;
+            rsp->data.regs.x86.rdx = vmec.data.regs.x86.rdx;
+            rsp->data.regs.x86.rbx = vmec.data.regs.x86.rbx;
+            rsp->data.regs.x86.rsp = vmec.data.regs.x86.rsp;
+            rsp->data.regs.x86.rbp = vmec.data.regs.x86.rbp;
+            rsp->data.regs.x86.rsi = vmec.data.regs.x86.rsi;
+            rsp->data.regs.x86.rdi = vmec.data.regs.x86.rdi;
+            rsp->data.regs.x86.r8 = vmec.data.regs.x86.r8;
+            rsp->data.regs.x86.r9 = vmec.data.regs.x86.r9;
+            rsp->data.regs.x86.r10 = vmec.data.regs.x86.r10;
+            rsp->data.regs.x86.r11 = vmec.data.regs.x86.r11;
+            rsp->data.regs.x86.r12 = vmec.data.regs.x86.r12;
+            rsp->data.regs.x86.r13 = vmec.data.regs.x86.r13;
+            rsp->data.regs.x86.r14 = vmec.data.regs.x86.r14;
+            rsp->data.regs.x86.r15 = vmec.data.regs.x86.r15;
+            rsp->data.regs.x86.rflags = vmec.data.regs.x86.rflags;
+            rsp->data.regs.x86.dr7 = vmec.data.regs.x86.dr7;
+            rsp->data.regs.x86.rip = vmec.data.regs.x86.rip;
+            rsp->data.regs.x86.cr0 = vmec.data.regs.x86.cr0;
+            rsp->data.regs.x86.cr2 = vmec.data.regs.x86.cr2;
+            rsp->data.regs.x86.cr3 = vmec.data.regs.x86.cr3;
+            rsp->data.regs.x86.cr4 = vmec.data.regs.x86.cr4;
+            rsp->data.regs.x86.sysenter_cs = vmec.data.regs.x86.sysenter_cs;
+            rsp->data.regs.x86.sysenter_esp = vmec.data.regs.x86.sysenter_esp;
+            rsp->data.regs.x86.sysenter_eip = vmec.data.regs.x86.sysenter_eip;
+            rsp->data.regs.x86.msr_efer = vmec.data.regs.x86.msr_efer;
+            rsp->data.regs.x86.msr_star = vmec.data.regs.x86.msr_star;
+            rsp->data.regs.x86.msr_lstar = vmec.data.regs.x86.msr_lstar;
+            rsp->data.regs.x86.fs_base = vmec.data.regs.x86.fs_base;
+            rsp->data.regs.x86.gs_base = vmec.data.regs.x86.gs_base;
+            rsp->data.regs.x86.cs_arbytes = vmec.data.regs.x86.cs_arbytes;
+            rsp->data.regs.x86._pad = 0;
+#endif
+        }
+
+        processed++;
+        RING_PUSH_RESPONSES(&xe->back_ring_2);
+
+        /*
+         * Send notification to Xen that response(s) were placed on the ring
+         *
+         * Note: it is more performant to send notification after each event if
+         * there are a lot of vCPUs assigned to the VM.
+         */
+        if (vmi->num_vcpus >= 7) {
+            rc = xen->libxcw.xc_evtchn_notify(xe->xce_handle, xe->port);
+
+#ifdef ENABLE_SAFETY_CHECKS
+            if ( rc ) {
+                errprint("Error sending event channel notification.\n");
+                return VMI_FAILURE;
+            }
+#endif
+        }
+    }
+
+    *requests_processed = processed;
+    return vrc;
+}
+
+int xen_are_events_pending_2(vmi_instance_t vmi)
+{
+    xen_events_t *xe = xen_get_events(vmi);
+
+#ifdef ENABLE_SAFETY_CHECKS
+    if ( !xe ) {
+        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
+        return -1;
+    }
+#endif
+
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_2);
+}
+
+status_t init_events_2(vmi_instance_t vmi)
+{
+    xen_events_t *xe = xen_get_events(vmi);
+
+    xe->process_requests = &process_requests_2;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_2;
+
+    SHARED_RING_INIT((vm_event_2_sring_t *)xe->ring_page);
+    BACK_RING_INIT(&xe->back_ring_2,
+                   (vm_event_2_sring_t *)xe->ring_page,
+                   XC_PAGE_SIZE);
+
+    return VMI_SUCCESS;
+}
+
+/*
+ * VM_EVENT_VERSION 3 ring functions
+ */
+
+static inline
+void ring_get_request_and_response_3(xen_events_t *xe,
+                                     vm_event_3_request_t **req,
+                                     vm_event_3_request_t **rsp)
+{
+    vm_event_3_back_ring_t *back_ring = &xe->back_ring_3;
+    RING_IDX req_cons = back_ring->req_cons;
+    RING_IDX rsp_prod = back_ring->rsp_prod_pvt;
+
+    *req = RING_GET_REQUEST(back_ring, req_cons);
+    *rsp = RING_GET_RESPONSE(back_ring, rsp_prod);
+
+    // Update ring positions
+    req_cons++;
+    back_ring->req_cons = req_cons;
+    back_ring->sring->req_event = req_cons + 1;
+    back_ring->rsp_prod_pvt++;
+}
+
+status_t process_requests_3(vmi_instance_t vmi, uint32_t *requests_processed)
+{
+    vm_event_3_request_t *req;
+    vm_event_3_response_t *rsp;
+    vm_event_compat_t vmec = { 0 };
+    xen_events_t *xe = xen_get_events(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
+    int rc;
+    status_t vrc = VMI_SUCCESS;
+    uint32_t processed = 0;
+
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_3) ) {
+
+        ring_get_request_and_response_3(xe, &req, &rsp);
+
+        if ( req->version != 0x00000003 ) {
+            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is different then what we expect (0x%x != 0x%x)!\n",
                      req->version, 0x00000003);
             return VMI_FAILURE;
         }
@@ -1581,11 +1817,7 @@ status_t process_requests_48(vmi_instance_t vmi, uint32_t *requests_processed)
                 break;
 
             case VM_EVENT_REASON_MOV_TO_MSR:
-                if ( xen->minor_version < 11 ) {
-                    vmec.mov_to_msr.msr = req->u.mov_to_msr_46.msr;
-                    vmec.mov_to_msr.new_value = req->u.mov_to_msr_46.value;
-                } else
-                    memcpy(&vmec.mov_to_msr, &req->u.mov_to_msr_411, sizeof(vmec.mov_to_msr));
+                memcpy(&vmec.mov_to_msr, &req->u.mov_to_msr_3, sizeof(vmec.mov_to_msr));
                 break;
 
             case VM_EVENT_REASON_SINGLESTEP:
@@ -1674,7 +1906,7 @@ status_t process_requests_48(vmi_instance_t vmi, uint32_t *requests_processed)
         }
 
         processed++;
-        RING_PUSH_RESPONSES(&xe->back_ring_48);
+        RING_PUSH_RESPONSES(&xe->back_ring_3);
 
         /*
          * Send notification to Xen that response(s) were placed on the ring
@@ -1698,7 +1930,7 @@ status_t process_requests_48(vmi_instance_t vmi, uint32_t *requests_processed)
     return vrc;
 }
 
-int xen_are_events_pending_48(vmi_instance_t vmi)
+int xen_are_events_pending_3(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
@@ -1709,34 +1941,34 @@ int xen_are_events_pending_48(vmi_instance_t vmi)
     }
 #endif
 
-    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_48);
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_3);
 }
 
-status_t init_events_48(vmi_instance_t vmi)
+status_t init_events_3(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
-    xe->process_requests = &process_requests_48;
-    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_48;
+    xe->process_requests = &process_requests_3;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_3;
 
-    SHARED_RING_INIT((vm_event_48_sring_t *)xe->ring_page);
-    BACK_RING_INIT(&xe->back_ring_48,
-                   (vm_event_48_sring_t *)xe->ring_page,
+    SHARED_RING_INIT((vm_event_3_sring_t *)xe->ring_page);
+    BACK_RING_INIT(&xe->back_ring_3,
+                   (vm_event_3_sring_t *)xe->ring_page,
                    XC_PAGE_SIZE);
 
     return VMI_SUCCESS;
 }
 
 /*
- * Xen 4.12 ring functions
+ * VM_EVENT_VERSION 4 ring functions
  */
 
 static inline
-void ring_get_request_and_response_412(xen_events_t *xe,
-                                       vm_event_412_request_t **req,
-                                       vm_event_412_request_t **rsp)
+void ring_get_request_and_response_4(xen_events_t *xe,
+                                     vm_event_4_request_t **req,
+                                     vm_event_4_request_t **rsp)
 {
-    vm_event_412_back_ring_t *back_ring = &xe->back_ring_412;
+    vm_event_4_back_ring_t *back_ring = &xe->back_ring_4;
     RING_IDX req_cons = back_ring->req_cons;
     RING_IDX rsp_prod = back_ring->rsp_prod_pvt;
 
@@ -1750,10 +1982,10 @@ void ring_get_request_and_response_412(xen_events_t *xe,
     back_ring->rsp_prod_pvt++;
 }
 
-status_t process_requests_412(vmi_instance_t vmi, uint32_t *requests_processed)
+status_t process_requests_4(vmi_instance_t vmi, uint32_t *requests_processed)
 {
-    vm_event_412_request_t *req;
-    vm_event_412_response_t *rsp;
+    vm_event_4_request_t *req;
+    vm_event_4_response_t *rsp;
     vm_event_compat_t vmec = { 0 };
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -1761,12 +1993,12 @@ status_t process_requests_412(vmi_instance_t vmi, uint32_t *requests_processed)
     status_t vrc = VMI_SUCCESS;
     uint32_t processed = 0;
 
-    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_412) ) {
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_4) ) {
 
-        ring_get_request_and_response_412(xe, &req, &rsp);
+        ring_get_request_and_response_4(xe, &req, &rsp);
 
-        if ( req->version > 0x00000004 ) {
-            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is newer then what we understand (0x%x > 0x%x)!\n",
+        if ( req->version != 0x00000004 ) {
+            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is different then what we expect (0x%x != 0x%x)!\n",
                      req->version, 0x00000004);
             return VMI_FAILURE;
         }
@@ -1959,7 +2191,7 @@ status_t process_requests_412(vmi_instance_t vmi, uint32_t *requests_processed)
         }
 
         processed++;
-        RING_PUSH_RESPONSES(&xe->back_ring_412);
+        RING_PUSH_RESPONSES(&xe->back_ring_4);
 
         /*
          * Send notification to Xen that response(s) were placed on the ring
@@ -1983,7 +2215,7 @@ status_t process_requests_412(vmi_instance_t vmi, uint32_t *requests_processed)
     return vrc;
 }
 
-int xen_are_events_pending_412(vmi_instance_t vmi)
+int xen_are_events_pending_4(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
@@ -1994,34 +2226,34 @@ int xen_are_events_pending_412(vmi_instance_t vmi)
     }
 #endif
 
-    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_412);
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_4);
 }
 
-status_t init_events_412(vmi_instance_t vmi)
+status_t init_events_4(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
-    xe->process_requests = &process_requests_412;
-    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_412;
+    xe->process_requests = &process_requests_4;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_4;
 
-    SHARED_RING_INIT((vm_event_412_sring_t *)xe->ring_page);
-    BACK_RING_INIT(&xe->back_ring_412,
-                   (vm_event_412_sring_t *)xe->ring_page,
+    SHARED_RING_INIT((vm_event_4_sring_t *)xe->ring_page);
+    BACK_RING_INIT(&xe->back_ring_4,
+                   (vm_event_4_sring_t *)xe->ring_page,
                    XC_PAGE_SIZE);
 
     return VMI_SUCCESS;
 }
 
 /*
- * Xen 4.13 ring functions
+ * VM_EVENT_VERSION 5 ring functions
  */
 
 static inline
-void ring_get_request_and_response_413(xen_events_t *xe,
-                                       vm_event_413_request_t **req,
-                                       vm_event_413_request_t **rsp)
+void ring_get_request_and_response_5(xen_events_t *xe,
+                                     vm_event_5_request_t **req,
+                                     vm_event_5_request_t **rsp)
 {
-    vm_event_413_back_ring_t *back_ring = &xe->back_ring_413;
+    vm_event_5_back_ring_t *back_ring = &xe->back_ring_5;
     RING_IDX req_cons = back_ring->req_cons;
     RING_IDX rsp_prod = back_ring->rsp_prod_pvt;
 
@@ -2035,10 +2267,10 @@ void ring_get_request_and_response_413(xen_events_t *xe,
     back_ring->rsp_prod_pvt++;
 }
 
-status_t process_requests_413(vmi_instance_t vmi, uint32_t *requests_processed)
+status_t process_requests_5(vmi_instance_t vmi, uint32_t *requests_processed)
 {
-    vm_event_413_request_t *req;
-    vm_event_413_response_t *rsp;
+    vm_event_5_request_t *req;
+    vm_event_5_response_t *rsp;
     vm_event_compat_t vmec = { 0 };
     xen_events_t *xe = xen_get_events(vmi);
     xen_instance_t *xen = xen_get_instance(vmi);
@@ -2046,12 +2278,12 @@ status_t process_requests_413(vmi_instance_t vmi, uint32_t *requests_processed)
     status_t vrc = VMI_SUCCESS;
     uint32_t processed = 0;
 
-    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_413) ) {
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_5) ) {
 
-        ring_get_request_and_response_413(xe, &req, &rsp);
+        ring_get_request_and_response_5(xe, &req, &rsp);
 
-        if ( req->version > 0x00000005 ) {
-            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is newer then what we understand (0x%x > 0x%x)!\n",
+        if ( req->version != 0x00000005 ) {
+            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is different then what we expect (0x%x > 0x%x)!\n",
                      req->version, 0x00000005);
             return VMI_FAILURE;
         }
@@ -2248,7 +2480,7 @@ status_t process_requests_413(vmi_instance_t vmi, uint32_t *requests_processed)
         }
 
         processed++;
-        RING_PUSH_RESPONSES(&xe->back_ring_413);
+        RING_PUSH_RESPONSES(&xe->back_ring_5);
 
         /*
          * Send notification to Xen that response(s) were placed on the ring
@@ -2272,7 +2504,7 @@ status_t process_requests_413(vmi_instance_t vmi, uint32_t *requests_processed)
     return vrc;
 }
 
-int xen_are_events_pending_413(vmi_instance_t vmi)
+int xen_are_events_pending_5(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
@@ -2283,25 +2515,314 @@ int xen_are_events_pending_413(vmi_instance_t vmi)
     }
 #endif
 
-    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_413);
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_5);
 }
 
 
-status_t init_events_413(vmi_instance_t vmi)
+status_t init_events_5(vmi_instance_t vmi)
 {
     xen_events_t *xe = xen_get_events(vmi);
 
-    xe->process_requests = &process_requests_413;
-    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_413;
+    xe->process_requests = &process_requests_5;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_5;
 
-    SHARED_RING_INIT((vm_event_413_sring_t *)xe->ring_page);
-    BACK_RING_INIT(&xe->back_ring_413,
-                   (vm_event_413_sring_t *)xe->ring_page,
+    SHARED_RING_INIT((vm_event_5_sring_t *)xe->ring_page);
+    BACK_RING_INIT(&xe->back_ring_5,
+                   (vm_event_5_sring_t *)xe->ring_page,
                    XC_PAGE_SIZE);
 
     return VMI_SUCCESS;
 }
 
+/*
+ * VM_EVENT_VERSION 6 ring functions
+ */
+
+static inline
+void ring_get_request_and_response_6(xen_events_t *xe,
+                                     vm_event_6_request_t **req,
+                                     vm_event_6_request_t **rsp)
+{
+    vm_event_6_back_ring_t *back_ring = &xe->back_ring_6;
+    RING_IDX req_cons = back_ring->req_cons;
+    RING_IDX rsp_prod = back_ring->rsp_prod_pvt;
+
+    *req = RING_GET_REQUEST(back_ring, req_cons);
+    *rsp = RING_GET_RESPONSE(back_ring, rsp_prod);
+
+    // Update ring positions
+    req_cons++;
+    back_ring->req_cons = req_cons;
+    back_ring->sring->req_event = req_cons + 1;
+    back_ring->rsp_prod_pvt++;
+}
+
+status_t process_requests_6(vmi_instance_t vmi, uint32_t *requests_processed)
+{
+    vm_event_6_request_t *req;
+    vm_event_6_response_t *rsp;
+    vm_event_compat_t vmec = { 0 };
+    xen_events_t *xe = xen_get_events(vmi);
+    xen_instance_t *xen = xen_get_instance(vmi);
+    int rc;
+    status_t vrc = VMI_SUCCESS;
+    uint32_t processed = 0;
+
+    while ( RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_6) ) {
+
+        ring_get_request_and_response_6(xe, &req, &rsp);
+
+        if ( req->version != 0x00000006 ) {
+            errprint("Error, Xen reports a VM_EVENT_INTERFACE_VERSION that is different then what we expect (0x%x != 0x%x)!\n",
+                     req->version, 0x00000006);
+            return VMI_FAILURE;
+        }
+
+        vmec.version = req->version;
+        vmec.flags = req->flags;
+        vmec.reason = req->reason;
+        vmec.vcpu_id = req->vcpu_id;
+        vmec.altp2m_idx = req->altp2m_idx;
+
+#if defined(ARM32) || defined(ARM64)
+        memcpy(&vmec.data.regs.arm, &req->data.regs.arm, sizeof(vmec.data.regs.arm));
+#elif defined(I386) || defined(X86_64)
+        vmec.data.regs.x86.rax = req->data.regs.x86.rax;
+        vmec.data.regs.x86.rcx = req->data.regs.x86.rcx;
+        vmec.data.regs.x86.rdx = req->data.regs.x86.rdx;
+        vmec.data.regs.x86.rbx = req->data.regs.x86.rbx;
+        vmec.data.regs.x86.rsp = req->data.regs.x86.rsp;
+        vmec.data.regs.x86.rbp = req->data.regs.x86.rbp;
+        vmec.data.regs.x86.rsi = req->data.regs.x86.rsi;
+        vmec.data.regs.x86.rdi = req->data.regs.x86.rdi;
+        vmec.data.regs.x86.r8 = req->data.regs.x86.r8;
+        vmec.data.regs.x86.r9 = req->data.regs.x86.r9;
+        vmec.data.regs.x86.r10 = req->data.regs.x86.r10;
+        vmec.data.regs.x86.r11 = req->data.regs.x86.r11;
+        vmec.data.regs.x86.r12 = req->data.regs.x86.r12;
+        vmec.data.regs.x86.r13 = req->data.regs.x86.r13;
+        vmec.data.regs.x86.r14 = req->data.regs.x86.r14;
+        vmec.data.regs.x86.r15 = req->data.regs.x86.r15;
+        vmec.data.regs.x86.rflags = req->data.regs.x86.rflags;
+        vmec.data.regs.x86.dr6 = req->data.regs.x86.dr6;
+        vmec.data.regs.x86.dr7 = req->data.regs.x86.dr7;
+        vmec.data.regs.x86.rip = req->data.regs.x86.rip;
+        vmec.data.regs.x86.cr0 = req->data.regs.x86.cr0;
+        vmec.data.regs.x86.cr2 = req->data.regs.x86.cr2;
+        vmec.data.regs.x86.cr3 = req->data.regs.x86.cr3;
+        vmec.data.regs.x86.cr4 = req->data.regs.x86.cr4;
+        vmec.data.regs.x86.sysenter_cs = req->data.regs.x86.sysenter_cs;
+        vmec.data.regs.x86.sysenter_esp = req->data.regs.x86.sysenter_esp;
+        vmec.data.regs.x86.sysenter_eip = req->data.regs.x86.sysenter_eip;
+        vmec.data.regs.x86.msr_efer = req->data.regs.x86.msr_efer;
+        vmec.data.regs.x86.msr_star = req->data.regs.x86.msr_star;
+        vmec.data.regs.x86.msr_lstar = req->data.regs.x86.msr_lstar;
+        vmec.data.regs.x86.gdtr_base = req->data.regs.x86.gdtr_base;
+        vmec.data.regs.x86.gdtr_limit = req->data.regs.x86.gdtr_limit;
+        vmec.data.regs.x86.shadow_gs = req->data.regs.x86.shadow_gs;
+        vmec.data.regs.x86.fs_base = req->data.regs.x86.fs_base;
+        vmec.data.regs.x86.fs_sel = req->data.regs.x86.fs_sel;
+        vmec.data.regs.x86.fs_limit = req->data.regs.x86.fs.limit;
+        vmec.data.regs.x86.fs_arbytes = req->data.regs.x86.fs.ar;
+        vmec.data.regs.x86.gs_base = req->data.regs.x86.gs_base;
+        vmec.data.regs.x86.gs_sel = req->data.regs.x86.gs_sel;
+        vmec.data.regs.x86.gs_limit = req->data.regs.x86.gs.limit;
+        vmec.data.regs.x86.gs_arbytes = req->data.regs.x86.gs.ar;
+        vmec.data.regs.x86.cs_base = req->data.regs.x86.cs_base;
+        vmec.data.regs.x86.cs_sel = req->data.regs.x86.cs_sel;
+        vmec.data.regs.x86.cs_limit = req->data.regs.x86.cs.limit;
+        vmec.data.regs.x86.cs_arbytes = req->data.regs.x86.cs.ar;
+        vmec.data.regs.x86.ds_base = req->data.regs.x86.ds_base;
+        vmec.data.regs.x86.ds_sel = req->data.regs.x86.ds_sel;
+        vmec.data.regs.x86.ds_limit = req->data.regs.x86.ds.limit;
+        vmec.data.regs.x86.ds_arbytes = req->data.regs.x86.ds.ar;
+        vmec.data.regs.x86.es_base = req->data.regs.x86.es_base;
+        vmec.data.regs.x86.es_sel = req->data.regs.x86.es_sel;
+        vmec.data.regs.x86.es_limit = req->data.regs.x86.es.limit;
+        vmec.data.regs.x86.es_arbytes = req->data.regs.x86.es.ar;
+        vmec.data.regs.x86.ss_base = req->data.regs.x86.ss_base;
+        vmec.data.regs.x86.ss_sel = req->data.regs.x86.ss_sel;
+        vmec.data.regs.x86.ss_limit = req->data.regs.x86.ss.limit;
+        vmec.data.regs.x86.ss_arbytes = req->data.regs.x86.ss.ar;
+#endif
+
+        switch ( vmec.reason ) {
+            case VM_EVENT_REASON_MEM_ACCESS:
+                memcpy(&vmec.mem_access, &req->u.mem_access, sizeof(vmec.mem_access));
+                break;
+
+            case VM_EVENT_REASON_WRITE_CTRLREG:
+                memcpy(&vmec.write_ctrlreg, &req->u.write_ctrlreg, sizeof(vmec.write_ctrlreg));
+                break;
+
+            case VM_EVENT_REASON_MOV_TO_MSR:
+                memcpy(&vmec.mov_to_msr, &req->u.mov_to_msr, sizeof(vmec.mov_to_msr));
+                break;
+
+            case VM_EVENT_REASON_SINGLESTEP:
+                memcpy(&vmec.singlestep, &req->u.singlestep, sizeof(vmec.singlestep));
+                break;
+
+            case VM_EVENT_REASON_SOFTWARE_BREAKPOINT:
+                memcpy(&vmec.software_breakpoint, &req->u.software_breakpoint, sizeof(vmec.software_breakpoint));
+                break;
+
+            case VM_EVENT_REASON_INTERRUPT:
+                memcpy(&vmec.x86_interrupt, &req->u.interrupt.x86, sizeof(vmec.x86_interrupt));
+                break;
+
+            case VM_EVENT_REASON_DEBUG_EXCEPTION:
+                memcpy(&vmec.debug_exception, &req->u.debug_exception, sizeof(vmec.debug_exception));
+                break;
+
+            case VM_EVENT_REASON_CPUID:
+                memcpy(&vmec.cpuid, &req->u.cpuid, sizeof(vmec.cpuid));
+                break;
+
+            case VM_EVENT_REASON_DESCRIPTOR_ACCESS:
+                memcpy(&vmec.desc_access, &req->u.desc_access, sizeof(vmec.desc_access));
+                break;
+        }
+
+        vrc = process_request(vmi, &vmec);
+#ifdef ENABLE_SAFETY_CHECKS
+        if ( VMI_FAILURE == vrc )
+            break;
+#endif
+
+        rsp->version = vmec.version;
+        rsp->vcpu_id = vmec.vcpu_id;
+        rsp->flags = vmec.flags;
+        rsp->reason = vmec.reason;
+        rsp->altp2m_idx = vmec.altp2m_idx;
+
+        if ( rsp->flags & VM_EVENT_FLAG_SET_EMUL_READ_DATA ) {
+            rsp->data.emul.read.size = vmec.data.emul.read.size;
+            memcpy(&rsp->data.emul.read.data, &vmec.data.emul.read.data, vmec.data.emul.read.size);
+        }
+
+        if ( rsp->flags & VM_EVENT_FLAG_SET_EMUL_INSN_DATA )
+            memcpy(&rsp->data.emul.insn, &vmec.data.emul.insn, sizeof(rsp->data.emul.insn));
+
+        if ( rsp->flags & VM_EVENT_FLAG_SET_REGISTERS ) {
+#if defined(ARM32) || defined(ARM64)
+            memcpy(&rsp->data.regs.arm, &vmec.data.regs.arm, sizeof(rsp->data.regs.arm));
+#elif defined(I386) || defined(X86_64)
+            rsp->data.regs.x86.rax = vmec.data.regs.x86.rax;
+            rsp->data.regs.x86.rcx = vmec.data.regs.x86.rcx;
+            rsp->data.regs.x86.rdx = vmec.data.regs.x86.rdx;
+            rsp->data.regs.x86.rbx = vmec.data.regs.x86.rbx;
+            rsp->data.regs.x86.rsp = vmec.data.regs.x86.rsp;
+            rsp->data.regs.x86.rbp = vmec.data.regs.x86.rbp;
+            rsp->data.regs.x86.rsi = vmec.data.regs.x86.rsi;
+            rsp->data.regs.x86.rdi = vmec.data.regs.x86.rdi;
+            rsp->data.regs.x86.r8 = vmec.data.regs.x86.r8;
+            rsp->data.regs.x86.r9 = vmec.data.regs.x86.r9;
+            rsp->data.regs.x86.r10 = vmec.data.regs.x86.r10;
+            rsp->data.regs.x86.r11 = vmec.data.regs.x86.r11;
+            rsp->data.regs.x86.r12 = vmec.data.regs.x86.r12;
+            rsp->data.regs.x86.r13 = vmec.data.regs.x86.r13;
+            rsp->data.regs.x86.r14 = vmec.data.regs.x86.r14;
+            rsp->data.regs.x86.r15 = vmec.data.regs.x86.r15;
+            rsp->data.regs.x86.rflags = vmec.data.regs.x86.rflags;
+            rsp->data.regs.x86.dr6 = vmec.data.regs.x86.dr6;
+            rsp->data.regs.x86.dr7 = vmec.data.regs.x86.dr7;
+            rsp->data.regs.x86.rip = vmec.data.regs.x86.rip;
+            rsp->data.regs.x86.cr0 = vmec.data.regs.x86.cr0;
+            rsp->data.regs.x86.cr2 = vmec.data.regs.x86.cr2;
+            rsp->data.regs.x86.cr3 = vmec.data.regs.x86.cr3;
+            rsp->data.regs.x86.cr4 = vmec.data.regs.x86.cr4;
+            rsp->data.regs.x86.sysenter_cs = vmec.data.regs.x86.sysenter_cs;
+            rsp->data.regs.x86.sysenter_esp = vmec.data.regs.x86.sysenter_esp;
+            rsp->data.regs.x86.sysenter_eip = vmec.data.regs.x86.sysenter_eip;
+            rsp->data.regs.x86.msr_efer = vmec.data.regs.x86.msr_efer;
+            rsp->data.regs.x86.msr_star = vmec.data.regs.x86.msr_star;
+            rsp->data.regs.x86.msr_lstar = vmec.data.regs.x86.msr_lstar;
+            rsp->data.regs.x86.gdtr_base = vmec.data.regs.x86.gdtr_base;
+            rsp->data.regs.x86.gdtr_limit = vmec.data.regs.x86.gdtr_limit;
+            rsp->data.regs.x86.shadow_gs = vmec.data.regs.x86.shadow_gs;
+            rsp->data.regs.x86.fs_base = vmec.data.regs.x86.fs_base;
+            rsp->data.regs.x86.fs_sel = vmec.data.regs.x86.fs_sel;
+            rsp->data.regs.x86.fs.ar = vmec.data.regs.x86.fs_arbytes;
+            rsp->data.regs.x86.fs.limit = vmec.data.regs.x86.fs_limit;
+            rsp->data.regs.x86.gs_base = vmec.data.regs.x86.gs_base;
+            rsp->data.regs.x86.gs_sel = vmec.data.regs.x86.gs_sel;
+            rsp->data.regs.x86.gs.ar = vmec.data.regs.x86.gs_arbytes;
+            rsp->data.regs.x86.gs.limit = vmec.data.regs.x86.gs_limit;
+            rsp->data.regs.x86.cs_base = vmec.data.regs.x86.cs_base;
+            rsp->data.regs.x86.cs_sel = vmec.data.regs.x86.cs_sel;
+            rsp->data.regs.x86.cs.ar = vmec.data.regs.x86.cs_arbytes;
+            rsp->data.regs.x86.cs.limit = vmec.data.regs.x86.cs_limit;
+            rsp->data.regs.x86.ds_base = vmec.data.regs.x86.ds_base;
+            rsp->data.regs.x86.ds_sel = vmec.data.regs.x86.ds_sel;
+            rsp->data.regs.x86.ds.ar = vmec.data.regs.x86.ds_arbytes;
+            rsp->data.regs.x86.ds.limit = vmec.data.regs.x86.ds_limit;
+            rsp->data.regs.x86.es_base = vmec.data.regs.x86.es_base;
+            rsp->data.regs.x86.es_sel = vmec.data.regs.x86.es_sel;
+            rsp->data.regs.x86.es.ar = vmec.data.regs.x86.es_arbytes;
+            rsp->data.regs.x86.es.limit = vmec.data.regs.x86.es_limit;
+            rsp->data.regs.x86.ss_base = vmec.data.regs.x86.ss_base;
+            rsp->data.regs.x86.ss_sel = vmec.data.regs.x86.ss_sel;
+            rsp->data.regs.x86.ss.ar = vmec.data.regs.x86.ss_arbytes;
+            rsp->data.regs.x86.ss.limit = vmec.data.regs.x86.ss_limit;
+            rsp->data.regs.x86._pad = 0;
+#endif
+        }
+
+        processed++;
+        RING_PUSH_RESPONSES(&xe->back_ring_6);
+
+        /*
+         * Send notification to Xen that response(s) were placed on the ring
+         *
+         * Note: it is more performant to send notification after each event if
+         * there are a lot of vCPUs assigned to the VM.
+         */
+        if (vmi->num_vcpus >= 7) {
+            rc = xen->libxcw.xc_evtchn_notify(xe->xce_handle, xe->port);
+
+#ifdef ENABLE_SAFETY_CHECKS
+            if ( rc ) {
+                errprint("Error sending event channel notification.\n");
+                return VMI_FAILURE;
+            }
+#endif
+        }
+    }
+
+    *requests_processed = processed;
+    return vrc;
+}
+
+int xen_are_events_pending_6(vmi_instance_t vmi)
+{
+    xen_events_t *xe = xen_get_events(vmi);
+
+#ifdef ENABLE_SAFETY_CHECKS
+    if ( !xe ) {
+        errprint("%s error: invalid xen_events_t handle\n", __FUNCTION__);
+        return -1;
+    }
+#endif
+
+    return RING_HAS_UNCONSUMED_REQUESTS(&xe->back_ring_6);
+}
+
+
+status_t init_events_6(vmi_instance_t vmi)
+{
+    xen_events_t *xe = xen_get_events(vmi);
+
+    xe->process_requests = &process_requests_6;
+    vmi->driver.are_events_pending_ptr = &xen_are_events_pending_6;
+
+    SHARED_RING_INIT((vm_event_6_sring_t *)xe->ring_page);
+    BACK_RING_INIT(&xe->back_ring_6,
+                   (vm_event_6_sring_t *)xe->ring_page,
+                   XC_PAGE_SIZE);
+
+    return VMI_SUCCESS;
+}
 
 /*
  * Main event functions
@@ -2659,23 +3180,24 @@ status_t xen_init_events(
      * and we don't have to deduce it from the Xen minor version, allowing vm_event
      * versions to be backported to older Xen releases.
      *
-     * TODO: rename internal functions here from having suffixes tied to Xen's minor version
      */
     if ( xen->libxcw.xc_vm_event_get_version ) {
         switch (xen->libxcw.xc_vm_event_get_version(xch) ) {
-            default: /* fall-through */
             case 5:
-                return init_events_413(vmi);
+                return init_events_5(vmi);
+            default: /* fall-through */
+            case 6:
+                return init_events_6(vmi);
         };
     } else {
         switch (xen->minor_version) {
             case 6 ... 7:
-                return init_events_46(vmi);
+                return init_events_1(vmi);
             case 8 ... 11:
-                return init_events_48(vmi);
+                return init_events_2(vmi);
             default: /* fall-through */
             case 12:
-                return init_events_412(vmi);
+                return init_events_4(vmi);
         };
     }
 

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -136,7 +136,7 @@ typedef enum {
 #define XEN_DOMCTL_MONITOR_EVENT_CPUID                 6
 #define XEN_DOMCTL_MONITOR_EVENT_PRIVILEGED_CALL       7
 
-struct regs_x86_46 {
+struct regs_x86_1 {
     uint64_t rax;
     uint64_t rcx;
     uint64_t rdx;
@@ -177,7 +177,7 @@ struct x86_selector_reg {
     uint32_t ar     :    12;
 };
 
-struct regs_x86_412 {
+struct regs_x86_4 {
     uint64_t rax;
     uint64_t rcx;
     uint64_t rdx;
@@ -230,7 +230,7 @@ struct regs_x86_412 {
     uint32_t _pad;
 };
 
-struct regs_x86_413 {
+struct regs_x86_5 {
     uint64_t rax;
     uint64_t rcx;
     uint64_t rdx;
@@ -313,19 +313,23 @@ struct vm_event_singlestep {
     uint64_t gfn;
 };
 
-struct vm_event_debug {
+struct vm_event_debug_1 {
+    uint64_t gfn;
+};
+
+struct vm_event_debug_2 {
     uint64_t gfn;
     uint32_t insn_length;
     uint8_t type;
     uint8_t _pad[3];
 };
 
-struct vm_event_mov_to_msr_46 {
+struct vm_event_mov_to_msr_1 {
     uint64_t msr;
     uint64_t value;
 };
 
-struct vm_event_mov_to_msr_411 {
+struct vm_event_mov_to_msr_3 {
     uint64_t msr;
     uint64_t new_value;
     uint64_t old_value;
@@ -336,7 +340,7 @@ struct vm_event_mov_to_msr_411 {
 #define VM_EVENT_DESC_LDTR           3
 #define VM_EVENT_DESC_TR             4
 
-struct vm_event_desc_access {
+struct vm_event_desc_access_3 {
     union {
         struct {
             uint32_t instr_info;         /* VMX: VMCS Instruction-Information */
@@ -353,6 +357,19 @@ struct vm_event_desc_access {
     uint8_t _pad[6];
 };
 
+struct vm_event_desc_access_6 {
+    union {
+        struct {
+            uint32_t instr_info;         /* VMX: VMCS Instruction-Information */
+            uint32_t _pad1;
+            uint64_t exit_qualification; /* VMX: VMCS Exit Qualification */
+        } vmx;
+    } arch;
+    uint8_t descriptor;                  /* VM_EVENT_DESC_* */
+    uint8_t is_write;
+    uint8_t _pad[6];
+};
+
 struct vm_event_cpuid {
     uint32_t insn_length;
     uint32_t leaf;
@@ -360,19 +377,19 @@ struct vm_event_cpuid {
     uint32_t _pad;
 };
 
-struct vm_event_emul_read_data_46 {
+struct vm_event_emul_read_data_1 {
     uint32_t size;
-    uint8_t  data[sizeof(struct regs_x86_46) - sizeof(uint32_t)];
+    uint8_t  data[sizeof(struct regs_x86_1) - sizeof(uint32_t)];
 };
 
-struct vm_event_emul_read_data_412 {
+struct vm_event_emul_read_data_4 {
     uint32_t size;
-    uint8_t  data[sizeof(struct regs_x86_412) - sizeof(uint32_t)];
+    uint8_t  data[sizeof(struct regs_x86_4) - sizeof(uint32_t)];
 };
 
-struct vm_event_emul_read_data_413 {
+struct vm_event_emul_read_data_5 {
     uint32_t size;
-    uint8_t  data[sizeof(struct regs_x86_413) - sizeof(uint32_t)];
+    uint8_t  data[sizeof(struct regs_x86_5) - sizeof(uint32_t)];
 };
 
 struct vm_event_emul_insn_data {
@@ -387,7 +404,7 @@ struct vm_event_interrupt_x86 {
     uint64_t cr2;
 };
 
-typedef struct vm_event_st_46 {
+typedef struct vm_event_st_1 {
     uint32_t version;
     uint32_t flags;
     uint32_t reason;
@@ -398,21 +415,21 @@ typedef struct vm_event_st_46 {
     union {
         struct vm_event_mem_access            mem_access;
         struct vm_event_write_ctrlreg         write_ctrlreg;
-        struct vm_event_mov_to_msr_46         mov_to_msr;
-        struct vm_event_singlestep            singlestep;
-        struct vm_event_debug                 software_breakpoint;
+        struct vm_event_mov_to_msr_1          mov_to_msr;
+        struct vm_event_debug_1               singlestep;
+        struct vm_event_debug_1               software_breakpoint;
     } u;
 
     union {
         union {
-            struct regs_x86_46 x86;
+            struct regs_x86_1 x86;
         } regs;
 
-        struct vm_event_emul_read_data_46 emul_read_data;
+        struct vm_event_emul_read_data_1 emul_read_data;
     } data;
-} vm_event_46_request_t, vm_event_46_response_t;
+} vm_event_1_request_t, vm_event_1_response_t;
 
-typedef struct vm_event_st_48 {
+typedef struct vm_event_st_2 {
     uint32_t version;
     uint32_t flags;
     uint32_t reason;
@@ -423,20 +440,10 @@ typedef struct vm_event_st_48 {
     union {
         struct vm_event_mem_access            mem_access;
         struct vm_event_write_ctrlreg         write_ctrlreg;
-        /*
-         * The event structure is still ABI compatible regardless of this change in 4.11 below
-         * because mov_to_msr is in union with other structures that are still larger,
-         * so the union u size didn't change.
-         * Otherwise we would need to create a new vm_event_st.
-         */
-        union {
-            struct vm_event_mov_to_msr_46     mov_to_msr_46;
-            struct vm_event_mov_to_msr_411    mov_to_msr_411;
-        };
-        struct vm_event_desc_access           desc_access;
+        struct vm_event_mov_to_msr_1          mov_to_msr_1;
         struct vm_event_singlestep            singlestep;
-        struct vm_event_debug                 software_breakpoint;
-        struct vm_event_debug                 debug_exception;
+        struct vm_event_debug_2               software_breakpoint;
+        struct vm_event_debug_2               debug_exception;
         struct vm_event_cpuid                 cpuid;
         union {
             struct vm_event_interrupt_x86     x86;
@@ -445,18 +452,18 @@ typedef struct vm_event_st_48 {
 
     union {
         union {
-            struct regs_x86_46 x86;
+            struct regs_x86_1 x86;
             struct regs_arm arm;
         } regs;
 
         union {
-            struct vm_event_emul_read_data_46 read;
+            struct vm_event_emul_read_data_1 read;
             struct vm_event_emul_insn_data insn;
         } emul;
     } data;
-} vm_event_48_request_t, vm_event_48_response_t;
+} vm_event_2_request_t, vm_event_2_response_t;
 
-typedef struct vm_event_st_412 {
+typedef struct vm_event_st_3 {
     uint32_t version;
     uint32_t flags;
     uint32_t reason;
@@ -467,11 +474,11 @@ typedef struct vm_event_st_412 {
     union {
         struct vm_event_mem_access            mem_access;
         struct vm_event_write_ctrlreg         write_ctrlreg;
-        struct vm_event_mov_to_msr_411        mov_to_msr;
-        struct vm_event_desc_access           desc_access;
+        struct vm_event_mov_to_msr_3          mov_to_msr_3;
+        struct vm_event_desc_access_3         desc_access;
         struct vm_event_singlestep            singlestep;
-        struct vm_event_debug                 software_breakpoint;
-        struct vm_event_debug                 debug_exception;
+        struct vm_event_debug_2               software_breakpoint;
+        struct vm_event_debug_2               debug_exception;
         struct vm_event_cpuid                 cpuid;
         union {
             struct vm_event_interrupt_x86     x86;
@@ -480,18 +487,18 @@ typedef struct vm_event_st_412 {
 
     union {
         union {
-            struct regs_x86_412 x86;
+            struct regs_x86_1 x86;
             struct regs_arm arm;
         } regs;
 
         union {
-            struct vm_event_emul_read_data_412 read;
+            struct vm_event_emul_read_data_1 read;
             struct vm_event_emul_insn_data insn;
         } emul;
     } data;
-} vm_event_412_request_t, vm_event_412_response_t;
+} vm_event_3_request_t, vm_event_3_response_t;
 
-typedef struct vm_event_st_413 {
+typedef struct vm_event_st_4 {
     uint32_t version;
     uint32_t flags;
     uint32_t reason;
@@ -502,11 +509,11 @@ typedef struct vm_event_st_413 {
     union {
         struct vm_event_mem_access            mem_access;
         struct vm_event_write_ctrlreg         write_ctrlreg;
-        struct vm_event_mov_to_msr_411        mov_to_msr;
-        struct vm_event_desc_access           desc_access;
+        struct vm_event_mov_to_msr_3          mov_to_msr;
+        struct vm_event_desc_access_3         desc_access;
         struct vm_event_singlestep            singlestep;
-        struct vm_event_debug                 software_breakpoint;
-        struct vm_event_debug                 debug_exception;
+        struct vm_event_debug_2               software_breakpoint;
+        struct vm_event_debug_2               debug_exception;
         struct vm_event_cpuid                 cpuid;
         union {
             struct vm_event_interrupt_x86     x86;
@@ -515,20 +522,92 @@ typedef struct vm_event_st_413 {
 
     union {
         union {
-            struct regs_x86_413 x86;
+            struct regs_x86_4 x86;
             struct regs_arm arm;
         } regs;
 
         union {
-            struct vm_event_emul_read_data_413 read;
+            struct vm_event_emul_read_data_4 read;
             struct vm_event_emul_insn_data insn;
         } emul;
     } data;
-} vm_event_413_request_t, vm_event_413_response_t;
+} vm_event_4_request_t, vm_event_4_response_t;
 
-DEFINE_RING_TYPES(vm_event_46, vm_event_46_request_t, vm_event_46_response_t);
-DEFINE_RING_TYPES(vm_event_48, vm_event_48_request_t, vm_event_48_response_t);
-DEFINE_RING_TYPES(vm_event_412, vm_event_412_request_t, vm_event_412_response_t);
-DEFINE_RING_TYPES(vm_event_413, vm_event_413_request_t, vm_event_413_response_t);
+typedef struct vm_event_st_5 {
+    uint32_t version;
+    uint32_t flags;
+    uint32_t reason;
+    uint32_t vcpu_id;
+    uint16_t altp2m_idx;
+    uint16_t _pad[3];
+
+    union {
+        struct vm_event_mem_access            mem_access;
+        struct vm_event_write_ctrlreg         write_ctrlreg;
+        struct vm_event_mov_to_msr_3          mov_to_msr;
+        struct vm_event_desc_access_3         desc_access;
+        struct vm_event_singlestep            singlestep;
+        struct vm_event_debug_2               software_breakpoint;
+        struct vm_event_debug_2               debug_exception;
+        struct vm_event_cpuid                 cpuid;
+        union {
+            struct vm_event_interrupt_x86     x86;
+        } interrupt;
+    } u;
+
+    union {
+        union {
+            struct regs_x86_5 x86;
+            struct regs_arm arm;
+        } regs;
+
+        union {
+            struct vm_event_emul_read_data_5 read;
+            struct vm_event_emul_insn_data insn;
+        } emul;
+    } data;
+} vm_event_5_request_t, vm_event_5_response_t;
+
+typedef struct vm_event_st_6 {
+    uint32_t version;
+    uint32_t flags;
+    uint32_t reason;
+    uint32_t vcpu_id;
+    uint16_t altp2m_idx;
+    uint16_t _pad[3];
+
+    union {
+        struct vm_event_mem_access            mem_access;
+        struct vm_event_write_ctrlreg         write_ctrlreg;
+        struct vm_event_mov_to_msr_3          mov_to_msr;
+        struct vm_event_desc_access_6         desc_access;
+        struct vm_event_singlestep            singlestep;
+        struct vm_event_debug_2               software_breakpoint;
+        struct vm_event_debug_2               debug_exception;
+        struct vm_event_cpuid                 cpuid;
+        union {
+            struct vm_event_interrupt_x86     x86;
+        } interrupt;
+    } u;
+
+    union {
+        union {
+            struct regs_x86_5 x86;
+            struct regs_arm arm;
+        } regs;
+
+        union {
+            struct vm_event_emul_read_data_5 read;
+            struct vm_event_emul_insn_data insn;
+        } emul;
+    } data;
+} vm_event_6_request_t, vm_event_6_response_t;
+
+DEFINE_RING_TYPES(vm_event_1, vm_event_1_request_t, vm_event_1_response_t);
+DEFINE_RING_TYPES(vm_event_2, vm_event_2_request_t, vm_event_2_response_t);
+DEFINE_RING_TYPES(vm_event_3, vm_event_3_request_t, vm_event_3_response_t);
+DEFINE_RING_TYPES(vm_event_4, vm_event_4_request_t, vm_event_4_response_t);
+DEFINE_RING_TYPES(vm_event_5, vm_event_5_request_t, vm_event_5_response_t);
+DEFINE_RING_TYPES(vm_event_6, vm_event_6_request_t, vm_event_6_response_t);
 
 #endif

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -79,11 +79,11 @@ typedef struct vm_event_compat {
     union {
         struct vm_event_mem_access            mem_access;
         struct vm_event_write_ctrlreg         write_ctrlreg;
-        struct vm_event_mov_to_msr_411        mov_to_msr;
-        struct vm_event_desc_access           desc_access;
+        struct vm_event_mov_to_msr_3          mov_to_msr;
+        struct vm_event_desc_access_3         desc_access;
         struct vm_event_singlestep            singlestep;
-        struct vm_event_debug                 software_breakpoint;
-        struct vm_event_debug                 debug_exception;
+        struct vm_event_debug_2               software_breakpoint;
+        struct vm_event_debug_2               debug_exception;
         struct vm_event_cpuid                 cpuid;
         struct vm_event_interrupt_x86         x86_interrupt;
     };
@@ -95,7 +95,7 @@ typedef struct vm_event_compat {
         } regs;
 
         union {
-            struct vm_event_emul_read_data_412 read;
+            struct vm_event_emul_read_data_4 read;
             struct vm_event_emul_insn_data insn;
         } emul;
     } data;
@@ -115,10 +115,12 @@ typedef struct {
     bool external_poll;
     void *ring_page;
     union {
-        vm_event_46_back_ring_t back_ring_46;
-        vm_event_48_back_ring_t back_ring_48;
-        vm_event_412_back_ring_t back_ring_412;
-        vm_event_413_back_ring_t back_ring_413;
+        vm_event_1_back_ring_t back_ring_1;
+        vm_event_2_back_ring_t back_ring_2;
+        vm_event_3_back_ring_t back_ring_3;
+        vm_event_4_back_ring_t back_ring_4;
+        vm_event_5_back_ring_t back_ring_5;
+        vm_event_6_back_ring_t back_ring_6;
     };
     xen_pfn_t max_gpfn;
     uint32_t monitor_capabilities;


### PR DESCRIPTION
Also switch internal Xen ABI structure and function names to reflect vm_event version instead of Xen versions.