### PR TITLE
Fix handling of glib link libraries in cmake (#1002)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,6 @@ set_package_properties(PkgConfig PROPERTIES
     TYPE REQUIRED
     PURPOSE "Find and configure multiple LibVMI dependencies")
 pkg_search_module(GLIB REQUIRED glib-2.0)
-# cleanup GLIB_LDFLAGS (remove -l prefix)
-string(REGEX REPLACE "-l" "" GLIB_LDFLAGS ${GLIB_LDFLAGS})
 
 include(DetectArchitecture)
 include(StaticAnalysis)

--- a/libvmi/CMakeLists.txt
+++ b/libvmi/CMakeLists.txt
@@ -36,10 +36,8 @@ set(VMI_PUBLIC_DEPS "")
 # create libvmi.so
 add_library (vmi_shared SHARED $<TARGET_OBJECTS:vmi>)
 # one libvmi_extra.h function returns a GSList*
-target_link_libraries(vmi_shared PUBLIC ${GLIB_LDFLAGS})
-# cleanup GLIB_LDFLAGS (remove -l prefix)
-string(REGEX REPLACE "-l" "" GLIB_LDFLAGS ${GLIB_LDFLAGS})
-list(APPEND VMI_PUBLIC_DEPS ${GLIB_LDFLAGS})
+target_link_libraries(vmi_shared PUBLIC ${GLIB_LIBRARIES})
+list(APPEND VMI_PUBLIC_DEPS ${GLIB_LIBRARIES})
 set_target_properties(vmi_shared PROPERTIES OUTPUT_NAME "vmi")
 # set soname
 set_target_properties(vmi_shared PROPERTIES


### PR DESCRIPTION
The `target_link_libraries` command is supposed to be called using the contents of `GLIB_LIBRARIES` instead of `GLIB_LDFLAGS`.

Fixes: #1002

Signed-off-by: Björn Esser <besser82@fedoraproject.org>