### PR TITLE
Pause VM in Xen HVM setregs calls for safety

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -1322,6 +1322,9 @@ xen_set_vcpureg_hvm(
     struct hvm_save_descriptor *desc = NULL;
     xen_instance_t *xen = xen_get_instance(vmi);
 
+    if ( VMI_FAILURE == xen_pause_vm(vmi) )
+        return VMI_FAILURE;
+
     /* calling with no arguments --> return is the size of buffer required
      *  for storing the HVM context
      */
@@ -1343,7 +1346,6 @@ xen_set_vcpureg_hvm(
     /* Locate runtime CPU registers in the context record, using the full
      *  version of xc_domain_hvm_getcontext rather than the partial
      *  variant, because there is no equivalent setcontext_partial.
-     * NOTE: to avoid inducing race conditions/errors, run while VM is paused.
      */
     if (xen->libxcw.xc_domain_hvm_getcontext(xen->xchandle,
             xen->domainid,
@@ -1637,6 +1639,7 @@ xen_set_vcpureg_hvm(
 _bail:
 
     free(buf);
+    xen_resume_vm(vmi);
 
     return ret;
 }
@@ -1654,6 +1657,9 @@ xen_set_vcpuregs_hvm(
     HVM_SAVE_TYPE(CPU) *cpu = NULL;
     struct hvm_save_descriptor *desc = NULL;
     xen_instance_t *xen = xen_get_instance(vmi);
+
+    if ( VMI_FAILURE == xen_pause_vm(vmi) )
+        return VMI_FAILURE;
 
     /* calling with no arguments --> return is the size of buffer required
      *  for storing the HVM context
@@ -1677,7 +1683,6 @@ xen_set_vcpuregs_hvm(
     /* Locate runtime CPU registers in the context record, using the full
      *  version of xc_domain_hvm_getcontext rather than the partial
      *  variant, because there is no equivalent setcontext_partial.
-     * NOTE: to avoid inducing race conditions/errors, run while VM is paused.
      */
     if (xen->libxcw.xc_domain_hvm_getcontext(xen->xchandle, xen->domainid,
             buf, size) < 0) {
@@ -1750,6 +1755,7 @@ xen_set_vcpuregs_hvm(
 
 _bail:
     free(buf);
+    xen_resume_vm(vmi);
 
     return ret;
 }

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -2270,12 +2270,7 @@ status_t vmi_get_vcpuregs(
 /**
  * Sets the current value of a VCPU register.  This currently only
  * supports control registers.  When LibVMI is accessing a raw
- * memory file, this function will fail. Operating upon an unpaused
- * vCPU with this function is likely to have unexpected results.
- *
- * On Xen HVM VMs the entire domain must be paused. Using this function in an event
- * callback where only the vCPU is paused will have unexpected results as this
- * function is not multi-vCPU safe.
+ * memory file, this function will fail.
  *
  * @param[in] vmi LibVMI instance
  * @param[in] value Value to assign to the register
@@ -2294,8 +2289,6 @@ status_t vmi_set_vcpureg(
  * a valid value in all registers when calling this function, so the user likely
  * wants to call vmi_get_vcpuregs before calling this function.
  * When LibVMI is accessing a raw memory file or KVM, this function will fail.
- * Operating upon an unpaused VM with this function is likely to have unexpected
- * results.
  *
  * @param[in] vmi LibVMI instance
  * @param[regs] regs The register struct holding the values to be set


### PR DESCRIPTION
As the comment in these functions noted, calling these while the VM is unpaused was unsafe. It is unclear why we never made these functions safe from the start, but since the VM pause/unpause calls are reference counted in Xen it is always safe to do this, the VM only actually gets resumed if it was running at the start of the function.