### PR TITLE
Make all char inputs to _ksym functions const

### DIFF
--- a/examples/map-addr.c
+++ b/examples/map-addr.c
@@ -42,7 +42,7 @@ main(
         return 1;
 
     vmi_instance_t vmi;
-    unsigned char *memory = malloc(PAGE_SIZE);
+    char *memory = malloc(PAGE_SIZE);
 
     /* this is the VM or file that we are looking at */
     char *name = argv[1];

--- a/examples/map-symbol.c
+++ b/examples/map-symbol.c
@@ -42,7 +42,7 @@ main(
         return 1;
 
     vmi_instance_t vmi;
-    unsigned char *memory = malloc(PAGE_SIZE);
+    char *memory = malloc(PAGE_SIZE);
 
     /* this is the VM or file that we are looking at */
     char *name = argv[1];

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1252,7 +1252,7 @@ status_t vmi_read_pa(
  */
 status_t vmi_read_8_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint8_t * value) NOEXCEPT;
 
 /**
@@ -1265,7 +1265,7 @@ status_t vmi_read_8_ksym(
  */
 status_t vmi_read_16_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint16_t * value) NOEXCEPT;
 
 /**
@@ -1278,7 +1278,7 @@ status_t vmi_read_16_ksym(
  */
 status_t vmi_read_32_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint32_t * value) NOEXCEPT;
 
 /**
@@ -1291,7 +1291,7 @@ status_t vmi_read_32_ksym(
  */
 status_t vmi_read_64_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint64_t * value) NOEXCEPT;
 
 /**
@@ -1305,7 +1305,7 @@ status_t vmi_read_64_ksym(
  */
 status_t vmi_read_addr_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     addr_t *value) NOEXCEPT;
 
 /**
@@ -1319,7 +1319,7 @@ status_t vmi_read_addr_ksym(
  */
 char *vmi_read_str_ksym(
     vmi_instance_t vmi,
-    char *sym) NOEXCEPT;
+    const char *sym) NOEXCEPT;
 
 /**
  * Reads 8 bits from memory, given a virtual address.
@@ -1563,7 +1563,7 @@ status_t vmi_write(
  */
 status_t vmi_write_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     size_t count,
     void *buf,
     size_t *bytes_written) NOEXCEPT;
@@ -1682,7 +1682,7 @@ status_t vmi_write_addr(
  */
 status_t vmi_write_8_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint8_t * value) NOEXCEPT;
 
 /**
@@ -1695,7 +1695,7 @@ status_t vmi_write_8_ksym(
  */
 status_t vmi_write_16_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint16_t * value) NOEXCEPT;
 
 /**
@@ -1708,7 +1708,7 @@ status_t vmi_write_16_ksym(
  */
 status_t vmi_write_32_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint32_t * value) NOEXCEPT;
 
 /**
@@ -1721,7 +1721,7 @@ status_t vmi_write_32_ksym(
  */
 status_t vmi_write_64_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint64_t * value) NOEXCEPT;
 
 /**
@@ -1735,7 +1735,7 @@ status_t vmi_write_64_ksym(
  */
 status_t vmi_write_addr_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     addr_t * value) NOEXCEPT;
 
 /**
@@ -1893,7 +1893,7 @@ status_t vmi_write_addr_pa(
  * @param[in] length The length (in bytes) of data
  */
 void vmi_print_hex(
-    unsigned char *data,
+    const char *data,
     unsigned long length) NOEXCEPT;
 
 /**
@@ -1907,7 +1907,7 @@ void vmi_print_hex(
  */
 void vmi_print_hex_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     size_t length) NOEXCEPT;
 
 /**

--- a/libvmi/pretty_print.c
+++ b/libvmi/pretty_print.c
@@ -30,7 +30,7 @@
 
 void
 vmi_print_hex(
-    unsigned char *data,
+    const char *data,
     unsigned long length)
 {
     unsigned long i, j, numrows, index;
@@ -84,7 +84,7 @@ vmi_print_hex_pa(
     addr_t paddr,
     size_t length)
 {
-    unsigned char *buf = safe_malloc(length);
+    char *buf = safe_malloc(length);
 
     if ( VMI_SUCCESS == vmi_read_pa(vmi, paddr, length, buf, NULL) )
         vmi_print_hex(buf, length);
@@ -113,7 +113,7 @@ vmi_print_hex_va(
 void
 vmi_print_hex_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     size_t length)
 {
     addr_t vaddr = 0;

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -737,7 +737,7 @@ vmi_read_unicode_str_va(vmi_instance_t vmi, addr_t vaddr, vmi_pid_t pid)
 status_t
 vmi_read_8_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint8_t * value)
 {
     return vmi_read_ksym(vmi, sym, 1, value, NULL);
@@ -746,7 +746,7 @@ vmi_read_8_ksym(
 status_t
 vmi_read_16_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint16_t * value)
 {
     return vmi_read_ksym(vmi, sym, 2, value, NULL);
@@ -755,7 +755,7 @@ vmi_read_16_ksym(
 status_t
 vmi_read_32_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint32_t * value)
 {
     return vmi_read_ksym(vmi, sym, 4, value, NULL);
@@ -764,7 +764,7 @@ vmi_read_32_ksym(
 status_t
 vmi_read_64_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint64_t * value)
 {
     return vmi_read_ksym(vmi, sym, 8, value, NULL);
@@ -773,7 +773,7 @@ vmi_read_64_ksym(
 status_t
 vmi_read_addr_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     addr_t *value)
 {
     status_t ret = VMI_FAILURE;
@@ -813,7 +813,7 @@ vmi_read_addr_ksym(
 char *
 vmi_read_str_ksym(
     vmi_instance_t vmi,
-    char *sym)
+    const char *sym)
 {
     addr_t vaddr = 0;
 

--- a/libvmi/write.c
+++ b/libvmi/write.c
@@ -185,7 +185,7 @@ vmi_write_va(
 status_t
 vmi_write_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     size_t count,
     void *buf,
     size_t *bytes_written)
@@ -384,7 +384,7 @@ vmi_write_addr_va(
 status_t
 vmi_write_8_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint8_t * value)
 {
     return vmi_write_ksym(vmi, sym, 1, value, NULL);
@@ -393,7 +393,7 @@ vmi_write_8_ksym(
 status_t
 vmi_write_16_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint16_t * value)
 {
     return vmi_write_ksym(vmi, sym, 2, value, NULL);
@@ -402,7 +402,7 @@ vmi_write_16_ksym(
 status_t
 vmi_write_32_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint32_t * value)
 {
     return vmi_write_ksym(vmi, sym, 4, value, NULL);
@@ -411,7 +411,7 @@ vmi_write_32_ksym(
 status_t
 vmi_write_64_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     uint64_t * value)
 {
     return vmi_write_ksym(vmi, sym, 8, value, NULL);
@@ -420,7 +420,7 @@ vmi_write_64_ksym(
 status_t
 vmi_write_addr_ksym(
     vmi_instance_t vmi,
-    char *sym,
+    const char *sym,
     addr_t * value)
 {
     access_context_t ctx = {


### PR DESCRIPTION
Some already were, so this just makes things more consistent.