### PR TITLE
allow targeting designated kernel source

### DIFF
--- a/tools/linux-offset-finder/Makefile
+++ b/tools/linux-offset-finder/Makefile
@@ -1,7 +1,10 @@
 obj-m +=findoffsets.o
 
+# Use "make KERNEL=</path/to/target/kernel/src>" to override this
+KERNEL=/lib/modules/$(shell uname -r)/build
+
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules -lcsys
+	make -C $(KERNEL) M=$(PWD) modules -lcsys
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C $(KERNEL) M=$(PWD) clean


### PR DESCRIPTION
tools/linux-offset-finder: add a KERNEL variable to allow override the targeting kernel source