### PR TITLE
Add vmi_get_struct_field_type_name

### DIFF
--- a/libvmi/json_profiles/json_profiles.c
+++ b/libvmi/json_profiles/json_profiles.c
@@ -63,6 +63,7 @@ bool json_profile_init(vmi_instance_t vmi, const char* path)
             json->handler = volatility_ist_symbol_to_rva;
             json->bitfield_offset_and_size = volatility_profile_bitfield_offset_and_size;
             json->get_os_type = volatility_get_os_type;
+            json->struct_field_type_name = volatility_struct_field_type_name;
             break;
         case JPT_REKALL_PROFILE:
             json->handler = rekall_profile_symbol_to_rva;
@@ -122,4 +123,13 @@ vmi_get_bitfield_offset_and_size_from_json(vmi_instance_t vmi, json_object *json
         return VMI_FAILURE;
 
     return vmi->json.bitfield_offset_and_size(json, struct_name, struct_member, offset, start_bit, end_bit);
+}
+
+status_t
+vmi_get_struct_field_type_name(vmi_instance_t vmi, json_object *json, const char *struct_name, const char *struct_member, const char **member_type_name)
+{
+    if ( !vmi->json.struct_field_type_name )
+        return VMI_FAILURE;
+
+    return vmi->json.struct_field_type_name(json, struct_name, struct_member, member_type_name);
 }

--- a/libvmi/json_profiles/json_profiles.h
+++ b/libvmi/json_profiles/json_profiles.h
@@ -52,6 +52,13 @@ typedef struct json_interface {
         size_t *start_bit,
         size_t *end_bit);
 
+    status_t
+    (*struct_field_type_name)(
+        json_object *json,
+        const char *struct_name,
+        const char *struct_member,
+        const char **member_type_name);
+
     const char* (*get_os_type)(
         vmi_instance_t vmi);
 } json_interface_t;

--- a/libvmi/json_profiles/volatility_ist.c
+++ b/libvmi/json_profiles/volatility_ist.c
@@ -306,3 +306,98 @@ exit:
 
     return ret;
 }
+
+status_t
+volatility_struct_field_type_name(
+    json_object *json_profile,
+    const char* struct_name,
+    const char* field_name,
+    const char** member_type_name)
+{
+    *member_type_name = NULL;
+
+    struct json_object* json_user_types;
+    if (!json_object_object_get_ex(json_profile, "user_types", &json_user_types)) {
+        dbprint(VMI_DEBUG_MISC, "Volatility profile: no user_types section found.\n");
+        return VMI_FAILURE;
+    }
+
+    struct json_object* json_struct;
+    if (!json_object_object_get_ex(json_user_types, struct_name, &json_struct)) {
+        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: no %s found\n", struct_name);
+        return VMI_FAILURE;
+    }
+
+    struct json_object* json_fields;
+    if (!json_object_object_get_ex(json_struct, "fields", &json_fields)) {
+        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: %s has no `fields` key.\n", struct_name);
+        return VMI_FAILURE;
+    }
+
+    struct json_object* json_field = NULL;
+    if (!json_object_object_get_ex(json_fields, field_name, &json_field)) {
+        // Check recursively all unnamed structure fields aswell, as many fields in linux are wrapped in anonymous structures for structure randomization.
+        struct json_object_iterator it = json_object_iter_begin(json_fields);
+        struct json_object_iterator it_end = json_object_iter_end(json_fields);
+        for (; !json_object_iter_equal(&it, &it_end); json_object_iter_next(&it)) {
+            if (strncmp(json_object_iter_peek_name(&it), "unnamed", strlen("unnamed")) != 0)
+                continue;
+
+            json_object* json_field_val = json_object_iter_peek_value(&it);
+
+            struct json_object* json_field_subtype;
+            if (!json_object_object_get_ex(json_field_val, "type", &json_field_subtype)) {
+                dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find `type` key.\n");
+                return VMI_FAILURE;
+            }
+
+            struct json_object* json_field_subkind;
+            if (!json_object_object_get_ex(json_field_subtype, "kind", &json_field_subkind)) {
+                dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find `kind` key.\n");
+                return VMI_FAILURE;
+            }
+            if (strcmp(json_object_get_string(json_field_subkind), "struct") != 0)
+                continue;
+
+            struct json_object* json_anonymous_struct_name;
+            if (!json_object_object_get_ex(json_field_subtype, "name", &json_anonymous_struct_name)) {
+                dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find `name` key\n");
+                return VMI_FAILURE;
+            }
+
+            struct json_object *json_anonymous_struct;
+            if (!json_object_object_get_ex(json_user_types, json_object_get_string(json_anonymous_struct_name), &json_anonymous_struct)) {
+                dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find %s in user_types.\n", json_object_get_string(json_anonymous_struct_name));
+                return VMI_FAILURE;
+            }
+
+            struct json_object* json_anonymous_struct_fields;
+            if (!json_object_object_get_ex(json_anonymous_struct, "fields", &json_anonymous_struct_fields)) {
+                dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find `fields` key.\n");
+                return VMI_FAILURE;
+            }
+
+            if (json_object_object_get_ex(json_anonymous_struct_fields, field_name, &json_field))
+                break;
+        }
+    }
+    if (!json_field) {
+        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find %s\n", field_name);
+        return VMI_FAILURE;
+    }
+
+    struct json_object* json_struct_type;
+    if (!json_object_object_get_ex(json_field, "type", &json_struct_type)) {
+        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find `type` key.\n");
+        return VMI_FAILURE;
+    }
+
+    struct json_object* json_type_name;
+    if (!json_object_object_get_ex(json_struct_type, "name", &json_type_name)) {
+        dbprint(VMI_DEBUG_MISC, "Volatility IST profile: Failed to find `name` key.\n");
+        return VMI_FAILURE;
+    }
+
+    *member_type_name = json_object_get_string(json_type_name);
+    return VMI_SUCCESS;
+}

