### PR TITLE
fix libxc->xc_monitor_guest_request for Xen >4.9

### DIFF
--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -89,7 +89,8 @@ static status_t sanity_check(xen_instance_t *xen)
                 break;
         /* Fall-through */
         case 10:
-            if ( !w->xc_monitor_descriptor_access || !w->xc_monitor_write_ctrlreg2 )
+            if ( !w->xc_monitor_descriptor_access || !w->xc_monitor_write_ctrlreg2 ||
+                    !w->xc_monitor_guest_request2)
                 break;
         /* Fall-through */
         case 9:
@@ -204,6 +205,7 @@ status_t create_libxc_wrapper(xen_instance_t *xen)
     wrapper->xc_monitor_singlestep = dlsym(wrapper->handle, "xc_monitor_singlestep");
     wrapper->xc_monitor_software_breakpoint = dlsym(wrapper->handle, "xc_monitor_software_breakpoint");
     wrapper->xc_monitor_guest_request = dlsym(wrapper->handle, "xc_monitor_guest_request");
+    wrapper->xc_monitor_guest_request2 = dlsym(wrapper->handle, "xc_monitor_guest_request");
     wrapper->xc_monitor_privileged_call = dlsym(wrapper->handle, "xc_monitor_privileged_call");
     wrapper->xc_monitor_descriptor_access = dlsym(wrapper->handle, "xc_monitor_descriptor_access");
     wrapper->xc_monitor_emul_unimplemented = dlsym(wrapper->handle, "xc_monitor_emul_unimplemented");

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -249,6 +249,9 @@ typedef struct {
     int (*xc_monitor_write_ctrlreg2)
     (xc_interface *xch, uint32_t domain_id, uint16_t index, bool enable, bool sync, uint64_t bitmask, bool onchangeonly);
 
+    int (*xc_monitor_guest_request2)
+    (xc_interface *xch, uint32_t domain_id, bool enable, bool sync, bool allow_userspace);
+
     /* Xen 4.11+ */
     int (*xc_monitor_emul_unimplemented)
     (xc_interface *xch, uint32_t domain_id, bool enable);

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -407,9 +407,16 @@ status_t xen_set_guest_requested_event(vmi_instance_t vmi, bool enabled)
     if ( !enabled && !vmi->guest_requested_event )
         return VMI_SUCCESS;
 
-    rc  = xen->libxcw.xc_monitor_guest_request(xen_get_xchandle(vmi),
-            xen_get_domainid(vmi),
-            enabled, 1);
+    if ( xen->minor_version < 10 ) {
+        rc  = xen->libxcw.xc_monitor_guest_request(xen_get_xchandle(vmi),
+                xen_get_domainid(vmi),
+                enabled, 1);
+    } else {
+        rc  = xen->libxcw.xc_monitor_guest_request2(xen_get_xchandle(vmi),
+                xen_get_domainid(vmi),
+                enabled, 1, 1);
+    }
+
     if ( rc < 0 ) {
         errprint("Error %i setting guest request monitor\n", rc);
         return VMI_FAILURE;


### PR DESCRIPTION
The signature of xc_monitor_guest_request changed with 4.10,
the dynamic wrapper needs to account for this.

I adapted this from the other cases, which are handled similarly.