### PR TITLE
Fix memory cache remove

### DIFF
--- a/libvmi/driver/memory_cache.c
+++ b/libvmi/driver/memory_cache.c
@@ -225,9 +225,7 @@ void memory_cache_remove(
         return;
     }
 
-    gint64 *key = (gint64*)&paddr;
-
-    g_hash_table_remove(vmi->memory_cache, key);
+    g_hash_table_remove(vmi->memory_cache, GSIZE_TO_POINTER(paddr));
 }
 
 void


### PR DESCRIPTION
Stale pages are never removed because they are looked up by the location of the physical address on the stack instead of the actual physical address.