### PR TITLE
slice quick fix to prevend a segment fault

### DIFF
--- a/libvmi/driver/kvm/kvm_legacy.c
+++ b/libvmi/driver/kvm/kvm_legacy.c
@@ -718,6 +718,10 @@ kvm_destroy(
     vmi_instance_t vmi)
 {
     kvm_instance_t *kvm = kvm_get_instance(vmi);
+    if (!kvm) {
+        return;
+    }
+    
     destroy_domain_socket(kvm);
 
     if (kvm->dom) {

--- a/libvmi/driver/kvm/kvm_legacy.c
+++ b/libvmi/driver/kvm/kvm_legacy.c
@@ -721,7 +721,7 @@ kvm_destroy(
     if (!kvm) {
         return;
     }
-    
+
     destroy_domain_socket(kvm);
 
     if (kvm->dom) {


### PR DESCRIPTION
There is a case that kvm_destroy() in kvm_legacy.c is called after kvm_init() failing. In that case vmi->driver.driver_data is NULL and a segment fault would happen.