### PR TITLE
Pop pending events after pausing vm

### DIFF
--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -993,7 +993,7 @@ kvm_pause_vm(
 {
     kvm_instance_t *kvm = kvm_get_instance(vmi);
     // already paused ?
-    if (kvm->expected_pause_count)
+    if (kvm->paused)
         return VMI_SUCCESS;
 
     // pause vcpus
@@ -1002,9 +1002,9 @@ kvm_pause_vm(
         return VMI_FAILURE;
     }
 
-    kvm->expected_pause_count = vmi->num_vcpus;
+    kvm->paused = true;
 
-    dbprint(VMI_DEBUG_KVM, "--We should receive %u pause events\n", kvm->expected_pause_count);
+    dbprint(VMI_DEBUG_KVM, "--We should receive %u pause events\n", vmi->num_vcpus);
 
     return VMI_SUCCESS;
 }
@@ -1016,54 +1016,36 @@ kvm_resume_vm(
     kvm_instance_t *kvm = kvm_get_instance(vmi);
 
     // already resumed ?
-    if (!kvm->expected_pause_count)
+    if (!kvm->paused)
         return VMI_SUCCESS;
 
-    // wait to receive pause events
-    while (kvm->expected_pause_count) {
+    // iterate over pause_events_list and unpause every single vcpu by sending a continue reply for each pause event
+    for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
         struct kvmi_dom_event *ev = NULL;
-        unsigned int ev_id = 0;
 
-        // check pause events poped by vmi_events_listen first
-        for (unsigned int vcpu = 0; vcpu < vmi->num_vcpus; vcpu++) {
-            if (kvm->pause_events_list[vcpu]) {
-                dbprint(VMI_DEBUG_KVM, "--Removing PAUSE_VCPU event from the buffer\n");
-                ev = kvm->pause_events_list[vcpu];
-                kvm->pause_events_list[vcpu] = NULL;
-                break;
-            }
-        }
-
-        // if no pause event is waiting in the list, pop next one
-        if (!ev) {
-            if (VMI_FAILURE == kvm_get_next_event(kvm, &ev, 1000)) {
-                errprint("Failed to get next KVMi event\n");
-            }
-            if (!ev) {
-                // no new events
-                // report error
+        // wait until the pause event for the current vcpu is received
+        while (!kvm->pause_events_list[vcpu]) {
+            dbprint(VMI_DEBUG_KVM, "--Waiting to receive PAUSE_VCPU event for vcpu %u\n", vcpu);
+            if (kvm_process_events_with_timeout(vmi, 100) == VMI_FAILURE) {
                 return VMI_FAILURE;
             }
         }
+
+        dbprint(VMI_DEBUG_KVM, "--Removing PAUSE_VCPU event from the buffer\n");
+        ev = kvm->pause_events_list[vcpu];
+        kvm->pause_events_list[vcpu] = NULL;
+
         // handle event
-        ev_id = ev->event.common.event;
-        switch (ev_id) {
-            case KVMI_EVENT_PAUSE_VCPU:
-                dbprint(VMI_DEBUG_KVM, "--Received VCPU pause event\n");
-                kvm->expected_pause_count--;
-                if (reply_continue(kvm, ev) == VMI_FAILURE) {
-                    errprint("%s: Fail to send continue reply", __func__);
-                    free(ev);
-                    return VMI_FAILURE;
-                }
-                free(ev);
-                break;
-            default:
-                errprint("%s: Unexpected event %u\n", __func__, ev_id);
-                free(ev);
-                return VMI_FAILURE;
+        dbprint(VMI_DEBUG_KVM, "--Sending continue reply\n");
+        if (reply_continue(kvm, ev) == VMI_FAILURE) {
+            errprint("%s: Failed to send continue reply\n", __func__);
+            free(ev);
+            return VMI_FAILURE;
         }
+        free(ev);
     }
+
+    kvm->paused = false;
 
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/kvm/kvm.c
+++ b/libvmi/driver/kvm/kvm.c
@@ -31,24 +31,13 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/un.h>
-#include <sys/mman.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/socket.h>
 #include <sys/time.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <glib.h>
-#include <math.h>
-#include <glib/gstdio.h>
 #include <libvirt/libvirt.h>
-#include <libvirt/virterror.h>
 #include <libkvmi.h>
 
 #include "private.h"
 #include "msr-index.h"
-#include "driver/driver_wrapper.h"
 #include "driver/memory_cache.h"
 #include "driver/kvm/kvm.h"
 #include "driver/kvm/kvm_private.h"

--- a/libvmi/driver/kvm/kvm_events.c
+++ b/libvmi/driver/kvm/kvm_events.c
@@ -821,7 +821,7 @@ kvm_events_destroy(
     dbprint(VMI_DEBUG_KVM, "--Destroying KVM driver events\n");
     // pause VM
     dbprint(VMI_DEBUG_KVM, "--Ensure VM is paused\n");
-    if (VMI_FAILURE == vmi_pause_vm(vmi))
+    if (VMI_FAILURE == kvm_pause_vm(vmi))
         errprint("--Failed to pause VM while destroying events\n");
 
     reg_event_t regevent = { .in_access = VMI_REGACCESS_N };
@@ -878,13 +878,13 @@ kvm_events_destroy(
     // clean event queue
     if (kvm_are_events_pending(vmi)) {
         dbprint(VMI_DEBUG_KVM, "--Cleanup event queue\n");
-        if (VMI_FAILURE == vmi_events_listen(vmi, 0))
+        if (VMI_FAILURE == kvm_events_listen(vmi, 0))
             errprint("--Failed to clean event queue\n");
     }
 
     // resume VM
     dbprint(VMI_DEBUG_KVM, "--Resume VM\n");
-    if (VMI_FAILURE == vmi_resume_vm(vmi))
+    if (VMI_FAILURE == kvm_resume_vm(vmi))
         errprint("--Failed to resume VM while destroying events\n");
 }
 

--- a/libvmi/driver/kvm/kvm_events.h
+++ b/libvmi/driver/kvm/kvm_events.h
@@ -39,6 +39,11 @@ void
 kvm_events_destroy(vmi_instance_t vmi);
 
 status_t
+kvm_process_events_with_timeout(
+    vmi_instance_t vmi,
+    uint32_t timeout);
+
+status_t
 kvm_events_listen(
     vmi_instance_t vmi,
     uint32_t timeout);

--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -56,8 +56,8 @@ typedef struct kvm_instance {
     libkvmi_wrapper_t libkvmi;
     pthread_mutex_t kvm_connect_mutex;
     pthread_cond_t kvm_start_cond;
-    unsigned int expected_pause_count;
-    // store KVMI_EVENT_PAUSE_VCPU events poped by vmi_events_listen(vmi, 0)
+    bool paused;
+    // store KVMI_EVENT_PAUSE_VCPU events popped by vmi_events_listen(vmi, 0)
     // to be used by vmi_resume_vm()
     struct kvmi_dom_event** pause_events_list;
     // dispatcher to handle VM events in each process_xxx functions


### PR DESCRIPTION
In some edge cases the pause event might not be the first event in the queue. This causes `kvm_resume_vm` to fail. Therefore we should process all pending events immediately after pausing the vm and let the pause event be inserted into `pause_events_list`.