### PR TITLE
Do not require macro definitions for libvmi_extra.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -231,6 +231,7 @@ if LINUX
     examples_vmi_linux_offsets_LDADD = $(GLIB_LIBS) libvmi/libvmi.la
 
     examples_vmi_dmesg_SOURCES = examples/dmesg.c
+    examples_vmi_dmesg_CFLAGS = $(GLIB_CFLAGS)
     examples_vmi_linux_offsets_SOURCES = examples/linux-offsets.c
 endif
 

--- a/examples/dmesg.c
+++ b/examples/dmesg.c
@@ -34,7 +34,6 @@
 #include <getopt.h>
 
 #include <libvmi/libvmi.h>
-#define LIBVMI_EXTRA_JSON
 #include <libvmi/libvmi_extra.h>
 
 static vmi_instance_t vmi;

--- a/examples/linux-offsets.c
+++ b/examples/linux-offsets.c
@@ -22,8 +22,6 @@
 
 #define _GNU_SOURCE
 
-#define LIBVMI_EXTRA_JSON
-
 #include <libvmi/libvmi.h>
 #include <libvmi/peparse.h>
 #include <libvmi/events.h>

--- a/examples/va-pages.c
+++ b/examples/va-pages.c
@@ -31,7 +31,6 @@
 
 #include <libvmi/libvmi.h>
 #include <libvmi/events.h>
-#define LIBVMI_EXTRA_GLIB
 #include <libvmi/libvmi_extra.h>
 
 reg_t cr3;

--- a/examples/win-offsets.c
+++ b/examples/win-offsets.c
@@ -22,8 +22,6 @@
 
 #define _GNU_SOURCE
 
-#define LIBVMI_EXTRA_JSON
-
 #include <libvmi/libvmi.h>
 #include <libvmi/peparse.h>
 #include <libvmi/events.h>

--- a/libvmi/config.h.in
+++ b/libvmi/config.h.in
@@ -1,3 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
 /* Define for the ARM32 architecture. */
 #cmakedefine ARM32
 
@@ -110,3 +113,5 @@
 
 /* Version number of package */
 #define VERSION "${PROJECT_VERSION}"
+
+#endif // CONFIG_H

--- a/libvmi/json_profiles/json_profiles.h
+++ b/libvmi/json_profiles/json_profiles.h
@@ -24,7 +24,6 @@
 #define LIBVMI_JSON_PROFILES_H
 
 #ifdef ENABLE_JSON_PROFILES
-#define LIBVMI_EXTRA_JSON
 
 #include <json-c/json.h>
 #include "private.h"

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -22,15 +22,16 @@
  * @file libvmi_extra.h
  * @brief The Extra LibVMI API is defined here.
  *
- * To use GLib functions compile with -DLIBVMI_EXTRA_GLIB
- * To use JSON functions compile with -DLIBVMI_EXTRA_JSON
+ * To use JSON functions compile with -DENABLE_JSON_PROFILES
  */
 #ifndef LIBVMI_EXTRA_H
 #define LIBVMI_EXTRA_H
 
-#ifdef LIBVMI_EXTRA_GLIB
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
 #include <glib.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,8 +41,6 @@ extern "C" {
 #endif
 
 #pragma GCC visibility push(default)
-
-#ifdef LIBVMI_EXTRA_GLIB
 
 /**
  * Retrieve the pages mapped into the address space of a process.
@@ -73,9 +72,7 @@ GSList* vmi_get_nested_va_pages(
     addr_t pt,
     page_mode_t pm) NOEXCEPT;
 
-#endif
-
-#ifdef LIBVMI_EXTRA_JSON
+#ifdef ENABLE_JSON_PROFILES
 #include <json-c/json.h>
 
 /**

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -41,10 +41,6 @@
 #include <time.h>
 #include <inttypes.h>
 #include "libvmi.h"
-#define LIBVMI_EXTRA_GLIB
-#ifdef ENABLE_JSON_PROFILES
-#define LIBVMI_EXTRA_JSON
-#endif
 #include "libvmi_extra.h"
 #include "cache.h"
 #include "events.h"

--- a/tests/test_cache.c
+++ b/tests/test_cache.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include "../libvmi/libvmi.h"
-#define LIBVMI_EXTRA_GLIB
 #include "../libvmi/libvmi_extra.h"
 #include "../libvmi/cache.h"
 #include "check_tests.h"

--- a/tests/test_getvapages.c
+++ b/tests/test_getvapages.c
@@ -30,7 +30,6 @@
 #include <glib.h>
 
 #include <libvmi/libvmi.h>
-#define LIBVMI_EXTRA_GLIB
 #include <libvmi/libvmi_extra.h>
 
 #include "check_tests.h"


### PR DESCRIPTION
Users of `libvmi_extra.h` are required to define various macros although the underlying functionality should be activated via feature flags.