### PR TITLE
 Kvm: Implement pause counter

### DIFF
--- a/libvmi/driver/kvm/kvm_private.h
+++ b/libvmi/driver/kvm/kvm_private.h
@@ -56,7 +56,7 @@ typedef struct kvm_instance {
     libkvmi_wrapper_t libkvmi;
     pthread_mutex_t kvm_connect_mutex;
     pthread_cond_t kvm_start_cond;
-    bool paused;
+    int pause_count;
     // store KVMI_EVENT_PAUSE_VCPU events popped by vmi_events_listen(vmi, 0)
     // to be used by vmi_resume_vm()
     struct kvmi_dom_event** pause_events_list;


### PR DESCRIPTION
If we pause the vm and then call `vmi_events_listen` the vm might be resumed unexpectedly if `swap_events` or `clear_events` have to be handled.