### PR TITLE
README: update KVM-VMI setup link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,9 +126,9 @@ currently hosting this new API:
 
 https://github.com/KVM-VMI/kvm-vmi
 
-Follow this wiki page to setup KVM-VMI:
+The installation guide can be found at the following link:
 
-https://github.com/KVM-VMI/kvm-vmi/wiki/KVM-VMI-setup
+https://kvm-vmi.github.io/kvm-vmi/kvmi-v6/setup.html
 
 KVM legacy driver support:
 


### PR DESCRIPTION
This PR updates the KVM-VMI setup documentation link to point to the new Sphinx documentation hosted on Github Pages instead of the Wiki, for `kvmi-v6` only.