### PR TITLE
Rework vmi-dump-memory

### DIFF
--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -24,171 +24,206 @@
  * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <config.h>
-#include <libvmi/libvmi.h>
 #define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <string.h>
-#include <sys/mman.h>
 #include <stdio.h>
 #include <limits.h>
 #include <getopt.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <config.h>
+#include <libvmi/libvmi.h>
 
-#define PAGE_SIZE 1UL << 12
-static int sparse_flag = 0;
+#define FRAME_SIZE (1UL << 12)
+#define PROGRESS_STRIDE (1024 * 1024 * 32) // 32 MiB
 
-static inline void usage(const char *argv0)
+/* Create sparse file */
+static int sparse_flag;
+
+/* Print progress when dumping the memory */
+static int progress_flag;
+
+/* Pause VM when dumping memory */
+static int pause_vm_flag = 1;
+
+volatile int interrupted;
+void sigint_handler()
 {
-    printf("Usage: %s [-s|--sparse] domain output_file\n", argv0);
+    interrupted = 1;
 }
 
-int
-main(
-    int argc,
-    char **argv)
+static int bareflank_setup(vmi_init_data_t **init_data_ptr, memory_map_t **memmap_ptr)
 {
-    if ( argc != 3 ) {
+    printf("Using this example on Bareflank is not safe.\n");
+    printf("You have to adjust it to match your machine before running it.\n");
+    return 1;
+
+    /* The following is an example based on the e820 map described in
+     * notes/memory_map.txt. */
+    uint32_t e820_entries = 5;
+
+    memory_map_t *memmap = malloc(sizeof(memory_map_t) + sizeof(addr_t) * 2 * e820_entries);
+    memmap->count = e820_entries;
+    memmap->range[0][0] = 0xfff;
+    memmap->range[0][1] = 0x57fff;
+    memmap->range[1][0] = 0x60000;
+    memmap->range[1][1] = 0x97fff;
+    memmap->range[2][0] = 0x100000;
+    memmap->range[2][1] = 0xdbfb8fff;
+    memmap->range[3][0] = 0xdcfff000;
+    memmap->range[3][1] = 0xdcffffff;
+    memmap->range[4][0] = 0x100000000;
+    memmap->range[4][1] = 0x21e5fffff;
+
+    vmi_init_data_t *init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+    init_data->count = 1;
+    init_data->entry[0].type = VMI_INIT_DATA_MEMMAP;
+    init_data->entry[0].data = memmap;
+    *init_data_ptr = init_data;
+    *memmap_ptr = memmap;
+    return 0;
+}
+
+static void usage(const char *argv0)
+{
+    printf("Usage: %s [options] domain output_file\n", argv0);
+    printf("Available options:\n");
+    printf("  -p, --progress print progress when dumping\n");
+    printf("  -s, --sparse   save dump as sparse file\n");
+    printf("      --no-pause don't pause the VM when dumping memory\n");
+    printf("  -h, --help     print help and exit\n");
+}
+
+static const struct option long_opts[] = {
+    {"sparse",   no_argument, &sparse_flag,   1},
+    {"progress", no_argument, &progress_flag, 1},
+    {"no-pause", no_argument, &pause_vm_flag, 0},
+    {0, 0, 0, 0}
+};
+
+int main(int argc, char **argv)
+{
+    int c;
+    while ((c = getopt_long(argc, argv, "psh", long_opts, NULL)) != -1) {
+        switch (c) {
+            case 0:
+                break;
+            case 's':
+                sparse_flag = 1;
+                printf("found sparse flag!");
+                break;
+            case 'p':
+                progress_flag = 1;
+                printf("found progress flag!");
+                break;
+            case 'h':
+            default:
+                usage(argv[0]);
+                return 1;
+        }
+    }
+
+    /* two other arguments required */
+    if (argc - optind != 2) {
         usage(argv[0]);
         return 1;
     }
 
-    char c;
-    const char* opts = "s";
-    const struct option long_opts[] = {
-        {"sparse", no_argument, &sparse_flag, 1},
-    };
-
-    vmi_instance_t vmi = NULL;
-    char *filename = NULL;
-    FILE *f = NULL;
-    unsigned char memory[PAGE_SIZE];
-    unsigned char zeros[PAGE_SIZE];
-
-    memset(zeros, 0, PAGE_SIZE);
-
-    addr_t address = 0;
-    addr_t size = 0;
-    vmi_mode_t mode;
-    vmi_init_data_t *init_data = NULL;
-    memory_map_t *memmap = NULL;
-    int status;
-    while (1) {
-        c = getopt_long (argc, argv, opts, long_opts, NULL);
-        if (c == -1) break;
-        switch (c) {
-            case 0: //long opt flag is set
-                break;
-            case 's':
-                sparse_flag = 1;
-                break;
-            case '?':
-            default:
-                usage(argv[0]);
-                return 2;
-        }
-    }
-
     /* this is the VM or file that we are looking at */
-    char *name = argv[1];
+    const char *name = argv[optind];
 
     /* this is the file name to write the memory image to */
-    filename = strndup(argv[2], PATH_MAX);
+    const char *filename = argv[optind + 1];
 
-    if (VMI_FAILURE == vmi_get_access_mode(vmi, (void*)name, VMI_INIT_DOMAINNAME, NULL, &mode) )
-        goto error_exit;
+    vmi_mode_t mode;
+    if (VMI_FAILURE == vmi_get_access_mode(NULL, name, VMI_INIT_DOMAINNAME, NULL, &mode) ) {
+        return 1;
+    }
 
-    /*
-     * For bareflank we have to pass-in the actual memory map of the machine.
-     */
-    if ( mode == VMI_BAREFLANK ) {
-        printf("Using this example on Bareflank is not safe.\n");
-        printf("You have to adjust it to match your machine before running it.\n");
-        goto error_exit;
-
-        /* The following is an example based on the e820 map described in
-         * notes/memory_map.txt. */
-        uint32_t e820_entries = 5;
-
-        memmap = malloc(sizeof(memory_map_t) + sizeof(addr_t) * 2 * e820_entries);
-        memmap->count = e820_entries;
-        memmap->range[0][0] = 0xfff;
-        memmap->range[0][1] = 0x57fff;
-        memmap->range[1][0] = 0x60000;
-        memmap->range[1][1] = 0x97fff;
-        memmap->range[2][0] = 0x100000;
-        memmap->range[2][1] = 0xdbfb8fff;
-        memmap->range[3][0] = 0xdcfff000;
-        memmap->range[3][1] = 0xdcffffff;
-        memmap->range[4][0] = 0x100000000;
-        memmap->range[4][1] = 0x21e5fffff;
-
-        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
-        init_data->count = 1;
-        init_data->entry[0].type = VMI_INIT_DATA_MEMMAP;
-        init_data->entry[0].data = memmap;
+    /* for bareflank we have to pass-in the actual memory map of the machine. */
+    vmi_init_data_t *init_data = NULL;
+    memory_map_t *memmap = NULL;
+    if (mode == VMI_BAREFLANK && bareflank_setup(&init_data, &memmap) != 0) {
+        return 1;
     }
 
     /* initialize the libvmi library */
+    vmi_instance_t vmi = NULL;
     if (VMI_FAILURE == vmi_init(&vmi, mode, (void*)name, VMI_INIT_DOMAINNAME, init_data, NULL)) {
-        printf("Failed to init LibVMI library.\n");
-        goto error_exit;
+        printf("Failed to initialize LibVMI library.\n");
+        goto free_setup_info;
     }
 
     /* open the file for writing */
-    if ((f = fopen(filename, "w+")) == NULL) {
-        printf("failed to open file for writing.\n");
-        goto error_exit;
+    FILE *f = fopen(filename, "w+");
+    if (f == NULL) {
+        printf("Failed to open file for writing.\n");
+        goto destroy_vmi;
     }
 
-    size = vmi_get_max_physical_address(vmi);
+    /* pause the VM */
+    if (pause_vm_flag && VMI_FAILURE == vmi_pause_vm(vmi)) {
+        printf("Failed to pause the VM.\n");
+        goto close_file;
+    }
 
-    while (address < size) {
+    /* handle ctrl+c gracefully */
+    signal(SIGINT, sigint_handler);
 
-        /* write memory to file */
-        if (VMI_SUCCESS == vmi_read_pa(vmi, address, PAGE_SIZE, memory, NULL)) {
-            /* memory mapped, just write to file */
-            size_t written = fwrite(memory, 1, PAGE_SIZE, f);
+    /* dump physical memory */
+    char memory[FRAME_SIZE];
+    char zeros[FRAME_SIZE];
+    memset(zeros, 0, FRAME_SIZE);
+    addr_t addr_max = vmi_get_max_physical_address(vmi);
 
-            if (written != PAGE_SIZE) {
-                printf("failed to write memory to file.\n");
-                goto error_exit;
-            }
-        } else {
-            /* memory not mapped */
-            if (sparse_flag) {
-                /* seek to maintain offset with sparse output */
-                status = fseek(f, PAGE_SIZE, SEEK_CUR);
-                if (status != 0) {
-                    printf("failed to fseek PAGE_SIZE in file.\n");
-                    goto error_exit;
-                }
-            } else {
-                /* write zeros to maintain offset */
-                size_t written = fwrite(zeros, 1, PAGE_SIZE, f);
+    for (addr_t address = 0; address < addr_max && !interrupted; address += FRAME_SIZE) {
+        if (progress_flag && (address % PROGRESS_STRIDE == 0)) {
+            printf("Progress: %lu%%\n", (address * 100) / addr_max);
+        }
 
-                if (written != PAGE_SIZE) {
-                    printf("failed to write zeros to file.\n");
-                    goto error_exit;
-                }
+        int empty_frame = 1;
+        /* try to read current frame*/
+        if (VMI_SUCCESS == vmi_read_pa(vmi, address, FRAME_SIZE, memory, NULL)) {
+            /* check if frame has some non-zero byte */
+            if (memcmp(memory, zeros, FRAME_SIZE) != 0) {
+                empty_frame = 0;
             }
         }
 
-        /* move on to the next page */
-        address += PAGE_SIZE;
+        /* skip empty frame in sparse mode*/
+        if (sparse_flag && empty_frame) {
+            int status = fseek(f, FRAME_SIZE, SEEK_CUR);
+            if (status != 0) {
+                printf("Failed to fseek FRAME_SIZE into file.\n");
+                goto resume_vm;
+            }
+            continue;
+        }
+
+        /* write frame to output file */
+        char *buffer = empty_frame ? zeros : memory;
+        size_t written = fwrite(buffer, 1, FRAME_SIZE, f);
+        if (written != FRAME_SIZE) {
+            printf("Failed to saved frame.\n");
+            goto resume_vm;
+        }
     }
 
-error_exit:
-    if (f)
-        fclose(f);
-    if (memmap)
-        free(memmap);
-    if (init_data)
-        free(init_data);
+resume_vm:
+    if (pause_vm_flag) {
+        vmi_resume_vm(vmi);
+    }
 
-    free(filename);
+close_file:
+    fclose(f);
 
-    /* cleanup any memory associated with the libvmi instance */
+destroy_vmi:
     vmi_destroy(vmi);
 
+free_setup_info:
+    free(memmap);
+    free(init_data);
     return 0;
 }

--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -112,11 +112,9 @@ int main(int argc, char **argv)
                 break;
             case 's':
                 sparse_flag = 1;
-                printf("found sparse flag!");
                 break;
             case 'p':
                 progress_flag = 1;
-                printf("found progress flag!");
                 break;
             case 'h':
             default:


### PR DESCRIPTION
At the beginning I wanted to add support for pausing the VM when dumping memory, however I've found some bigger issues (it seems that `--sparse` is not working because  `if (argc != 3)` makes the program exit, missing null getopt at the end of the array causing UB, etc.).

Summary:
* Reworded page as frame, since it seems more appropriate in this context
* Added working sparse file support for both unmapped frames and zero-only frames
* Added pausing the VM as default behavior (this seems reasonable)
* Added SIGINT handler to cleanly stop the program
* Added `--progress` switch for tracking progress every 32MiB dumped
* Added `--no-pause` switch to disable VM pausing if it's desired