### PR TITLE
Specify noexcept for C++ inclusion

### DIFF
--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -37,6 +37,9 @@
 
 #ifdef __cplusplus
 extern "C" {
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
 #endif
 
 #pragma GCC visibility push(default)
@@ -625,7 +628,7 @@ struct vmi_event {
  *
  * @return max supported events version
  */
-uint32_t vmi_events_version(void);
+uint32_t vmi_events_version(void) NOEXCEPT;
 
 /**
  * Register to handle the event specified by the vmi_event object.
@@ -647,7 +650,7 @@ uint32_t vmi_events_version(void);
  */
 status_t vmi_register_event(
     vmi_instance_t vmi,
-    vmi_event_t *event);
+    vmi_event_t *event) NOEXCEPT;
 
 /**
  * Swap a registered event to another.
@@ -670,7 +673,7 @@ status_t vmi_swap_events(
     vmi_instance_t vmi,
     vmi_event_t *swap_from,
     vmi_event_t *swap_to,
-    vmi_event_free_t free_routine);
+    vmi_event_free_t free_routine) NOEXCEPT;
 
 /**
  * Clear the event specified by the vmi_event_t object.
@@ -692,7 +695,7 @@ status_t vmi_swap_events(
 status_t vmi_clear_event(
     vmi_instance_t vmi,
     vmi_event_t *event,
-    vmi_event_free_t free_routine);
+    vmi_event_free_t free_routine) NOEXCEPT;
 
 /**
  * Return the pointer to the vmi_event_t if one is set on the given register.
@@ -703,7 +706,7 @@ status_t vmi_clear_event(
  */
 vmi_event_t *vmi_get_reg_event(
     vmi_instance_t vmi,
-    reg_t reg);
+    reg_t reg) NOEXCEPT;
 
 /**
  * Return the pointer to the vmi_event_t if one is set on the given page or
@@ -717,7 +720,7 @@ vmi_event_t *vmi_get_reg_event(
 vmi_event_t *vmi_get_mem_event(
     vmi_instance_t vmi,
     addr_t gfn,
-    vmi_mem_access_t access);
+    vmi_mem_access_t access) NOEXCEPT;
 
 /**
  * Set mem event on a page. Intended to be used when already registered a generic
@@ -733,7 +736,7 @@ status_t vmi_set_mem_event(
     vmi_instance_t vmi,
     addr_t gfn,
     vmi_mem_access_t access,
-    uint16_t vmm_pagetable_id);
+    uint16_t vmm_pagetable_id) NOEXCEPT;
 
 /**
  * Setup single-stepping to register the given event
@@ -754,7 +757,7 @@ status_t vmi_step_event(
     vmi_event_t *event,
     uint32_t vcpu_id,
     uint64_t steps,
-    event_callback_t cb);
+    event_callback_t cb) NOEXCEPT;
 
 /**
  * Listen for events until one occurs or a timeout.
@@ -768,7 +771,7 @@ status_t vmi_step_event(
  */
 status_t vmi_events_listen(
     vmi_instance_t vmi,
-    uint32_t timeout);
+    uint32_t timeout) NOEXCEPT;
 
 /**
  * Set whether to crash the domain if the event listener is no longer present.
@@ -780,7 +783,7 @@ status_t vmi_events_listen(
  */
 status_t vmi_event_listener_required(
     vmi_instance_t vmi,
-    bool required);
+    bool required) NOEXCEPT;
 
 /**
  * Check if there are events pending to be processed.
@@ -789,7 +792,7 @@ status_t vmi_event_listener_required(
  * @return The number of pending events, or 0 if there are non, -1 on error.
  */
 int vmi_are_events_pending(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Return the pointer to the vmi_event_t if one is set on the given vcpu.
@@ -799,7 +802,7 @@ int vmi_are_events_pending(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 vmi_event_t *vmi_get_singlestep_event (vmi_instance_t vmi,
-                                       uint32_t vcpu);
+                                       uint32_t vcpu) NOEXCEPT;
 
 /**
  * Disables the MTF single step flag from a vcpu as well as the
@@ -816,7 +819,7 @@ vmi_event_t *vmi_get_singlestep_event (vmi_instance_t vmi,
 status_t vmi_stop_single_step_vcpu(
     vmi_instance_t vmi,
     vmi_event_t* event,
-    uint32_t vcpu);
+    uint32_t vcpu) NOEXCEPT;
 
 /**
  * Toggles the MTF single step flag from a vcpu as well as the
@@ -838,7 +841,7 @@ status_t vmi_toggle_single_step_vcpu(
     vmi_instance_t vmi,
     vmi_event_t* event,
     uint32_t vcpu,
-    bool enabled);
+    bool enabled) NOEXCEPT;
 
 /**
  * Cleans up any domain wide single step settings.
@@ -850,7 +853,7 @@ status_t vmi_toggle_single_step_vcpu(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t vmi_shutdown_single_step(
-    vmi_instance_t);
+    vmi_instance_t) NOEXCEPT;
 
 #pragma GCC visibility pop
 

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -35,6 +35,9 @@
 
 #ifdef __cplusplus
 extern "C" {
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
 #endif
 
 #pragma GCC visibility push(default)
@@ -760,7 +763,7 @@ status_t vmi_init(
     const void *domain,
     uint64_t init_flags,
     vmi_init_data_t *init_data,
-    vmi_init_error_t *error);
+    vmi_init_error_t *error) NOEXCEPT;
 
 /**
  * Initializes access to a specific VM or file given a name or an ID.  All
@@ -798,7 +801,7 @@ status_t vmi_init_complete(
     vmi_init_data_t *init_data,
     vmi_config_t config_mode,
     void *config,
-    vmi_init_error_t *error);
+    vmi_init_error_t *error) NOEXCEPT;
 
 /*
  * Initialize or reinitialize the paging specific functionality of LibVMI
@@ -814,7 +817,7 @@ status_t vmi_init_complete(
  */
 page_mode_t vmi_init_paging(
     vmi_instance_t vmi,
-    uint64_t flags);
+    uint64_t flags) NOEXCEPT;
 
 /*
  * Initialize the OS specific functionality of LibVMI required for functions
@@ -835,7 +838,7 @@ os_t vmi_init_os(
     vmi_instance_t vmi,
     vmi_config_t config_mode,
     void *config,
-    vmi_init_error_t *error);
+    vmi_init_error_t *error) NOEXCEPT;
 
 /**
  * Destroys an instance by freeing memory and closing any open handles.
@@ -844,7 +847,7 @@ os_t vmi_init_os(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t vmi_destroy(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Obtain the library arch mode that was used for compiling.
@@ -852,7 +855,7 @@ status_t vmi_destroy(
  * @param[in] vmi LibVMI instance
  * @return The architecture of the library
  */
