### PR TITLE
fix incorrect pagesize constants

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -191,9 +191,9 @@ typedef enum page_size {
 
     VMI_PS_32MB     = 0x2000000ULL, /**< 32MB */
 
-    VMI_PS_512MB    = 0x2000000ULL,  /**< 512MB */
+    VMI_PS_512MB    = 0x20000000ULL,  /**< 512MB */
 
-    VMI_PS_1GB      = 0x4000000ULL,  /**< 1GB */
+    VMI_PS_1GB      = 0x40000000ULL,  /**< 1GB */
 
 } page_size_t;
 


### PR DESCRIPTION
```
>>> 0x4000000
67108864
>>> 0x40000000
1073741824
>>> 0x4000000 / (2**26)
1.0
>>> 2**30
1073741824
>>> 0x40000000 / (2**30)
1.0
>>> 2**26 == 64 * 1024 * 1024
True
>>> 2**30 == 1024 * 1024 * 1024
True
```