### PR TITLE
do not skip the pid=1 entry in tasklist

### DIFF
--- a/libvmi/os/linux/memory.c
+++ b/libvmi/os/linux/memory.c
@@ -59,7 +59,7 @@ linux_get_taskstruct_addr_from_pid(
      * the actual task struct, not to the linked list entry.
      */
     curr_proc = vmi->init_task;
-    vmi_read_addr_va(vmi, curr_proc + tasks_offset, 0, &curr_entry);
+    curr_entry = curr_proc + tasks_offset;
 
     list_head = curr_entry;
 


### PR DESCRIPTION
The code of #787 starts with curr_proc pointing to inittask (pid=0), curr_entry to the linked list of the next (pid=1).
The first loop iteration analyzes curr_proc (pid=0), then advances curr_entry to the linked list of the successor (pid=2) and curr_proc to that entry (pid=2).  pid=1 (the second entry of the task list) is never used.

The simple fix starts with curr_entry pointing to the linked list of the inittask.