### PR TITLE
kvm: sanity check mem_access flags for invalid EPT configurations

### DIFF
--- a/libvmi/arch/intel.c
+++ b/libvmi/arch/intel.c
@@ -582,3 +582,23 @@ status_t intel_init(vmi_instance_t vmi)
 
     return ret;
 }
+
+status_t
+intel_mem_access_sanity_check(vmi_mem_access_t page_access_flag)
+{
+    /*
+     * Setting a page write-only or write-execute in EPT triggers and EPT misconfiguration error
+     * which is unhandled by Xen (at least up to 4.3) and instantly crashes the domain on the first trigger.
+     *
+     * See Intel® 64 and IA-32 Architectures Software Developer’s Manual
+     * 28.2.3.1 EPT Misconfigurations
+     * AN EPT misconfiguration occurs if any of the following is identified while translating a guest-physical address:
+     * * The value of bits 2:0 of an EPT paging-structure entry is either 010b (write-only) or 110b (write/execute).
+     */
+    if (page_access_flag == VMI_MEMACCESS_R || page_access_flag == VMI_MEMACCESS_RX) {
+        errprint("%s error: can't set requested memory access, unsupported by EPT.\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+
+    return VMI_SUCCESS;
+}

--- a/libvmi/arch/intel.h
+++ b/libvmi/arch/intel.h
@@ -29,4 +29,8 @@
 
 status_t intel_init(vmi_instance_t vmi);
 
+/* checks for EPT misconfiguration in page_access_flag */
+status_t
+intel_mem_access_sanity_check(vmi_mem_access_t page_access_flag);
+
 #endif

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -23,9 +23,11 @@
 
 #include "private.h"
 #include "msr-index.h"
+#include "arch/intel.h"
 #include "kvm.h"
 #include "kvm_events.h"
 #include "kvm_private.h"
+
 
 // helper struct for process_cb_response_emulate to avoid ugly
 // pointer arithmetic to find back pf field in process_cb_response_emulate()
@@ -1136,6 +1138,10 @@ kvm_set_mem_access(
         return VMI_FAILURE;
     }
 #endif
+    // sanity check access type
+    if (VMI_FAILURE == intel_mem_access_sanity_check(page_access_flag))
+        return VMI_FAILURE;
+
     // check access type and convert to KVMI
     switch (page_access_flag) {
         case VMI_MEMACCESS_N:


### PR DESCRIPTION
* adds sanity check for `vmi_mem_access_t` flags in `kvm_set_mem_access`, as the Xen driver does already.

fix https://github.com/KVM-VMI/libvmi/issues/38