-vmi_arch_t vmi_get_library_arch(void);
+vmi_arch_t vmi_get_library_arch(void) NOEXCEPT;
 
 /*---------------------------------------------------------
  * Memory translation functions from memory.c
@@ -870,7 +873,7 @@ vmi_arch_t vmi_get_library_arch(void);
 status_t vmi_translate_kv2p(
     vmi_instance_t vmi,
     addr_t vaddr,
-    addr_t *paddr);
+    addr_t *paddr) NOEXCEPT;
 
 /**
  * Performs the translation from a user virtual address to a
@@ -886,7 +889,7 @@ status_t vmi_translate_uv2p(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    addr_t *paddr);
+    addr_t *paddr) NOEXCEPT;
 
 /**
  * Performs the translation from a kernel symbol to a virtual address.
@@ -899,7 +902,7 @@ status_t vmi_translate_uv2p(
 status_t vmi_translate_ksym2v(
     vmi_instance_t vmi,
     const char *symbol,
-    addr_t *vaddr);
+    addr_t *vaddr) NOEXCEPT;
 
 /**
  * Performs the translation from a symbol to a virtual address.
@@ -916,7 +919,7 @@ status_t vmi_translate_sym2v(
     vmi_instance_t vmi,
     const access_context_t *ctx,
     const char *symbol,
-    addr_t *vaddr);
+    addr_t *vaddr) NOEXCEPT;
 
 /**
  * Performs the translation from an RVA to a symbol
@@ -932,7 +935,7 @@ status_t vmi_translate_sym2v(
 const char* vmi_translate_v2sym(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    addr_t rva);
+    addr_t rva) NOEXCEPT;
 
 /**
  * Performs the translation from VA to a symbol for Linux with KASLR offset
@@ -947,7 +950,7 @@ const char* vmi_translate_v2sym(
 const char* vmi_translate_v2ksym(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    addr_t va);
+    addr_t va) NOEXCEPT;
 
 /**
  * Given a pid, this function returns the virtual address of the
@@ -969,7 +972,7 @@ const char* vmi_translate_v2ksym(
 status_t vmi_pid_to_dtb(
     vmi_instance_t vmi,
     vmi_pid_t pid,
-    addr_t *dtb);
+    addr_t *dtb) NOEXCEPT;
 
 /**
  * Given a dtb, this function returns the PID corresponding to the
@@ -994,7 +997,7 @@ status_t vmi_pid_to_dtb(
 status_t vmi_dtb_to_pid(
     vmi_instance_t vmi,
     addr_t dtb,
-    vmi_pid_t *pid);
+    vmi_pid_t *pid) NOEXCEPT;
 
 /**
  * Translates a virtual address to a physical address.
@@ -1010,7 +1013,7 @@ status_t vmi_pagetable_lookup (
     vmi_instance_t vmi,
     addr_t dtb,
     addr_t vaddr,
-    addr_t *paddr);
+    addr_t *paddr) NOEXCEPT;
 
 /**
  * Gets the physical address and page size of the VA
@@ -1027,7 +1030,7 @@ status_t vmi_pagetable_lookup_extended(
     vmi_instance_t vmi,
     addr_t dtb,
     addr_t vaddr,
-    page_info_t *info);
+    page_info_t *info) NOEXCEPT;
 
 /*---------------------------------------------------------
  * Memory access functions
@@ -1048,7 +1051,7 @@ status_t vmi_read(
     const access_context_t *ctx,
     size_t count,
     void *buf,
-    size_t *bytes_read);
+    size_t *bytes_read) NOEXCEPT;
 
 /**
  * Reads 8 bits from memory.
@@ -1061,7 +1064,7 @@ status_t vmi_read(
 status_t vmi_read_8(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Reads 16 bits from memory, given a virtual address.
@@ -1074,7 +1077,7 @@ status_t vmi_read_8(
 status_t vmi_read_16(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Reads 32 bits from memory, given a virtual address.
@@ -1087,7 +1090,7 @@ status_t vmi_read_16(
 status_t vmi_read_32(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Reads 64 bits from memory, given a virtual address.
@@ -1101,7 +1104,7 @@ status_t vmi_read_32(
 status_t vmi_read_64(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Reads an address from memory, given a virtual address.  The number of
@@ -1115,7 +1118,7 @@ status_t vmi_read_64(
 status_t vmi_read_addr(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    addr_t *value);
+    addr_t *value) NOEXCEPT;
 
 /**
  * Reads a null terminated string from memory, starting at
@@ -1128,7 +1131,7 @@ status_t vmi_read_addr(
  */
 char *vmi_read_str(
     vmi_instance_t vmi,
-    const access_context_t *ctx);
+    const access_context_t *ctx) NOEXCEPT;
 
 /**
  * Reads a Unicode string from the given address. If the guest is running
@@ -1142,7 +1145,7 @@ char *vmi_read_str(
  */
 unicode_string_t *vmi_read_unicode_str(
     vmi_instance_t vmi,
-    const access_context_t *ctx);
+    const access_context_t *ctx) NOEXCEPT;
 
 /**
  * Reads a Unicode string from the given address using the specified page mode.
@@ -1160,7 +1163,7 @@ unicode_string_t *vmi_read_unicode_str(
 unicode_string_t *vmi_read_unicode_str_pm(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    page_mode_t mode );
+    page_mode_t mode ) NOEXCEPT;
 
 /**
  * Reads count bytes from memory located at the kernel symbol sym
@@ -1179,7 +1182,7 @@ status_t vmi_read_ksym(
     size_t count,
     void *buf,
     size_t *bytes_read
-);
+) NOEXCEPT;
 
 /**
  * Reads count bytes from memory located at the virtual address vaddr
@@ -1200,7 +1203,7 @@ status_t vmi_read_va(
     size_t count,
     void *buf,
     size_t *bytes_read
-);
+) NOEXCEPT;
 
 /**
  * Maps num_pages of the guest's virtual memory into host, starting at the provided vaddr.
@@ -1218,7 +1221,7 @@ status_t vmi_mmap_guest(
     const access_context_t *ctx,
     size_t num_pages,
     void **access_ptrs
-);
+) NOEXCEPT;
 
 /**
  * Reads count bytes from memory located at the physical address paddr
@@ -1237,7 +1240,7 @@ status_t vmi_read_pa(
     size_t count,
     void *buf,
     size_t *bytes_read
-);
+) NOEXCEPT;
 
 /**
  * Reads 8 bits from memory, given a kernel symbol.
@@ -1250,7 +1253,7 @@ status_t vmi_read_pa(
 status_t vmi_read_8_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Reads 16 bits from memory, given a kernel symbol.
@@ -1263,7 +1266,7 @@ status_t vmi_read_8_ksym(
 status_t vmi_read_16_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Reads 32 bits from memory, given a kernel symbol.
@@ -1276,7 +1279,7 @@ status_t vmi_read_16_ksym(
 status_t vmi_read_32_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Reads 64 bits from memory, given a kernel symbol.
@@ -1289,7 +1292,7 @@ status_t vmi_read_32_ksym(
 status_t vmi_read_64_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Reads an address from memory, given a kernel symbol.  The number of
@@ -1303,7 +1306,7 @@ status_t vmi_read_64_ksym(
 status_t vmi_read_addr_ksym(
     vmi_instance_t vmi,
     char *sym,
-    addr_t *value);
+    addr_t *value) NOEXCEPT;
 
 /**
  * Reads a null-terminated string from memory, starting at
@@ -1316,7 +1319,7 @@ status_t vmi_read_addr_ksym(
  */
 char *vmi_read_str_ksym(
     vmi_instance_t vmi,
-    char *sym);
+    char *sym) NOEXCEPT;
 
 /**
  * Reads 8 bits from memory, given a virtual address.
@@ -1331,7 +1334,7 @@ status_t vmi_read_8_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Reads 16 bits from memory, given a virtual address.
@@ -1346,7 +1349,7 @@ status_t vmi_read_16_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Reads 32 bits from memory, given a virtual address.
@@ -1361,7 +1364,7 @@ status_t vmi_read_32_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Reads 64 bits from memory, given a virtual address.
@@ -1376,7 +1379,7 @@ status_t vmi_read_64_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Reads an address from memory, given a virtual address.  The number of
@@ -1392,7 +1395,7 @@ status_t vmi_read_addr_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    addr_t *value);
+    addr_t *value) NOEXCEPT;
 
 /**
  * Reads a null terminated string from memory, starting at
@@ -1407,7 +1410,7 @@ status_t vmi_read_addr_va(
 char *vmi_read_str_va(
     vmi_instance_t vmi,
     addr_t vaddr,
-    vmi_pid_t pid);
+    vmi_pid_t pid) NOEXCEPT;
 
 /**
  * Reads a Unicode string from the given address. If the guest is running
@@ -1423,12 +1426,12 @@ char *vmi_read_str_va(
 unicode_string_t *vmi_read_unicode_str_va(
     vmi_instance_t vmi,
     addr_t vaddr,
-    vmi_pid_t pid);
+    vmi_pid_t pid) NOEXCEPT;
 
 /**
  * Converts character encoding from that in the input string to another
  * specified encoding. Two common ways to use this function are: (1) convert a
- * string to the "UTF-8" encoding and output with printf("%s"); (2) convert a
+ * string to the "UTF-8" encoding and output with printf("%s") NOEXCEPT; (2) convert a
  * string to the "WCHAR_T" encoding and output with printf("%ls").
  *
  * @param[in] in  unicode_string_t to be converted; encoding field must be set
@@ -1439,7 +1442,7 @@ unicode_string_t *vmi_read_unicode_str_va(
 status_t vmi_convert_str_encoding(
     const unicode_string_t *in,
     unicode_string_t *out,
-    const char *outencoding);
+    const char *outencoding) NOEXCEPT;
 
 /**
  * Convenience function to free a unicode_string_t struct.
@@ -1448,7 +1451,7 @@ status_t vmi_convert_str_encoding(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 void vmi_free_unicode_str(
-    unicode_string_t *p_us);
+    unicode_string_t *p_us) NOEXCEPT;
 
 /**
  * Reads 8 bits from memory, given a physical address.
@@ -1461,7 +1464,7 @@ void vmi_free_unicode_str(
 status_t vmi_read_8_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Reads 16 bits from memory, given a physical address.
@@ -1474,7 +1477,7 @@ status_t vmi_read_8_pa(
 status_t vmi_read_16_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Reads 32 bits from memory, given a physical address.
@@ -1487,7 +1490,7 @@ status_t vmi_read_16_pa(
 status_t vmi_read_32_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Reads 64 bits from memory, given a physical address.
@@ -1500,7 +1503,7 @@ status_t vmi_read_32_pa(
 status_t vmi_read_64_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Reads an address from memory, given a physical address.  The number of
@@ -1514,7 +1517,7 @@ status_t vmi_read_64_pa(
 status_t vmi_read_addr_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    addr_t *value);
+    addr_t *value) NOEXCEPT;
 
 /**
  * Reads a nul terminated string from memory, starting at
@@ -1527,7 +1530,7 @@ status_t vmi_read_addr_pa(
  */
 char *vmi_read_str_pa(
     vmi_instance_t vmi,
-    addr_t paddr);
+    addr_t paddr) NOEXCEPT;
 
 
 /**
@@ -1545,7 +1548,7 @@ status_t vmi_write(
     const access_context_t *ctx,
     size_t count,
     void *buf,
-    size_t *bytes_written);
+    size_t *bytes_written) NOEXCEPT;
 
 /**
  * Writes count bytes to memory located at the kernel symbol sym
@@ -1563,7 +1566,7 @@ status_t vmi_write_ksym(
     char *sym,
     size_t count,
     void *buf,
-    size_t *bytes_written);
+    size_t *bytes_written) NOEXCEPT;
 
 /**
  * Writes count bytes to memory located at the virtual address vaddr
@@ -1583,7 +1586,7 @@ status_t vmi_write_va(
     vmi_pid_t pid,
     size_t count,
     void *buf,
-    size_t *bytes_written);
+    size_t *bytes_written) NOEXCEPT;
 
 /**
  * Writes count bytes to memory located at the physical address paddr
@@ -1601,7 +1604,7 @@ status_t vmi_write_pa(
     addr_t paddr,
     size_t count,
     void *buf,
-    size_t *bytes_written);
+    size_t *bytes_written) NOEXCEPT;
 
 /**
  * Writes 8 bits to memory
@@ -1614,7 +1617,7 @@ status_t vmi_write_pa(
 status_t vmi_write_8(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Writes 16 bits to memory
@@ -1627,7 +1630,7 @@ status_t vmi_write_8(
 status_t vmi_write_16(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Writes 32 bits to memory
@@ -1640,7 +1643,7 @@ status_t vmi_write_16(
 status_t vmi_write_32(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Writes 64 bits to memory
@@ -1653,7 +1656,7 @@ status_t vmi_write_32(
 status_t vmi_write_64(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Writes the address to memory. The number of
@@ -1667,7 +1670,7 @@ status_t vmi_write_64(
 status_t vmi_write_addr(
     vmi_instance_t vmi,
     const access_context_t *ctx,
-    addr_t * value);
+    addr_t * value) NOEXCEPT;
 
 /**
  * Writes 8 bits to memory, given a kernel symbol.
@@ -1680,7 +1683,7 @@ status_t vmi_write_addr(
 status_t vmi_write_8_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Writes 16 bits to memory, given a kernel symbol.
@@ -1693,7 +1696,7 @@ status_t vmi_write_8_ksym(
 status_t vmi_write_16_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Writes 32 bits to memory, given a kernel symbol.
@@ -1706,7 +1709,7 @@ status_t vmi_write_16_ksym(
 status_t vmi_write_32_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Writes 64 bits to memory, given a kernel symbol.
@@ -1719,7 +1722,7 @@ status_t vmi_write_32_ksym(
 status_t vmi_write_64_ksym(
     vmi_instance_t vmi,
     char *sym,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Writes the address to memory. The number of
@@ -1733,7 +1736,7 @@ status_t vmi_write_64_ksym(
 status_t vmi_write_addr_ksym(
     vmi_instance_t vmi,
     char *sym,
-    addr_t * value);
+    addr_t * value) NOEXCEPT;
 
 /**
  * Writes 8 bits to memory, given a virtual address.
@@ -1748,7 +1751,7 @@ status_t vmi_write_8_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Writes 16 bits to memory, given a virtual address.
@@ -1763,7 +1766,7 @@ status_t vmi_write_16_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Writes 32 bits to memory, given a virtual address.
@@ -1778,7 +1781,7 @@ status_t vmi_write_32_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Writes 64 bits to memory, given a virtual address.
@@ -1793,7 +1796,7 @@ status_t vmi_write_64_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Writes the address to memory. The number of
@@ -1809,7 +1812,7 @@ status_t vmi_write_addr_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    addr_t * value);
+    addr_t * value) NOEXCEPT;
 
 /**
  * Writes 8 bits to memory, given a physical address.
@@ -1822,7 +1825,7 @@ status_t vmi_write_addr_va(
 status_t vmi_write_8_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint8_t * value);
+    uint8_t * value) NOEXCEPT;
 
 /**
  * Writes 16 bits to memory, given a physical address.
@@ -1835,7 +1838,7 @@ status_t vmi_write_8_pa(
 status_t vmi_write_16_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint16_t * value);
+    uint16_t * value) NOEXCEPT;
 
 /**
  * Writes 32 bits to memory, given a physical address.
@@ -1848,7 +1851,7 @@ status_t vmi_write_16_pa(
 status_t vmi_write_32_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint32_t * value);
+    uint32_t * value) NOEXCEPT;
 
 /**
  * Writes 64 bits from memory, given a physical address.
@@ -1861,7 +1864,7 @@ status_t vmi_write_32_pa(
 status_t vmi_write_64_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    uint64_t * value);
+    uint64_t * value) NOEXCEPT;
 
 /**
  * Writes the address to memory. The number of
@@ -1875,7 +1878,7 @@ status_t vmi_write_64_pa(
 status_t vmi_write_addr_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    addr_t * value);
+    addr_t * value) NOEXCEPT;
 
 /*---------------------------------------------------------
  * Print util functions from pretty_print.c
@@ -1891,7 +1894,7 @@ status_t vmi_write_addr_pa(
  */
 void vmi_print_hex(
     unsigned char *data,
-    unsigned long length);
+    unsigned long length) NOEXCEPT;
 
 /**
  * Prints out the hex and ascii version of a chunk of bytes. The
@@ -1905,7 +1908,7 @@ void vmi_print_hex(
 void vmi_print_hex_ksym(
     vmi_instance_t vmi,
     char *sym,
-    size_t length);
+    size_t length) NOEXCEPT;
 
 /**
  * Prints out the hex and ascii version of a chunk of bytes. The
@@ -1921,7 +1924,7 @@ void vmi_print_hex_va(
     vmi_instance_t vmi,
     addr_t vaddr,
     vmi_pid_t pid,
-    size_t length);
+    size_t length) NOEXCEPT;
 
 /**
  * Prints out the hex and ascii version of a chunk of bytes. The
@@ -1935,7 +1938,7 @@ void vmi_print_hex_va(
 void vmi_print_hex_pa(
     vmi_instance_t vmi,
     addr_t paddr,
-    size_t length);
+    size_t length) NOEXCEPT;
 
 /**
  * Gets the name of the VM (or file) that LibVMI is accessing.
@@ -1944,7 +1947,7 @@ void vmi_print_hex_pa(
  * @return VM (or file) name, must be free'd by caller
  */
 char *vmi_get_name(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Gets the id of the VM that LibVMI is accessing.
@@ -1953,7 +1956,7 @@ char *vmi_get_name(
  * @return VM id, or zero on error
  */
 uint64_t vmi_get_vmid(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Gets the current access mode for LibVMI, which tells what
@@ -1983,7 +1986,7 @@ status_t vmi_get_access_mode(
     const void *domain,
     uint64_t init_flags,
     vmi_init_data_t *init_data,
-    vmi_mode_t *mode);
+    vmi_mode_t *mode) NOEXCEPT;
 
 /**
  * Gets the current page mode for LibVMI, which tells what
@@ -2000,7 +2003,7 @@ status_t vmi_get_access_mode(
  */
 page_mode_t vmi_get_page_mode(
     vmi_instance_t vmi,
-    unsigned long vcpu);
+    unsigned long vcpu) NOEXCEPT;
 
 /**
  * Gets the current address width for the given vmi_instance_t
@@ -2014,7 +2017,7 @@ page_mode_t vmi_get_page_mode(
  * @return address size in bytes
  */
 uint8_t vmi_get_address_width(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get the OS type that LibVMI is currently accessing.  This is
@@ -2024,7 +2027,7 @@ uint8_t vmi_get_address_width(
  * @return OS type
  */
 os_t vmi_get_ostype(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get the version of Windows that LibVMI is currently accessing.  This is the
@@ -2034,7 +2037,7 @@ os_t vmi_get_ostype(
  * @return Windows version
  */
 win_ver_t vmi_get_winver(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get the build number of Windows that LibVMI is currently accessing.
@@ -2043,7 +2046,7 @@ win_ver_t vmi_get_winver(
  * @return Windows build number
  */
 uint16_t vmi_get_win_buildnumber(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get string represenatation of the version of Windows that LibVMI is currently accessing.
@@ -2052,7 +2055,7 @@ uint16_t vmi_get_win_buildnumber(
  * @return string description of Windows version (do not free)
  */
 const char *vmi_get_winver_str(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get the version of Windows based on the provided KDVB address.  This is the
@@ -2067,7 +2070,7 @@ const char *vmi_get_winver_str(
  */
 win_ver_t vmi_get_winver_manual(
     vmi_instance_t vmi,
-    addr_t kdvb_pa);
+    addr_t kdvb_pa) NOEXCEPT;
 
 /**
  * Get the memory offset associated with the given offset_name.
@@ -2081,7 +2084,7 @@ win_ver_t vmi_get_winver_manual(
 status_t vmi_get_offset(
     vmi_instance_t vmi,
     const char *offset_name,
-    addr_t *offset);
+    addr_t *offset) NOEXCEPT;
 
 /**
  * Get the memory offset associated with the given symbol and subsymbol in the struct
@@ -2096,7 +2099,7 @@ status_t vmi_get_kernel_struct_offset(
     vmi_instance_t vmi,
     const char* struct_name,
     const char* member,
-    addr_t *addr);
+    addr_t *addr) NOEXCEPT;
 
 /**
  * Gets the current value for a VCPU xsave info.When LibVMI is accessing a raw
@@ -2110,7 +2113,7 @@ status_t vmi_get_kernel_struct_offset(
 status_t vmi_get_xsave_info(
     vmi_instance_t vmi,
     unsigned long vcpu,
-    xsave_area_t *xsave_info);
+    xsave_area_t *xsave_info) NOEXCEPT;
 
 /**
  * Gets the memory size of the guest or file that LibVMI is currently
@@ -2126,7 +2129,7 @@ status_t vmi_get_xsave_info(
  * @return Memory size
  */
 uint64_t vmi_get_memsize(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Gets highest addressable physical memory address of the guest or file that
@@ -2142,7 +2145,7 @@ uint64_t vmi_get_memsize(
  * @param[in] vmi LibVMI instance @return physical memory size
  */
 addr_t vmi_get_max_physical_address(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Gets the memory size of the guest that LibVMI is accessing.
@@ -2152,7 +2155,7 @@ addr_t vmi_get_max_physical_address(
  * @return Number of VCPUs
  */
 unsigned int vmi_get_num_vcpus (
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Injects a page fault trap. It is assumed that the guest is in user-mode and in the proper
@@ -2169,7 +2172,7 @@ vmi_request_page_fault(
     vmi_instance_t vmi,
     unsigned long vcpu,
     uint64_t virtual_address,
-    uint32_t error_code);
+    uint32_t error_code) NOEXCEPT;
 
 /**
  * Gets the current value for tsc info.  This currently only
@@ -2189,7 +2192,7 @@ vmi_get_tsc_info(
     uint32_t *tsc_mode,
     uint64_t *elapsed_nsec,
     uint32_t *gtsc_khz,
-    uint32_t *incarnation);
+    uint32_t *incarnation) NOEXCEPT;
 
 /**
  * Gets the current value of VCPU mtrr registers.  This currently only
@@ -2204,7 +2207,7 @@ vmi_get_tsc_info(
 status_t vmi_get_vcpumtrr(
     vmi_instance_t vmi,
     mtrr_regs_t *hwMtrr,
-    unsigned long vcpu);
+    unsigned long vcpu) NOEXCEPT;
 
 /**
  * Gets the current value of a VCPU register.  This currently only
@@ -2228,7 +2231,7 @@ status_t vmi_get_vcpureg(
     vmi_instance_t vmi,
     uint64_t *value,
     reg_t reg,
-    unsigned long vcpu);
+    unsigned long vcpu) NOEXCEPT;
 
 /**
  * Gets the current value of VCPU registers.  This currently only
@@ -2243,7 +2246,7 @@ status_t vmi_get_vcpureg(
 status_t vmi_get_vcpuregs(
     vmi_instance_t vmi,
     registers_t *regs,
-    unsigned long vcpu);
+    unsigned long vcpu) NOEXCEPT;
 
 /**
  * Sets the current value of a VCPU register.  This currently only
@@ -2265,7 +2268,7 @@ status_t vmi_set_vcpureg(
     vmi_instance_t vmi,
     uint64_t value,
     reg_t reg,
-    unsigned long vcpu);
+    unsigned long vcpu) NOEXCEPT;
 
 /**
  * Sets the vCPU registers to the ones passed in the struct. It is important to have
@@ -2283,7 +2286,7 @@ status_t vmi_set_vcpureg(
 status_t vmi_set_vcpuregs(
     vmi_instance_t vmi,
     registers_t *regs,
-    unsigned long vcpu);
+    unsigned long vcpu) NOEXCEPT;
 
 /**
  * Pauses the VM.  Use vmi_resume_vm to resume the VM after pausing
@@ -2293,7 +2296,7 @@ status_t vmi_set_vcpuregs(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t vmi_pause_vm(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Resumes the VM.  Use vmi_pause_vm to pause the VM before calling
@@ -2303,7 +2306,7 @@ status_t vmi_pause_vm(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 status_t vmi_resume_vm(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Removes all entries from LibVMI's internal virtual to physical address
@@ -2316,7 +2319,7 @@ status_t vmi_resume_vm(
  */
 void vmi_v2pcache_flush(
     vmi_instance_t vmi,
-    addr_t dtb);
+    addr_t dtb) NOEXCEPT;
 
 /**
  * Adds one entry to LibVMI's internal virtual to physical address
@@ -2332,7 +2335,7 @@ void vmi_v2pcache_add(
     vmi_instance_t vmi,
     addr_t va,
     addr_t dtb,
-    addr_t pa);
+    addr_t pa) NOEXCEPT;
 
 /**
  * Removes all entries from LibVMI's internal kernel symbol to virtual address
@@ -2343,7 +2346,7 @@ void vmi_v2pcache_add(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 void vmi_symcache_flush(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Adds one entry to LibVMI's internal symbol to virtual address
@@ -2361,7 +2364,7 @@ void vmi_symcache_add(
     addr_t base_addr,
     vmi_pid_t pid,
     char *sym,
-    addr_t va);
+    addr_t va) NOEXCEPT;
 
 /**
  * Removes all entries from LibVMI's internal RVA to symbol
@@ -2372,7 +2375,7 @@ void vmi_symcache_add(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 void vmi_rvacache_flush(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Adds one entry to LibVMI's internal RVA to symbol
@@ -2390,7 +2393,7 @@ void vmi_rvacache_add(
     addr_t base_addr,
     vmi_pid_t pid,
     addr_t rva,
-    char *sym);
+    char *sym) NOEXCEPT;
 
 /**
  * Removes all entries from LibVMI's internal pid to directory table base
@@ -2401,7 +2404,7 @@ void vmi_rvacache_add(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 void vmi_pidcache_flush(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Adds one entry to LibVMI's internal pid to directory table base
@@ -2415,7 +2418,7 @@ void vmi_pidcache_flush(
 void vmi_pidcache_add(
     vmi_instance_t vmi,
     vmi_pid_t pid,
-    addr_t dtb);
+    addr_t dtb) NOEXCEPT;
 
 /**
  * Removes all entries from LibVMI's internal page cache.  This is
@@ -2426,7 +2429,7 @@ void vmi_pidcache_add(
  * @return VMI_SUCCESS or VMI_FAILURE
  */
 void vmi_pagecache_flush(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Returns the path of the Linux system map file for the given vmi instance
@@ -2436,7 +2439,7 @@ void vmi_pagecache_flush(
  * @param[in] vmi LibVMI instance
  * @return String file path location of the Linux system map
  */
-const char * vmi_get_linux_sysmap(vmi_instance_t vmi);
+const char * vmi_get_linux_sysmap(vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Returns the path of the FreeBSD system map file for the given vmi instance
@@ -2446,7 +2449,7 @@ const char * vmi_get_linux_sysmap(vmi_instance_t vmi);
  * @param[in] vmi LibVMI instance
  * @return String file path location of the FreeBSD system map
  */
-const char * vmi_get_freebsd_sysmap(vmi_instance_t vmi);
+const char * vmi_get_freebsd_sysmap(vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get full path of associated rekall profile
@@ -2457,7 +2460,7 @@ const char * vmi_get_freebsd_sysmap(vmi_instance_t vmi);
  * @return Full path of the rekall profile
  */
 const char *vmi_get_rekall_path(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Get full path of associated OS profile.
@@ -2468,7 +2471,7 @@ const char *vmi_get_rekall_path(
  * @return Full path of the OS profile
  */
 const char *vmi_get_os_profile_path(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 #pragma GCC visibility pop
 

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -30,6 +30,9 @@
 
 #ifdef __cplusplus
 extern "C" {
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
 #endif
 
 #pragma GCC visibility push(default)
@@ -47,7 +50,7 @@ extern "C" {
  */
 GSList* vmi_get_va_pages(
     vmi_instance_t vmi,
-    addr_t dtb);
+    addr_t dtb) NOEXCEPT;
 
 /**
  * Retrieve the kernel's open json_object
@@ -56,7 +59,7 @@ GSList* vmi_get_va_pages(
  * @return The json_object* open for the VM or NULL on error.
  */
 json_object* vmi_get_kernel_json(
-    vmi_instance_t vmi);
+    vmi_instance_t vmi) NOEXCEPT;
 
 /**
  * Look up the provided symbol's address from the json
@@ -71,7 +74,7 @@ status_t vmi_get_symbol_addr_from_json(
     vmi_instance_t vmi,
     json_object* json,
     const char* symbol,
-    addr_t* addr);
+    addr_t* addr) NOEXCEPT;
 
 /**
  * Look up the provided structure's size from the json
@@ -86,7 +89,7 @@ status_t vmi_get_struct_size_from_json(
     vmi_instance_t vmi,
     json_object* json,
     const char* struct_name,
-    size_t* size);
+    size_t* size) NOEXCEPT;
 
 /**
  * Look up the provided symbol's address from the json
@@ -103,7 +106,7 @@ status_t vmi_get_struct_member_offset_from_json(
     json_object* json,
     const char* struct_name,
     const char* struct_member,
-    addr_t* offset);
+    addr_t* offset) NOEXCEPT;
 
 #pragma GCC visibility pop
 

--- a/libvmi/peparse.h
+++ b/libvmi/peparse.h
@@ -29,6 +29,9 @@
 
 #ifdef __cplusplus
 extern "C" {
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
 #endif
 
 #pragma GCC visibility push(default)
@@ -200,7 +203,7 @@ struct export_table {
 status_t
 peparse_validate_pe_image(
     const uint8_t * const image,
-    size_t len);
+    size_t len) NOEXCEPT;
 
 /**
  * Return a valid PE image if one was found
@@ -217,7 +220,7 @@ peparse_get_image(
     vmi_instance_t vmi,
     const access_context_t *ctx,
     size_t len,
-    const uint8_t * const image);
+    const uint8_t * const image) NOEXCEPT;
 
 /**
  * Assign PE headers to an image.
@@ -238,7 +241,7 @@ peparse_assign_headers(
     uint16_t *optional_header_type,
     void **optional_pe_header,
     struct optional_header_pe32 **oh_pe32,
-    struct optional_header_pe32plus **oh_pe32plus);
+    struct optional_header_pe32plus **oh_pe32plus) NOEXCEPT;
 
 /**
  * Get an RVA value from the PE image data directory (idd).
@@ -258,7 +261,7 @@ peparse_get_idd_rva(
     uint16_t *optional_header_type,
     void *optional_header,
     struct optional_header_pe32 *oh_pe32,
-    struct optional_header_pe32plus *oh_pe32plus);
+    struct optional_header_pe32plus *oh_pe32plus) NOEXCEPT;
 
 /**
  * Get the size from the PE image data directory (idd).
@@ -278,7 +281,7 @@ peparse_get_idd_size(
     uint16_t *optional_header_type,
     void *optional_header,
     struct optional_header_pe32 *oh_pe32,
-    struct optional_header_pe32plus *oh_pe32plus);
+    struct optional_header_pe32plus *oh_pe32plus) NOEXCEPT;
 
 /**
  * Get the export table from a PE image.
@@ -295,7 +298,7 @@ peparse_get_export_table(
     const access_context_t *ctx,
     struct export_table *et,
     addr_t *export_table_rva,
-    size_t *export_table_size);
+    size_t *export_table_size) NOEXCEPT;
 
 #pragma GCC visibility pop
 #ifdef __cplusplus

--- a/libvmi/slat.h
+++ b/libvmi/slat.h
@@ -37,6 +37,9 @@
 
 #ifdef __cplusplus
 extern "C" {
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
 #endif
 
 #pragma GCC visibility push(default)
@@ -50,7 +53,7 @@ extern "C" {
 */
 status_t vmi_slat_get_domain_state (
     vmi_instance_t vmi,
-    bool *state);
+    bool *state) NOEXCEPT;
 
 /**
 * Enables or disables slat for the domain
@@ -61,7 +64,7 @@ status_t vmi_slat_get_domain_state (
 */
 status_t vmi_slat_set_domain_state (
     vmi_instance_t vmi,
-    bool state);
+    bool state) NOEXCEPT;
 
 /**
 * Creates a new slat slat_id
@@ -72,7 +75,7 @@ status_t vmi_slat_set_domain_state (
 */
 status_t vmi_slat_create (
     vmi_instance_t vmi,
-    uint16_t *slat_id);
+    uint16_t *slat_id) NOEXCEPT;
 
 /**
 * Destroys an slat slat_id
@@ -83,7 +86,7 @@ status_t vmi_slat_create (
 */
 status_t vmi_slat_destroy (
     vmi_instance_t vmi,
-    uint16_t slat_idx);
+    uint16_t slat_idx) NOEXCEPT;
 
 /**
 * Switches to a specific slat slat_id
@@ -94,7 +97,7 @@ status_t vmi_slat_destroy (
 */
 status_t vmi_slat_switch (
     vmi_instance_t vmi,
-    uint16_t slat_idx);
+    uint16_t slat_idx) NOEXCEPT;
 
 /**
 *
@@ -109,7 +112,7 @@ status_t vmi_slat_change_gfn (
     vmi_instance_t vmi,
     uint16_t slat_idx,
     addr_t old_gfn,
-    addr_t new_gfn);
+    addr_t new_gfn) NOEXCEPT;
 
 #pragma GCC visibility pop
 


### PR DESCRIPTION
Optimizes C++ code as C functions never throw exceptions