### PR TITLE
Fix vmi_init_paging issue on ARM64/ZCU102

### DIFF
--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -147,7 +147,7 @@ static status_t get_vcpu_page_mode_arm(vmi_instance_t vmi, unsigned long vcpu, p
         } else {
             /* See ARM ARMv8-A D7.2.84 TCR_EL1, Translation Control Register (EL1) */
             reg_t tcr_el1;
-            if ( !out_pm && VMI_SUCCESS == driver_get_vcpureg(vmi, &tcr_el1, TCR_EL1, vcpu)) {
+            if ( VMI_SUCCESS == driver_get_vcpureg(vmi, &tcr_el1, TCR_EL1, vcpu)) {
                 vmi->arm64.t0sz = tcr_el1 & VMI_BIT_MASK(0,5);
                 vmi->arm64.t1sz = (tcr_el1 & VMI_BIT_MASK(16,21)) >> 16;
                 switch ((tcr_el1 & VMI_BIT_MASK(14,15)) >> 14) {
@@ -232,15 +232,10 @@ void arch_init_lookup_tables(vmi_instance_t vmi)
 status_t arch_init(vmi_instance_t vmi)
 {
     if (vmi->page_mode != VMI_PM_UNKNOWN)
-    {
         return VMI_SUCCESS;
-    }
-    else
-    {
-        if (VMI_FAILURE == get_vcpu_page_mode(vmi, 0, NULL))
-        {
-            return VMI_FAILURE;
-        }
-        return VMI_SUCCESS;
-    }
+
+    if (VMI_FAILURE == get_vcpu_page_mode(vmi, 0, &vmi->page_mode))
+        return VMI_FAILURE;
+
+    return VMI_SUCCESS;
 }

--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -232,10 +232,15 @@ void arch_init_lookup_tables(vmi_instance_t vmi)
 status_t arch_init(vmi_instance_t vmi)
 {
     if (vmi->page_mode != VMI_PM_UNKNOWN)
+    {
         return VMI_SUCCESS;
-
-    if (VMI_FAILURE == get_vcpu_page_mode(vmi, 0, &vmi->page_mode))
-        return VMI_FAILURE;
-
-    return VMI_SUCCESS;
+    }
+    else
+    {
+        if (VMI_FAILURE == get_vcpu_page_mode(vmi, 0, NULL))
+        {
+            return VMI_FAILURE;
+        }
+        return VMI_SUCCESS;
+    }
 }


### PR DESCRIPTION
This PR addresses an issue I've discovered in recent versions of libvmi on a Xilinx ZCU102 ARM64 development board with Xen 4.16. I do not think this issue is exclusive to the ZCU102, but it's the only board I have to test on. 

The issue is that the TTBR0/TTBR1 values for paging are not correctly determined and libvmi initialization fails. I think this issue was introduced in #956 as part of a refactor (not trying to place blame, just pointing out where this code segment changed). Prior to that PR, the `get_vcpu_page_mode` function in [arch_interface.c](https://github.com/libvmi/libvmi/blob/master/libvmi/arch/arch_interface.c) was passed `NULL` for the value of `out_pm`. This caused the `if` check in `get_vcpu_page_mode_arm` on [arch_interface.c:150](https://github.com/libvmi/libvmi/blob/710b0a5c3a2416ae82f033fc3f9111a0abda7b19/libvmi/arch/arch_interface.c#L150) (`if ( !out_pm && VMI_SUCCESS == ...`) to succeed and set the `vmi->arm64.tg0` and `vmi->arm64.tg1` values appropriately. Currently, this check fails and the values remain unset because `vmi->page_mode` is set to `VMI_PM_UNKNOWN` (which equals 1). This causes the TTBR0/TTBR1 values to remain unset, which then causes failures later. 

I'm not familiar enough with the codebase to know for sure if this is the correct way to fix this issue, but I wanted to raise the issue I've seen as well as a fix that has worked for me so far. Any feedback/suggestions are welcome.

Current debug output:
```
**The running Xen version is 4.16
--found Xen
libvirt: QEMU Driver error : Domain not found: no domain with matching name 'paravirtual'
--failed to find kvm domain
LibVMI Version 0.15.0
LibVMI Driver Mode 0
**The running Xen version is 4.16
--completed driver init.
--got id from name (paravirtual --> 1)
**set image_type = paravirtual
**set vm_type HVM
--xen: setup live mode
**set allocated_ram_size = 7cfc4000, max_physical_address = 0xbd000000
**failed to get CR0
Found ARM64 pagemode. TTBR0 VA width: 64 Page size: 0 TTBR1 VA width:64 Page size: 0
--looking for config file at /home/root/libvmi.conf
--looking for config file at /home/root/etc/libvmi.conf
--looking for config file at /etc/libvmi.conf
**set os_type to Linux.
--V2P cache miss (no address space) 0x023600004118b000 0x0000000000000000
--ARM AArch64 PTLookup: vaddr = 0xffff8000113b4780, pt = 0x023600004118b000
VMI_ERROR: 16KB granule size ARM64 lookups are not yet implemented
--ARM PTLookup: PA = 0xaaaaf83ede70
Invalid or not supported paging mode during get_va_pages
--V2P cache miss (no address space) 0x023600004118b000 0x0000000000000000
--ARM AArch64 PTLookup: vaddr = 0xffff8000113b4780, pt = 0x023600004118b000
VMI_ERROR: 16KB granule size ARM64 lookups are not yet implemented
--ARM PTLookup: PA = 0xaaaaf83ede70
Invalid or not supported paging mode during get_va_pages
**failed to determine KASLR offset
Failed to init LibVMI library.
```

Debug output with change:
```
**The running Xen version is 4.16
--found Xen
libvirt: QEMU Driver error : Domain not found: no domain with matching name 'paravirtual'
--failed to find kvm domain
LibVMI Version 0.15.0
LibVMI Driver Mode 0
**The running Xen version is 4.16
--completed driver init.
--got id from name (paravirtual --> 1)
**set image_type = paravirtual
**set vm_type HVM
--xen: setup live mode
**set allocated_ram_size = 7cfc4000, max_physical_address = 0xbd000000
**failed to get CR0
Found ARM64 pagemode. TTBR0 VA width: 48 Page size: 4096 TTBR1 VA width:48 Page size: 4096
--looking for config file at /home/root/libvmi.conf
--looking for config file at /home/root/etc/libvmi.conf
--looking for config file at /etc/libvmi.conf
**set os_type to Linux.
--V2P cache miss (no address space) 0x023600004118b000 0x0000000000000000
--ARM AArch64 PTLookup: vaddr = 0xffff8000113b4780, pt = 0x023600004118b000
--Reading pfn 0x4118b
--MEMORY cache set 0x4118b000
...
```