### PR TITLE
Travis: Use clang 10 for static analysis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,9 +142,10 @@ jobs:
       install:
         - sudo apt-get update
         - sudo apt-get -q -y install bison flex libjson-c-dev libvirt-dev libxen-dev libfuse-dev
+        - sudo apt-get install clang-tools-10
       script:
         - mkdir build && cd build
-        - cmake ..
+        - cmake -DSCAN_BUILD='scan-build-10' ..
         - make static_analysis_test
 
 #

--- a/cmake/modules/StaticAnalysis.cmake
+++ b/cmake/modules/StaticAnalysis.cmake
@@ -1,20 +1,24 @@
-# detect ccc_analyzer
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/static_analysis_build)
+
+# add SCAN_BUILD var to select scan-build-x binary
+# default to "scan-build"
+set(SCAN_BUILD "scan-build" CACHE STRING "scan-build binary to be used for static analysis")
+
 # create custom target
 add_custom_target(
     static_analysis
-    COMMAND scan-build cmake -DCMAKE_BUILD_TYPE=DEBUG -DENABLE_CONFIGFILE=OFF ${PROJECT_SOURCE_DIR}
+    COMMAND ${SCAN_BUILD} cmake -DCMAKE_BUILD_TYPE=DEBUG -DENABLE_CONFIGFILE=OFF ${PROJECT_SOURCE_DIR}
     # -v -> verbosity
     # -V -> open results in browser
-    COMMAND scan-build -v -V make
+    COMMAND ${SCAN_BUILD} -v -V make
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/static_analysis_build)
 
 # create custom target
 # we don't need to analyze examples or test suite code
 add_custom_target(
     static_analysis_test
-    COMMAND scan-build cmake -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_EXAMPLES=OFF
+    COMMAND ${SCAN_BUILD} cmake -DCMAKE_BUILD_TYPE=DEBUG -DBUILD_EXAMPLES=OFF
         -DENABLE_TESTING=OFF -DENABLE_CONFIGFILE=OFF ${PROJECT_SOURCE_DIR}
     # -v -> verbosity
-    COMMAND scan-build -v --status-bugs make
+    COMMAND ${SCAN_BUILD} -v --status-bugs make
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/static_analysis_build)

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -461,13 +461,12 @@ xen_get_version(
     status_t status = VMI_FAILURE;
     char *line = NULL;
     size_t len = 0;
-    ssize_t read;
 
     FILE *fp = fopen("/sys/hypervisor/type", "r");
     if ( !fp )
         goto done;
 
-    if ((read = getline(&line, &len, fp)) == -1)
+    if (getline(&line, &len, fp) == -1)
         goto done;
 
     if ( strncmp("xen", line, 3) )
@@ -482,7 +481,7 @@ xen_get_version(
     if ( !fp )
         goto done;
 
-    if ((read = getline(&line, &len, fp)) == -1)
+    if (getline(&line, &len, fp) == -1)
         goto done;
 
     xen->major_version = atoi(line);
@@ -496,7 +495,7 @@ xen_get_version(
     if ( !fp )
         goto done;
 
-    if ((read = getline(&line, &len, fp)) == -1)
+    if (getline(&line, &len, fp) == -1)
         goto done;
 
     xen->minor_version = atoi(line);


### PR DESCRIPTION
* add `SCAN_BUILD` cmake var to configure `scan-build` binary used for static analysis
on Ubuntu, multiple version of the `clang-tools` package are available:
- `clang-tools`
- `clang-tools-6`
- `clang-tools-7`
- etc..

this variable allow to control which `scan-build` binary will be used.

* update static analysis in Travis to use `clang-tools-7`