### PR TITLE
Off-by-one error in xen driver renders last physical page inaccessible

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -790,7 +790,7 @@ xen_get_memsize(
     }
 
     *allocated_ram_size = XC_PAGE_SIZE * pages;
-    *max_physical_address = xen->max_gpfn << XC_PAGE_SHIFT;
+    *max_physical_address = (xen->max_gpfn + 1) << XC_PAGE_SHIFT;
 
     return VMI_SUCCESS;
 }


### PR DESCRIPTION
The max_physical_address member of the vmi_instance data structure must by definition point past the end of the last physical page.
However, in the current implementation of the Xen driver, this member points *at* the last physical page, therefore rendering it inaccessible as we hit a sanity check in the [memory cache](https://github.com/libvmi/libvmi/blob/master/libvmi/driver/memory_cache.c#L123) for HVM guests.