### PR TITLE
some slice fix about compile compatibility

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(event-example event-example.c)
 target_link_libraries(event-example vmi_shared)
 
 add_executable(fool-patchguard fool-patchguard.c)
+set_property(TARGET fool-patchguard PROPERTY C_STANDARD 99)
 target_link_libraries(fool-patchguard vmi_shared)
 
 add_executable(interrupt-event-example interrupt-event-example.c)
@@ -38,6 +39,7 @@ add_executable(msr-event-example msr-event-example.c)
 target_link_libraries(msr-event-example vmi_shared)
 
 add_executable(singlestep-event-example singlestep-event-example.c)
+set_property(TARGET singlestep-event-example PROPERTY C_STANDARD 99)
 target_link_libraries(singlestep-event-example vmi_shared)
 
 add_executable(step-event-example step-event-example.c)
@@ -50,6 +52,7 @@ add_executable(vmi-process-list process-list.c)
 target_link_libraries(vmi-process-list vmi_shared)
 
 add_executable(vmi-dump-memory dump-memory.c)
+set_property(TARGET vmi-dump-memory PROPERTY C_STANDARD 99)
 target_link_libraries(vmi-dump-memory vmi_shared)
 
 add_executable(vmi-module-list module-list.c)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(breakpoint-emulate-example breakpoint-emulate-example.c)
 target_link_libraries(breakpoint-emulate-example vmi_shared)
 
 add_executable(breakpoint-recoil-example breakpoint-recoil-example.c)
+set_property(TARGET breakpoint-recoil-example PROPERTY C_STANDARD 99)
 target_link_libraries(breakpoint-recoil-example vmi_shared)
 
 add_executable(wait-for-domain-example wait-for-domain-example.c)

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -31,6 +31,7 @@
 
 #include "private.h"
 #include "driver/driver_wrapper.h"
+#include "glib_compat.h"
 
 vmi_mem_access_t combine_mem_access(vmi_mem_access_t base, vmi_mem_access_t add)
 {
@@ -188,7 +189,7 @@ status_t register_interrupt_event(vmi_instance_t vmi, vmi_event_t *event)
         gint *intr = g_slice_new(gint);
         *intr = event->interrupt_event.intr;
 
-        g_hash_table_insert(vmi->interrupt_events, intr, event);
+        g_hash_table_insert_compat(vmi->interrupt_events, intr, event);
         dbprint(VMI_DEBUG_EVENTS, "Enabled event on interrupt: %d\n", event->interrupt_event.intr);
         rc = VMI_SUCCESS;
     }
@@ -207,7 +208,7 @@ static status_t register_msr_event(vmi_instance_t vmi, vmi_event_t *event)
         gint *msr = g_slice_new(gint);
         *msr = event->reg_event.msr;
 
-        g_hash_table_insert(vmi->msr_events, msr, event);
+        g_hash_table_insert_compat(vmi->msr_events, msr, event);
         dbprint(VMI_DEBUG_EVENTS, "Enabled register event on MSR: %"PRIx32"\n", event->reg_event.msr);
         rc = VMI_SUCCESS;
     }
@@ -231,7 +232,7 @@ status_t register_reg_event(vmi_instance_t vmi, vmi_event_t *event)
         gint *reg = g_slice_new(gint);
         *reg = event->reg_event.reg;
 
-        g_hash_table_insert(vmi->reg_events, reg, event);
+        g_hash_table_insert_compat(vmi->reg_events, reg, event);
         dbprint(VMI_DEBUG_EVENTS, "Enabled register event on reg: %"PRIu64"\n", event->reg_event.reg);
         rc = VMI_SUCCESS;
     }
@@ -316,7 +317,7 @@ static status_t register_mem_event_generic(vmi_instance_t vmi, vmi_event_t *even
     gint *access = g_slice_new(gint);
     *access = event->mem_event.in_access;
 
-    g_hash_table_insert(vmi->mem_events_generic, access, event);
+    g_hash_table_insert_compat(vmi->mem_events_generic, access, event);
     return VMI_SUCCESS;
 }
 
