### PR TITLE
json profiles: recurse down all embedded structs to find field

### DIFF
--- a/libvmi/json_profiles/rekall.c
+++ b/libvmi/json_profiles/rekall.c
@@ -81,9 +81,9 @@ rekall_find_offset(
         const char *subname1 = NULL;
         const char *embedded = NULL;
 
-        (void) subname1; // only used in dbprint()
         subval = json_object_iter_peek_value(&iter);
         subname1 = json_object_iter_peek_name(&iter);
+        (void) subname1; // only used in dbprint()
 
         // get the top-level array from the value, e.g. ["__unnamed_178927"]
         subval2 = json_object_array_get_idx(subval, 1);

--- a/libvmi/json_profiles/rekall.c
+++ b/libvmi/json_profiles/rekall.c
@@ -65,7 +65,7 @@ rekall_find_offset(
         goto exit;
     }
 
-    // subsymbol not found; search down all anonymous structures embedded in symbol.
+    // subsymbol not found; search down all anonymous or embedded structures in symbol.
     // example: "mm_struct": [1032, {
     //                           ....
     //                        "u1": [0, ["__unnamed_178927"]] .... }]
@@ -81,11 +81,9 @@ rekall_find_offset(
         const char *subname1 = NULL;
         const char *embedded = NULL;
 
+        (void) subname1; // only used in dbprint()
         subval = json_object_iter_peek_value(&iter);
         subname1 = json_object_iter_peek_name(&iter);
-
-        if (subname1[0] != 'u')
-            goto next;
 
         // get the top-level array from the value, e.g. ["__unnamed_178927"]
         subval2 = json_object_array_get_idx(subval, 1);
@@ -110,7 +108,7 @@ rekall_find_offset(
             jofs = json_object_array_get_idx(subval, 0);
             if (!jofs) {
                 ret = VMI_FAILURE;
-                dbprint(VMI_DEBUG_MISC, "Rekall profile: anonymous struct %s has no offset in %s\n", subname1, symbol);
+                dbprint(VMI_DEBUG_MISC, "Rekall profile: anonymous/embedded struct %s has no offset in %s\n", subname1, symbol);
                 goto exit;
             }
 
@@ -122,7 +120,6 @@ rekall_find_offset(
 next:
         json_object_iter_next (&iter);
     }
-
 
 exit:
     return ret;

--- a/libvmi/json_profiles/volatility_ist.c
+++ b/libvmi/json_profiles/volatility_ist.c
@@ -61,7 +61,7 @@ volatility_ist_find_offset(
         goto exit;
     }
 
-    // subsymbol not found; search down all anonymous structures embedded in symbol.
+    // subsymbol not found; search down all anonymous or embedded structures in symbol.
     // example:
     // "mm_struct": {
     //   "size": 1032,
@@ -87,14 +87,9 @@ volatility_ist_find_offset(
         const char *subname1 = NULL;
         const char *embedded = NULL;
 
+        (void) subname1; // only used in dprint
         subval = json_object_iter_peek_value(&iter);
         subname1 = json_object_iter_peek_name(&iter);
-
-#define UNNAMED_PREFIX "unnamed_field_"
-#define UNNAMED_PREFIX_SIZE (sizeof(UNNAMED_PREFIX) - 1)
-
-        if (0 != strncmp (subname1, UNNAMED_PREFIX, UNNAMED_PREFIX_SIZE))
-            goto next;
 
         // get the type dict for the subfield, e.g. "type": {"kind": "struct", "name": "unnamed_8216149fbf604e93" },
         if (!json_object_object_get_ex (subval, "type", &subval2))
@@ -110,7 +105,7 @@ volatility_ist_find_offset(
             goto next;
 
         // now recurse into embedded, still looking for original subsymbol
-        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: exploring anonymous struct %s (%s) for offset for %s\n",
+        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: exploring anonymous/embedded struct %s (%s) for offset for %s\n",
                 subname1, embedded, subsymbol);
         ret = volatility_ist_find_offset(json, embedded, subsymbol, rva);
         if (VMI_SUCCESS == ret) {

--- a/libvmi/json_profiles/volatility_ist.c
+++ b/libvmi/json_profiles/volatility_ist.c
@@ -87,9 +87,9 @@ volatility_ist_find_offset(
         const char *subname1 = NULL;
         const char *embedded = NULL;
 
-        (void) subname1; // only used in dprint
         subval = json_object_iter_peek_value(&iter);
         subname1 = json_object_iter_peek_name(&iter);
+        (void) subname1; // only used in dprint
 
         // get the type dict for the subfield, e.g. "type": {"kind": "struct", "name": "unnamed_8216149fbf604e93" },
         if (!json_object_object_get_ex (subval, "type", &subval2))


### PR DESCRIPTION
The conditional recursion previously merged doesn't handle a case in an old kernel. In 2.6, dentry contains a named union, `d_u`. Rather than making assumptions about whether it's an anonymous struct that holds the field the caller wants, we just recurse down every field. Sure, it's a tad slower, but this function shouldn't be used after initialization.