### PR TITLE
Read IDTR/GDTR support

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -732,6 +732,18 @@ kvm_get_vcpureg(
         case MSR_LSTAR:
             *value = regs.x86.msr_lstar;
             break;
+        case GDTR_BASE:
+            *value = regs.x86.gdtr_base;
+            break;
+        case GDTR_LIMIT:
+            *value = regs.x86.gdtr_limit;
+            break;
+        case IDTR_BASE:
+            *value = regs.x86.idtr_base;
+            break;
+        case IDTR_LIMIT:
+            *value = regs.x86.idtr_limit;
+            break;
         default:
             dbprint(VMI_DEBUG_KVM, "--Reading register %"PRIu64" not implemented\n", reg);
             return VMI_FAILURE;
@@ -777,6 +789,10 @@ kvm_get_vcpuregs(
     x86->msr_efer = msrs.entries[3].data;
     x86->msr_star = msrs.entries[4].data;
     x86->msr_lstar = msrs.entries[5].data;
+    x86->gdtr_base = sregs.gdt.base;
+    x86->gdtr_limit = sregs.gdt.limit;
+    x86->idtr_base = sregs.idt.base;
+    x86->idtr_limit = sregs.idt.limit;
 
     return VMI_SUCCESS;
 }


### PR DESCRIPTION
Recently I am testing LibVMI and realized some features for new KVM driver did not implemented yet. I created this PR to add functionality of reading IDTR/GDTR as they are implemented on KVM and it was straightforward to code in LibVMI.