--- a/libvmi/json_profiles/volatility_ist.h
+++ b/libvmi/json_profiles/volatility_ist.h
@@ -44,6 +44,13 @@ volatility_profile_bitfield_offset_and_size(
     size_t *start_bit,
     size_t *end_bit);
 
+status_t
+volatility_struct_field_type_name(
+    json_object *json,
+    const char *struct_name,
+    const char *struct_member,
+    const char **member_type_name);
+
 #else
 
 static inline status_t volatility_ist_symbol_to_rva(
@@ -68,6 +75,16 @@ volatility_profile_bitfield_offset_and_size(
     __attribute__((__unused__)) addr_t *rva,
     __attribute__((__unused__)) size_t *start_bit,
     __attribute__((__unused__)) size_t *end_bit)
+{
+    return VMI_FAILURE;
+}
+
+static inline status_t
+volatility_struct_field_type_name(
+    __attribute__((__unused__)) json_object *json,
+    __attribute__((__unused__)) const char *struct_name,
+    __attribute__((__unused__)) const char *struct_member,
+    __attribute__((__unused__)) const char **member_type_name)
 {
     return VMI_FAILURE;
 }

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -174,12 +174,14 @@ status_t vmi_get_bitfield_offset_and_size_from_json(vmi_instance_t vmi, json_obj
  * anonymous structure.
  * The returned string is managed by json_object and should not be freed by the user.
  *
- * @param[in] drakvuf Drakvuf instance.
- * @param[in] struct_name Name of the struct containing `field_name`.
- * @param[in] field_name Name of the field that we want to retrieve type name.
- * @return string or NULL on failure
+ * @param[in] vmi Instance.
+ * @param[in] json The open json_object* to use
+ * @param[in] struct_name Name of the struct containing `struct_member`.
+ * @param[in] struct_member The structure's member that we want to retrieve type name for.
+ * @param[out] member_type_name Type name of `struct_member`.
+ * @return VMI_SUCCESS or VMI_FAILURE
  */
-status_t vmi_get_struct_field_type_name(
+status_t vmi_get_struct_field_type_name_from_json(
     vmi_instance_t vmi,
     json_object *json,
     const char *struct_name,

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -168,6 +168,23 @@ status_t vmi_get_bitfield_offset_and_size_from_json(vmi_instance_t vmi, json_obj
         const char *struct_member,
         addr_t *offset, size_t *start_bit,
         size_t *end_bit);
+
+/**
+ * Useful when one wants to find rva of typedef as compiler will treat it as an
+ * anonymous structure.
+ * The returned string is managed by json_object and should not be freed by the user.
+ *
+ * @param[in] drakvuf Drakvuf instance.
+ * @param[in] struct_name Name of the struct containing `field_name`.
+ * @param[in] field_name Name of the field that we want to retrieve type name.
+ * @return string or NULL on failure
+ */
+status_t vmi_get_struct_field_type_name(
+    vmi_instance_t vmi,
+    json_object *json,
+    const char *struct_name,
+    const char *struct_member,
+    const char **member_type_name) NOEXCEPT;
 #endif
 
 #pragma GCC visibility pop


### PR DESCRIPTION
Useful when one wants to find rva of typedef.

**Example**
Let's say the types are defined as:
```c
typedef struct {
    int a;
} inner_t;

struct outer {
    inner_t inner;
};
```
and for variable `struct outer o` and we want to get the value of: `o.inner.a`. 
Unfortunately such approach won't work:
```c
addr_t outer_inner_rva;
vmi_get_struct_member_offset_from_json(vmi, "outer", "inner", &outer_inner_rva);

addr_t inner_t_a_rva;
vmi_get_struct_member_offset_from_json(vmi, "inner_t", "a", &inner_t_a_rva); // this won't work
```

as there is not `inner_t` in json profile:
```json
"outer": {
    "fields": {
        "inner": {
            "type": {
                "kind": "struct",
                "name": "unnamed_XYZ"
            },
            "offset": 0
        }
    },
    [...]
},
"unnamed_XYZ": {
    "fields": {
        "a": {
            "type": {
                "kind": "base",
                "name": "int"
            },
            "offset": 0
        }
    }
}
```

This PR. introduces a workaround for above problem:
```c
addr_t inner_t_a_rva;
vmi_get_struct_member_offset_from_json(vmi, vmi_get_struct_field_type_name_from_json(vmi, "outer", "inner"), "a", &inner_t_a_rva);
```