### PR TITLE
Fix segfault with --enable-vmi-debug

### DIFF
--- a/libvmi/json_profiles/rekall.c
+++ b/libvmi/json_profiles/rekall.c
@@ -105,7 +105,7 @@ rekall_profile_symbol_to_rva(
     }
 
 exit:
-    dbprint(VMI_DEBUG_MISC, "Rekall profile lookup %s %s: 0x%lx\n", symbol ?: NULL, subsymbol ?: NULL, *rva);
+    dbprint(VMI_DEBUG_MISC, "Rekall profile lookup %s %s: 0x%lx\n", symbol ?: NULL, subsymbol ?: NULL, rva ? *rva : NULL);
 
     return ret;
 }

--- a/libvmi/json_profiles/rekall.c
+++ b/libvmi/json_profiles/rekall.c
@@ -105,7 +105,7 @@ rekall_profile_symbol_to_rva(
     }
 
 exit:
-    dbprint(VMI_DEBUG_MISC, "Rekall profile lookup %s %s: 0x%lx\n", symbol ?: NULL, subsymbol ?: NULL, rva ? *rva : NULL);
+    dbprint(VMI_DEBUG_MISC, "Rekall profile lookup %s %s: 0x%lx\n", symbol ?: NULL, subsymbol ?: NULL, rva ? *rva : 0);
 
     return ret;
 }


### PR DESCRIPTION
`rekall_profile_symbol_to_rva` may be called only to query the size, not the RVA. In such case `RVA == NULL` and a segfault occurs when debug prints are enabled