### PR TITLE
Support vsock for kvmi

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -382,7 +382,12 @@ init_kvmi(
     kvm->kvmi_dom = NULL;
 
     pthread_mutex_lock(&kvm->kvm_connect_mutex);
-    kvm->kvmi = kvm->libkvmi.kvmi_init_unix_socket(sock_path, new_guest_cb, handshake_cb, kvm);
+    if (atoi(sock_path) > 0) {
+        kvm->kvmi = kvm->libkvmi.kvmi_init_vsock(atoi(sock_path), new_guest_cb, handshake_cb, kvm);
+    } else {
+        kvm->kvmi = kvm->libkvmi.kvmi_init_unix_socket(sock_path, new_guest_cb, handshake_cb, kvm);
+    }
+
     if (kvm->kvmi) {
         struct timeval now;
         if (gettimeofday(&now, NULL) == 0) {

--- a/libvmi/driver/kvm/libkvmi_wrapper.c
+++ b/libvmi/driver/kvm/libkvmi_wrapper.c
@@ -30,7 +30,7 @@ static status_t sanity_check(kvm_instance_t *kvm)
 {
     libkvmi_wrapper_t *w = &kvm->libkvmi;
 
-    if ( !w->kvmi_init_unix_socket || !w->kvmi_uninit || !w->kvmi_close ||
+    if ( !w->kvmi_init_unix_socket || !w->kvmi_init_vsock || !w->kvmi_uninit || !w->kvmi_close ||
             !w->kvmi_domain_close || !w->kvmi_connection_fd ||
             !w->kvmi_get_version || !w->kvmi_control_events ||
             !w->kvmi_control_vm_events || !w->kvmi_control_cr || !w->kvmi_control_singlestep ||
@@ -69,6 +69,7 @@ status_t create_libkvmi_wrapper(struct kvm_instance *kvm)
     dbprint(VMI_DEBUG_KVM, "--libkvmi path: %s\n", map->l_name);
 
     wrapper->kvmi_init_unix_socket = dlsym(wrapper->handle, "kvmi_init_unix_socket");
+    wrapper->kvmi_init_vsock = dlsym(wrapper->handle, "kvmi_init_vsock");
     wrapper->kvmi_uninit = dlsym(wrapper->handle, "kvmi_uninit");
     wrapper->kvmi_close = dlsym(wrapper->handle, "kvmi_close");
     wrapper->kvmi_domain_close = dlsym(wrapper->handle, "kvmi_domain_close");

--- a/libvmi/driver/kvm/libkvmi_wrapper.h
+++ b/libvmi/driver/kvm/libkvmi_wrapper.h
@@ -37,6 +37,9 @@ typedef struct {
     void* (*kvmi_init_unix_socket)
     (const char *socket, kvmi_new_guest_cb accept_cb, kvmi_handshake_cb hsk_cb, void *cb_ctx);
 
+    void* (*kvmi_init_vsock)
+    (unsigned int port, kvmi_new_guest_cb accept_cb, kvmi_handshake_cb hsk_cb, void *cb_ctx);
+
     void (*kvmi_uninit)
     (void* ctx);
 


### PR DESCRIPTION
libkvmi support both unix socket domain and vsock, the current libvmi only implemented the unix socket domain. This PR adds support for vsock.

reference: https://github.com/bitdefender/libkvmi/blob/master/examples/hookguest.c#L369