### PR TITLE
New changes to support win7, and rectify some SYSENTER based examples

### DIFF
--- a/libvmi/driver/kvm/README.md
+++ b/libvmi/driver/kvm/README.md
@@ -20,7 +20,7 @@ This section will give an implementation status of the LibVMI API on the new KVM
         - [x] segment registers
         - [ ] MSR
             - only essential MSRs are retrieved
-        - [ ] IDTR/GDTR
+        - [x] IDTR/GDTR
     - [ ] write
         - [x] general purpose registers
         - [ ] control registers

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -714,13 +714,13 @@ kvm_get_vcpureg(
         case GS_BASE:
             *value = regs.x86.gs_base;
             break;
-        case MSR_IA32_SYSENTER_CS:
+        case SYSENTER_CS:
             *value = regs.x86.sysenter_cs;
             break;
-        case MSR_IA32_SYSENTER_ESP:
+        case SYSENTER_ESP:
             *value = regs.x86.sysenter_esp;
             break;
-        case MSR_IA32_SYSENTER_EIP:
+        case SYSENTER_EIP:
             *value = regs.x86.sysenter_eip;
             break;
         case MSR_EFER:

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -785,7 +785,7 @@ static status_t kpcr_find3(vmi_instance_t vmi, windows_instance_t windows)
     uint16_t int0_low = 0, int0_middle = 0;
 
     if ( VMI_FAILURE == json_profile_lookup(vmi, "KiDivideErrorFault", NULL, &int0_rva) ) {
-        if ( VMI_FAILURE == json_profile_lookup(vmi, "KiTrap00", NULL, &int0_rva) );
+        if ( VMI_FAILURE == json_profile_lookup(vmi, "KiTrap00", NULL, &int0_rva) )
             return VMI_FAILURE;
     }
 

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -784,8 +784,10 @@ static status_t kpcr_find3(vmi_instance_t vmi, windows_instance_t windows)
     uint32_t int0_high = 0;
     uint16_t int0_low = 0, int0_middle = 0;
 
-    if ( VMI_FAILURE == json_profile_lookup(vmi, "KiDivideErrorFault", NULL, &int0_rva) )
-        return VMI_FAILURE;
+    if ( VMI_FAILURE == json_profile_lookup(vmi, "KiDivideErrorFault", NULL, &int0_rva) ) {
+        if ( VMI_FAILURE == json_profile_lookup(vmi, "KiTrap00", NULL, &int0_rva) );
+            return VMI_FAILURE;
+    }
 
     // Some Windows10+ JSON profiles don't have KiInitialPCR defined so we use the IDT route
     // For the layout of the IDT entry see http://wiki.osdev.org/Interrupt_Descriptor_Table


### PR DESCRIPTION
LibVMI not work on some of the newer build of Windows 7, so I added a symbol to solve this.

Also another matter is that it seems like there are some aliases for SYSENTER registers instead of using MSR index directly. using MSR registers directly caused event-example.c (and some other) to fail on KVM, I changed the registers to be similar to xen.c.