@@ -344,7 +345,7 @@ static status_t register_mem_event_on_gfn(vmi_instance_t vmi, vmi_event_t *event
     if (VMI_SUCCESS == driver_set_mem_access(vmi, event->mem_event.gfn,
             event->mem_event.in_access,
             event->slat_id)) {
-        g_hash_table_insert(vmi->mem_events_on_gfn, g_slice_dup(addr_t, &event->mem_event.gfn), event);
+        g_hash_table_insert_compat(vmi->mem_events_on_gfn, g_slice_dup(addr_t, &event->mem_event.gfn), event);
 
         if ( event->mem_event.gfn > (vmi->max_physical_address >> vmi->page_shift) )
             vmi->max_physical_address = event->mem_event.gfn << vmi->page_shift;
@@ -388,7 +389,7 @@ status_t register_singlestep_event(vmi_instance_t vmi, vmi_event_t *event)
             gint *key = g_slice_new(gint);
             *key = vcpu;
 
-            g_hash_table_insert(vmi->ss_events, key, event);
+            g_hash_table_insert_compat(vmi->ss_events, key, event);
         }
     }
 
@@ -891,7 +892,7 @@ status_t vmi_clear_event(
         }
 
         if (!g_hash_table_lookup(vmi->clear_events, &event)) {
-            g_hash_table_insert(vmi->clear_events,
+            g_hash_table_insert_compat(vmi->clear_events,
                                 g_slice_dup(vmi_event_t*, &event),
                                 free_routine);
             return VMI_SUCCESS;
@@ -1096,7 +1097,7 @@ vmi_toggle_single_step_vcpu(
         gint *key = g_slice_new(gint);
         *key = vcpu;
 
-        if (!g_hash_table_insert(vmi->ss_events, key, event)) {
+        if (!g_hash_table_insert_compat(vmi->ss_events, key, event)) {
             free_gint(key);
             return VMI_FAILURE;
         }

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -893,8 +893,8 @@ status_t vmi_clear_event(
 
         if (!g_hash_table_lookup(vmi->clear_events, &event)) {
             g_hash_table_insert_compat(vmi->clear_events,
-                                g_slice_dup(vmi_event_t*, &event),
-                                free_routine);
+                                       g_slice_dup(vmi_event_t*, &event),
+                                       free_routine);
             return VMI_SUCCESS;
         }
 

--- a/tools/qemu-kvm-patch/kvm-qemu-v2.10-libvmi.patch
+++ b/tools/qemu-kvm-patch/kvm-qemu-v2.10-libvmi.patch
@@ -14,7 +14,7 @@ index 474cc5e..2d569d9 100644
 -install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
 +install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir install-headers
  ifneq ($(TOOLS),)
- 	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
+	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
  endif
 diff --git a/Makefile.target b/Makefile.target
 index 7a5080e..a2f55df 100644

--- a/tools/qemu-kvm-patch/kvm-qemu-v2.10-libvmi.patch
+++ b/tools/qemu-kvm-patch/kvm-qemu-v2.10-libvmi.patch
@@ -1,0 +1,417 @@
+diff --git a/Makefile b/Makefile
+index 474cc5e..2d569d9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -600,8 +600,12 @@ ifneq (,$(findstring qemu-ga,$(TOOLS)))
+ endif
+ endif
+
++install-headers:
++	$(INSTALL_DIR) "$(DESTDIR)$(includedir)/qemu"
++	$(INSTALL_DATA) "$(SRC_PATH)/libvmi_request.h" "$(DESTDIR)$(includedir)/qemu/libvmi_request.h"
++
+
+-install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
++install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir install-headers
+ ifneq ($(TOOLS),)
+ 	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
+ endif
+diff --git a/Makefile.target b/Makefile.target
+index 7a5080e..a2f55df 100644
+--- a/Makefile.target
++++ b/Makefile.target
+@@ -139,7 +139,8 @@ endif #CONFIG_BSD_USER
+ #########################################################
+ # System emulator target
+ ifdef CONFIG_SOFTMMU
+-obj-y += arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o numa.o
++obj-y += arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o numa.o \
++			memory-access.o
+ obj-y += qtest.o
+ obj-y += hw/
+ obj-y += memory.o
+diff --git a/hmp.c b/hmp.c
+index b869617..cb8cb68 100644
+--- a/hmp.c
++++ b/hmp.c
+@@ -74,9 +74,10 @@ void hmp_info_version(Monitor *mon, const QDict *qdict)
+
+     info = qmp_query_version(NULL);
+
+-    monitor_printf(mon, "%" PRId64 ".%" PRId64 ".%" PRId64 "%s\n",
++    monitor_printf(mon, "%" PRId64 ".%" PRId64 ".%" PRId64 "%s %s\n",
+                    info->qemu->major, info->qemu->minor, info->qemu->micro,
+-                   info->package);
++                   info->package,
++                   "vmi");
+
+     qapi_free_VersionInfo(info);
+ }
+@@ -1094,6 +1095,15 @@ void hmp_pmemsave(Monitor *mon, const QDict *qdict)
+     hmp_handle_error(mon, &err);
+ }
+
++void hmp_pmemaccess(Monitor *mon, const QDict *qdict)
++{
++    const char *path = qdict_get_str(qdict, "path");
++    Error *err = NULL;
++
++    qmp_pmemaccess(path, &err);
++    hmp_handle_error(mon, &err);
++}
++
+ void hmp_ringbuf_write(Monitor *mon, const QDict *qdict)
+ {
+     const char *chardev = qdict_get_str(qdict, "device");
+diff --git a/hmp.h b/hmp.h
+index 05daf7c..f6571dd 100644
+--- a/hmp.h
++++ b/hmp.h
+@@ -49,6 +49,7 @@ void hmp_system_powerdown(Monitor *mon, const QDict *qdict);
+ void hmp_cpu(Monitor *mon, const QDict *qdict);
+ void hmp_memsave(Monitor *mon, const QDict *qdict);
+ void hmp_pmemsave(Monitor *mon, const QDict *qdict);
++void hmp_pmemaccess(Monitor *mon, const QDict *qdict);
+ void hmp_ringbuf_write(Monitor *mon, const QDict *qdict);
+ void hmp_ringbuf_read(Monitor *mon, const QDict *qdict);
+ void hmp_cont(Monitor *mon, const QDict *qdict);
+diff --git a/libvmi_request.h b/libvmi_request.h
+new file mode 100644
+index 0000000..e4fc87a
+--- /dev/null
++++ b/libvmi_request.h
+@@ -0,0 +1,10 @@
++#ifndef LIBVMI_REQUEST_H
++#define LIBVMI_REQUEST_H
++
++struct request {
++    uint64_t type;      // 0 quit, 1 read, 2 write, ... rest reserved
++    uint64_t address;  // address to read from OR write to
++    uint64_t length;   // number of bytes to read OR write
++};
++
++#endif /* LIBVMI_REQUEST_H */
+diff --git a/memory-access.c b/memory-access.c
+new file mode 100644
+index 0000000..72ac93a
+--- /dev/null
++++ b/memory-access.c
+@@ -0,0 +1,249 @@
++/*
++ * Access guest physical memory via a domain socket.
++ *
++ * Copyright (C) 2011 Sandia National Laboratories
++ * Original Author: Bryan D. Payne (bdpayne@acm.org)
++ *
++ * Refurbished for modern QEMU by Valerio Aimale (valerio@aimale.com), in 2015
++ */
++
++#include <stdlib.h>
++#include <stdio.h>
++#include <string.h>
++#include <pthread.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <sys/un.h>
++#include <unistd.h>
++#include <signal.h>
++#include <stdint.h>
++#include <poll.h>
++
++#include "memory-access.h"
++#include "exec/cpu-common.h"
++#include "libvmi_request.h"
++
++
++static uint64_t
++connection_read_memory (uint64_t user_paddr, void *buf, uint64_t user_len)
++{
++    hwaddr paddr = (hwaddr) user_paddr;
++    hwaddr len = (hwaddr) user_len;
++    void *guestmem = cpu_physical_memory_map(paddr, &len, 0);
++    if (!guestmem){
++        return 0;
++    }
++    memcpy(buf, guestmem, len);
++    cpu_physical_memory_unmap(guestmem, len, 0, len);
++
++    return len;
++}
++
++static uint64_t
++connection_write_memory (uint64_t user_paddr, void *buf, uint64_t user_len)
++{
++    hwaddr paddr = (hwaddr) user_paddr;
++    hwaddr len = (hwaddr) user_len;
++    void *guestmem = cpu_physical_memory_map(paddr, &len, 1);
++    if (!guestmem){
++        return 0;
++    }
++    memcpy(guestmem, buf, len);
++    cpu_physical_memory_unmap(guestmem, len, 0, len);
++
++    return len;
++}
++
++static void
++send_success_ack (int connection_fd)
++{
++    uint8_t success = 1;
++    int nbytes = write(connection_fd, &success, 1);
++    if (1 != nbytes){
++        fprintf(stderr, "Qemu pmemaccess: failed to send success ack\n");
++    }
++}
++
++static void
++send_fail_ack (int connection_fd)
++{
++    uint8_t fail = 0;
++    int nbytes = write(connection_fd, &fail, 1);
++    if (1 != nbytes){
++        fprintf(stderr, "Qemu pmemaccess: failed to send fail ack\n");
++    }
++}
++
++static void
++connection_handler (int connection_fd)
++{
++    int nbytes;
++    struct request req;
++    struct pollfd *fds = calloc(1, sizeof(struct pollfd));
++    if (!fds)
++    {
++        fprintf(stderr, "Allocating pollfd failed\n");
++        return;
++    }
++    fds[0].fd = connection_fd;
++    fds[0].events = POLLIN | POLLERR | POLLHUP | POLLNVAL;
++
++    while (1){
++        // poll on our connection fd
++        int nb_modified = poll(fds, 1, -1);
++        if (nb_modified < 0)
++        {
++            // poll failed
++            fprintf(stderr, "Poll failed on vmi socket: %s\n", strerror(errno));
++            continue;
++        }
++        else if (nb_modified == 0)
++        {
++            // timeout
++            fprintf(stderr, "Poll timeout on vmi socket\n");
++            continue;
++        }
++        else if (fds[0].revents & POLLERR
++                || fds[0].revents & POLLHUP
++                || fds[0].revents & POLLNVAL)
++        {
++            // error
++            fprintf(stderr, "Poll error on vmi socket\n");
++            break;
++        }
++        else if (fds[0].revents & POLLIN)
++        {
++            // client request should match the struct request format
++            nbytes = read(connection_fd, &req, sizeof(struct request));
++            if (nbytes == -1 || nbytes != sizeof(struct request)){
++                // error
++                continue;
++            }
++            else if (req.type == 0){
++                // request to quit, goodbye
++                break;
++            }
++            else if (req.type == 1){
++                // request to read
++                char *buf = malloc(req.length + 1);
++                nbytes = connection_read_memory(req.address, buf, req.length);
++                if (nbytes != req.length){
++                    // read failure, return failure message
++                    buf[req.length] = 0; // set last byte to 0 for failure
++                    nbytes = write(connection_fd, buf, 1);
++                }
++                else{
++                    // read success, return bytes
++                    buf[req.length] = 1; // set last byte to 1 for success
++                    nbytes = write(connection_fd, buf, nbytes + 1);
++                }
++                free(buf);
++            }
++            else if (req.type == 2){
++                // request to write
++                void *write_buf = malloc(req.length);
++                nbytes = read(connection_fd, write_buf, req.length);
++                if (nbytes != req.length){
++                    // failed reading the message to write
++                    send_fail_ack(connection_fd);
++                }
++                else{
++                    // do the write
++                    nbytes = connection_write_memory(req.address, write_buf, req.length);
++                    if (nbytes == req.length){
++                        send_success_ack(connection_fd);
++                    }
++                    else{
++                        send_fail_ack(connection_fd);
++                    }
++                }
++                free(write_buf);
++            }
++            else{
++                // unknown command
++                fprintf(stderr, "Qemu pmemaccess: ignoring unknown command (%" PRIu64 ")\n", req.type);
++                char *buf = malloc(1);
++                buf[0] = 0;
++                nbytes = write(connection_fd, buf, 1);
++                free(buf);
++            }
++        }
++    }
++
++    free(fds);
++    close(connection_fd);
++}
++
++static void *
++memory_access_thread (void *p)
++{
++    int connection_fd;
++    struct pmemaccess_args *pargs = (struct pmemaccess_args *)p;
++
++    // accept incoming connections
++    connection_fd = accept(pargs->socket_fd, (struct sockaddr *) pargs->address, &(pargs->address_length));
++    connection_handler(connection_fd);
++
++    close(pargs->socket_fd);
++    unlink(pargs->path);
++    free(pargs->path);
++    free(pargs->address);
++    free(pargs);
++    return NULL;
++}
++
++void
++qmp_pmemaccess (const char *path, Error **errp)
++{
++    pthread_t thread;
++    sigset_t set, oldset;
++    struct pmemaccess_args *pargs;
++
++    // create the args struct
++    pargs = (struct pmemaccess_args *) malloc(sizeof(struct pmemaccess_args));
++    if (pargs == NULL){
++        error_setg(errp, "Qemu pmemaccess: malloc failed");
++        return;
++    }
++
++    pargs->errp = errp;
++    // create a copy of path that we can safely use
++    size_t path_size = strlen(path);
++    pargs->path = malloc(path_size + 1);
++    memcpy(pargs->path, path, path_size);
++    pargs->path[path_size] = '\0';
++
++    // create socket
++    pargs->socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
++    if (pargs->socket_fd < 0){
++        error_setg(pargs->errp, "Qemu pmemaccess: socket failed");
++        return;
++    }
++    // unlink path if already exists
++    unlink(path);
++    // bind socket
++    pargs->address = malloc(sizeof(struct sockaddr_un));
++    if (pargs->address == NULL){
++        error_setg(pargs->errp, "Qemu pmemaccess: malloc failed");
++        return;
++    }
++    pargs->address->sun_family = AF_UNIX;
++    pargs->address_length = sizeof(pargs->address->sun_family) + sprintf(pargs->address->sun_path, "%s", (char *) pargs->path);
++    if (bind(pargs->socket_fd, (struct sockaddr *) pargs->address, pargs->address_length) != 0){
++        printf("could not bind\n");
++        error_setg(pargs->errp, "Qemu pmemaccess: bind failed");
++        return;
++    }
++
++    // listen
++    if (listen(pargs->socket_fd, 0) != 0){
++        error_setg(pargs->errp, "Qemu pmemaccess: listen failed");
++        return;
++    }
++
++    // start the thread
++    sigfillset(&set);
++    pthread_sigmask(SIG_SETMASK, &set, &oldset);
++    pthread_create(&thread, NULL, memory_access_thread, pargs);
++    pthread_sigmask(SIG_SETMASK, &oldset, NULL);
++}
+diff --git a/memory-access.h b/memory-access.h
+new file mode 100644
+index 0000000..21c7137
+--- /dev/null
++++ b/memory-access.h
+@@ -0,0 +1,24 @@
++/*
++ * Open A UNIX Socket access to physical memory
++ *
++ * Author: Valerio G. Aimale <valerio@aimale.com>
++ */
++
++#ifndef MEMORY_ACCESS_H
++#define MEMORY_ACCESS_H
++
++#include <sys/socket.h>
++#include "qemu/osdep.h"
++#include "qapi/error.h"
++
++void qmp_pmemaccess (const char *path, Error **errp);
++
++struct pmemaccess_args {
++    int socket_fd;
++    struct sockaddr_un *address;
++    socklen_t address_length;
++    char *path;
++    Error **errp;
++};
++
++#endif /* MEMORY_ACCESS_H */
+diff --git a/qapi-schema.json b/qapi-schema.json
+index a0d3b5d..f4bc922 100644
+--- a/qapi-schema.json
++++ b/qapi-schema.json
+@@ -2508,6 +2508,34 @@
+   'data': {'val': 'int', 'size': 'int', 'filename': 'str'} }
+
+ ##
++# @pmemaccess:
++#
++# Open A UNIX Socket access to physical memory
++#
++# @path: the name of the UNIX socket pipe
++#
++# Returns: Nothing on success
++#
++# Since: 2.4.0.1
++#
++# Notes: Derived from previously existing patches. When command
++# succeeds connect to the open socket. Write a binary structure to
++# the socket as:
++#
++# struct request {
++#     uint64_t type;   // 0 quit, 1 read, 2 write, ... rest reserved
++#     uint64_t address;   // address to read from OR write to
++#     uint64_t length;    // number of bytes to read OR write
++# };
++#
++# If it is a read operation, Qemu will return lenght+1 bytes. Read lenght+1
++# bytes. the last byte will be a 1 for success, or a 0 for failure.
++#
++##
++{ 'command': 'pmemaccess',
++  'data': {'path': 'str'} }
++
++##
+ # @cont:
+ #
+ # Resume guest VCPU execution.


### PR DESCRIPTION
1. support glib2 < 2.40 in libvmi/events.c (or a compile error occured under low version glib2)
2. support to compile examples together with libvmi.so, beacuse some examples use C99 feature
3. add an enable_kvm_legacy patch with qemu-2.10