### PR TITLE
Include libvmi.h in events.h

### DIFF
--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -45,6 +45,7 @@ extern "C" {
 #pragma GCC visibility push(default)
 
 #include <stdbool.h>
+#include <libvmi/libvmi.h>
 
 /*---------------------------------------------------------
  * Event management


### PR DESCRIPTION
Right now the order of includes matters. For example, you cannot include `events.h` before `libvmi.h` because it requires types defined in `libvmi.h`. This is especially a problem if you want to use code formatters that sort includes alphabetically (aside from the usual reasons for avoiding such behavior). I therefore propose moving all typedefs in `libvmi.h` to a separate header.