### PR TITLE
dump-memory example tool now produces sparse files

### DIFF
--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -37,13 +37,19 @@
 #define PAGE_SIZE 1UL << 12
 static int sparse_flag = 0;
 
+static inline void usage(const char *argv0) {
+    printf("Usage: %s [-s|--sparse] domain output_file\n", argv0);
+}
+
 int
 main(
     int argc,
     char **argv)
 {
-    if ( argc != 3 )
+    if ( argc != 3 ) {
+        usage(argv[0]);
         return 1;
+    }
 
     char c;
     const char* opts = "s";
@@ -76,6 +82,7 @@ main(
                 break;
             case '?':
             default:
+                usage(argv[0]);
                 return 2;
         }
     }

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -37,7 +37,8 @@
 #define PAGE_SIZE 1UL << 12
 static int sparse_flag = 0;
 
-static inline void usage(const char *argv0) {
+static inline void usage(const char *argv0)
+{
     printf("Usage: %s [-s|--sparse] domain output_file\n", argv0);
 }
 


### PR DESCRIPTION
mentioned, but not related, in this issue:
[https://github.com/libvmi/python/issues/58](url)