### PR TITLE
cmake: fix build failure and update CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           CC: ${{ matrix.compiler }}
         if: matrix.builder == 'cmake'
-        continue-on-error: true
         run: |
           while IFS= read -r options; do
             echo "Building with '$options'"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,7 @@ include(GNUInstallDirs)
 #-----------------------------------------------------------------------------
 #                           BUILD TYPES & FLAGS
 #-----------------------------------------------------------------------------
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3 -O0")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3 -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-missing-braces -Wno-unused-result -Wno-ignored-attributes")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Werror -O2")
 
 # default hardening flags that have no performance hit

--- a/libvmi/CMakeLists.txt
+++ b/libvmi/CMakeLists.txt
@@ -166,7 +166,6 @@ endif ()
 
 add_subdirectory(driver)
 add_subdirectory(os)
-add_subdirectory(disk)
 
 
 if (ENABLE_XEN)


### PR DESCRIPTION
This PR fixes a build failure in the CMake build, and updates the CI as well because it didn't catched the error unfortunately

Also it harmonizes the build flags used in the project between CMake and autotools debug builds: (`-Wall -Wextra -Wno-missing-field-initializers -Wno-missing-braces -Wno-unused-result -Wno-ignored-attributes`)
