### PR TITLE
Add VMI_CONFIG_JSON_PATH

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -683,6 +683,10 @@ os_t vmi_init_os(
             }
             _config = (GHashTable*)config;
             break;
+        case VMI_CONFIG_JSON_PATH:
+            _config = g_hash_table_new(g_str_hash, g_str_equal);
+            g_hash_table_insert(_config, "volatility_ist", config);
+            break;
         default:
             goto error_exit;
     }

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -76,6 +76,8 @@ typedef enum vmi_config {
     VMI_CONFIG_STRING,            /**< config string provided */
 
     VMI_CONFIG_GHASHTABLE,        /**< config GHashTable provided */
+
+    VMI_CONFIG_JSON_PATH,         /**< config in json file at the location provided */
 } vmi_config_t;
 
 typedef enum status {


### PR DESCRIPTION
Everything that's needed for LibVMI to init is contained in the Rekall/Volatility IST profile, so adding new init option to just pass in the path to the json file.