### PR TITLE
kvm: fix pf ctx_addr for SET_EMUL_READ_DATA event response

### DIFF
--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -137,7 +137,7 @@ process_cb_response_emulate(
                             rpl->pf.ctx_size = libvmi_event->emul_read->size;
                             // set linear address
                             // TODO: ARM support
-                            rpl->pf.ctx_addr = libvmi_event->x86_regs->rip;
+                            rpl->pf.ctx_addr = libvmi_event->mem_event.gla;
                             // copy libvmi buffer into kvm reply event
                             memcpy(rpl->pf.ctx_data, libvmi_event->emul_read->data, libvmi_event->emul_read->size);
                         }


### PR DESCRIPTION
After a documentation clarification of the KVMi API:
- https://github.com/KVM-VMI/kvm/pull/42
- https://github.com/KVM-VMI/kvm/pull/43

this PR fixes the context address used when emulating custom read data as a libvmi event response for KVM.
The context address that should be used is the one where the read actually happens, and not where RIP is located.

Related comment on another PR: https://github.com/libvmi/libvmi/pull/942#discussion_r531627986