### PR TITLE
I/O event hooking, firmware type check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -250,7 +250,8 @@ endif
                        examples/step-event-example \
                        examples/xen-emulate-response \
                        examples/breakpoint-emulate-example \
-                       examples/read-disk-example
+                       examples/read-disk-example \
+                       examples/io-event-example
 
     examples_map_symbol_SOURCES = examples/map-symbol.c
     examples_map_addr_SOURCES = examples/map-addr.c
@@ -262,6 +263,7 @@ endif
     examples_xen_emulate_response_SOURCES = examples/xen-emulate-response.c
     examples_breakpoint_emulate_example_SOURCES = examples/breakpoint-emulate-example.c
     examples_read_disk_example_SOURCES = examples/read-disk-example.c
+    examples_io_event_example_SOURCES = examples/io-event-example.c
 
     noinst_PROGRAMS += examples/va-pages
     examples_va_pages_SOURCES = examples/va-pages.c

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,6 +52,9 @@ target_link_libraries(xen-emulate-reponse vmi_shared)
 add_executable(read-disk-example read-disk-example.c)
 target_link_libraries(read-disk-example vmi_shared)
 
+add_executable(io-event-example io-event-example.c)
+target_link_libraries(io-event-example vmi_shared)
+
 add_executable(vmi-process-list process-list.c)
 target_link_libraries(vmi-process-list vmi_shared)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -85,6 +85,10 @@ A simple MSR event interception.
 
 Example reads bootable disk zero sector (MBR) and saves to file
 
+## io-event-example
+
+Example set breakpoint on I/O (in, out instrutions) events
+
 ## vmi-process-list
 
 Displays the VM's process list.

--- a/examples/io-event-example.c
+++ b/examples/io-event-example.c
@@ -1,0 +1,143 @@
+/* The LibVMI Library is an introspection library that simplifies access to
+ * memory in a target virtual machine or in a file containing a dump of
+ * a system's physical memory.  LibVMI is based on the XenAccess Library.
+ *
+ * Author: Anton Belousov <blsvntntx@gmail.com>
+ *
+ * This file is part of LibVMI.
+ *
+ * LibVMI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * LibVMI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with LibVMI.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <signal.h>
+#include <getopt.h>
+
+#include <libvmi/libvmi.h>
+#include <libvmi/events.h>
+
+event_response_t io_cb(vmi_instance_t vmi, vmi_event_t *event)
+{
+    (void)vmi;
+    if (event->io_event.port == 0x0CF8)
+        printf("IO cb: Port: 0x%"PRIx32", Address: %"PRIx64"\n", event->io_event.port, event->x86_regs->rax);
+
+    return VMI_EVENT_RESPONSE_NONE;
+}
+
+static int interrupted = 0;
+static void close_handler(int sig)
+{
+    interrupted = sig;
+}
+
+int main (int argc, char **argv)
+{
+    vmi_instance_t vmi = {0};
+    vmi_event_t io_event = {0};
+    struct sigaction act = {0};
+    vmi_init_data_t *init_data = NULL;
+    vmi_mode_t mode = {0};
+    uint64_t domid = 0;
+    uint8_t init = VMI_INIT_DOMAINNAME;
+    void *input = NULL, *config = NULL;
+    char *socket = NULL;
+    int retcode = 1;
+
+    if ( argc <= 2 ) {
+        printf("Usage: %s\n", argv[0]);
+        printf("\t -n/--name <domain name>\n");
+        printf("\t -d/--domid <domain id>\n\n");
+        return false;
+    }
+
+    const struct option long_opts[] = {
+        {"name", required_argument, NULL, 'n'},
+        {"domid", required_argument, NULL, 'd'},
+        {NULL, 0, NULL, 0}
+    };
+    const char* opts = "n:d:";
+    int c;
+    int long_index = 0;
+
+    while ((c = getopt_long (argc, argv, opts, long_opts, &long_index)) != -1)
+        switch (c) {
+            case 'n':
+                input = optarg;
+                break;
+            case 'd':
+                init = VMI_INIT_DOMAINID;
+                domid = strtoull(optarg, NULL, 0);
+                input = (void*)&domid;
+                break;
+            default:
+                printf("Unknown option\n");
+                return false;
+        }
+
+    /* initialize the libvmi library */
+    if (VMI_FAILURE == vmi_get_access_mode(NULL, input, init, init_data, &mode)) {
+        fprintf(stderr, "Failed to get access mode\n");
+        goto error_exit;
+    }
+
+    if (VMI_FAILURE == vmi_init(&vmi, mode, input, init | VMI_INIT_EVENTS, init_data, NULL)) {
+        fprintf(stderr, "Failed to init LibVMI library.\n");
+        goto error_exit;
+    }
+    printf("LibVMI init\n");
+
+    act.sa_handler = close_handler;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGHUP,  &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT,  &act, NULL);
+    sigaction(SIGALRM, &act, NULL);
+
+    SETUP_IO_EVENT(&io_event, io_cb);
+
+    if (VMI_FAILURE == vmi_register_event(vmi, &io_event)) {
+        fprintf(stderr, "Failed to register IO event\n");
+        goto error_exit;
+    }
+    printf("Registered event\n");
+    printf("Listening on events...\n");
+
+    while (!interrupted) {
+        if (VMI_FAILURE == vmi_events_listen(vmi,500)) {
+            fprintf(stderr, "Failed to listen on VMI events\n");
+            goto error_exit;
+        }
+    }
+
+    retcode = 0;
+error_exit:
+    vmi_clear_event(vmi, &io_event, NULL);
+
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    if (init_data) {
+        free(init_data->entry[0].data);
+        free(init_data);
+    }
+
+    return retcode;
+}

--- a/examples/io-event-example.c
+++ b/examples/io-event-example.c
@@ -56,8 +56,7 @@ int main (int argc, char **argv)
     vmi_mode_t mode = {0};
     uint64_t domid = 0;
     uint8_t init = VMI_INIT_DOMAINNAME;
-    void *input = NULL, *config = NULL;
-    char *socket = NULL;
+    void *input = NULL;
     int retcode = 1;
 
     if ( argc <= 2 ) {

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -1242,3 +1242,26 @@ status_t vmi_disk_is_bootable(
 
     return VMI_SUCCESS;
 }
+
+firmware_t vmi_get_firmware_type(
+    vmi_instance_t vmi)
+{
+    firmware_t result = VMI_FIRMWARE_UNKNOWN;
+    if ( vmi->mode != VMI_XEN)
+        return result;
+
+    char *bios = driver_get_bios(vmi);
+    if (bios) {
+        gchar *tmp = g_ascii_strdown(bios, -1);
+        if (!g_strcmp0(tmp, "ovmf"))
+            result = VMI_FIRMWARE_UEFI;
+        else if (!g_strcmp0(tmp, "seabios") || !g_strcmp0(tmp, "rombios"))
+            result = VMI_FIRMWARE_LEGACY;
+        else
+            result = VMI_FIRMWARE_UNKNOWN;
+        g_free(tmp);
+        free(bios);
+    }
+
+    return result;
+}

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -176,6 +176,9 @@ typedef struct driver_interface {
     status_t (*set_domain_watch_event_ptr)(
         vmi_instance_t,
         bool enabled);
+    status_t (*set_io_event_ptr)(
+        vmi_instance_t,
+        bool enabled);
     status_t (*slat_get_domain_state_ptr)(
         vmi_instance_t vmi,
         bool *state);
@@ -212,6 +215,8 @@ typedef struct driver_interface {
         vmi_instance_t vmi,
         const char *device_id,
         bool *bootable);
+    char* (*get_bios)(
+        vmi_instance_t vmi);
 
     /* Driver-specific data storage. */
     void* driver_data;

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -650,6 +650,21 @@ driver_set_watch_domain_event(
 }
 
 static inline status_t
+driver_set_io_event(
+    vmi_instance_t vmi,
+    bool enabled)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_io_event_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_io_event function not implemented.\n");
+        return VMI_FAILURE;
+    }
+#endif
+
+    return vmi->driver.set_io_event_ptr(vmi, enabled);
+}
+
+static inline status_t
 driver_slat_get_domain_state (
     vmi_instance_t vmi,
     bool *state )
@@ -803,6 +818,20 @@ driver_disk_is_bootable(
 #endif
 
     return vmi->driver.disk_is_bootable_ptr(vmi, device_id, bootable);
+}
+
+static inline char*
+driver_get_bios(
+    vmi_instance_t vmi)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_bios) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_bios function not implemented.\n");
+        return NULL;
+    }
+#endif
+
+    return vmi->driver.get_bios(vmi);
 }
 
 #endif /* DRIVER_WRAPPER_H */

--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -84,6 +84,10 @@ static status_t sanity_check(xen_instance_t *xen)
 
         default:
         /* Things start to be a bit saner from 4.6 */
+        case 16:
+            if ( !w->xc_monitor_io )
+                break;
+            __attribute__ ((fallthrough));
         case 11:
             if ( !w->xc_monitor_emul_unimplemented )
                 break;
@@ -220,6 +224,7 @@ status_t create_libxc_wrapper(xen_instance_t *xen)
     wrapper->xc_monitor_debug_exceptions = dlsym(wrapper->handle, "xc_monitor_debug_exceptions");
     wrapper->xc_monitor_cpuid = dlsym(wrapper->handle, "xc_monitor_cpuid");
     wrapper->xc_monitor_vmexit = dlsym(wrapper->handle, "xc_monitor_vmexit");
+    wrapper->xc_monitor_io = dlsym(wrapper->handle, "xc_monitor_io");
     wrapper->xc_hvm_param_get = dlsym(wrapper->handle, "xc_hvm_param_get");
     wrapper->xc_hvm_param_set = dlsym(wrapper->handle, "xc_hvm_param_set");
     wrapper->xc_get_hvm_param = dlsym(wrapper->handle, "xc_get_hvm_param");

--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -87,7 +87,7 @@ static status_t sanity_check(xen_instance_t *xen)
         case 16:
             if ( !w->xc_monitor_io )
                 break;
-            __attribute__ ((fallthrough));
+        /* Fall-through */
         case 11:
             if ( !w->xc_monitor_emul_unimplemented )
                 break;

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -260,6 +260,10 @@ typedef struct {
     int (*xc_vm_event_get_version)
     (xc_interface *xch);
 
+    /* Xen 4.16 */
+    int (*xc_monitor_io)
+    (xc_interface *xch, uint32_t domain_id, bool enable);
+
     /* Xen 4.17+ */
     int (*xc_monitor_vmexit)
     (xc_interface *xch, uint32_t domain_id, bool enable, bool sync);

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -656,8 +656,7 @@ xen_get_version(
     if (getline(&line, &len, fp) == -1)
         goto done;
 
-    //xen->minor_version = atoi(line);
-    xen->minor_version = 16;
+    xen->minor_version = atoi(line);
     status = VMI_SUCCESS;
 
     dbprint(VMI_DEBUG_XEN, "**The running Xen version is %u.%u\n",

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -656,7 +656,8 @@ xen_get_version(
     if (getline(&line, &len, fp) == -1)
         goto done;
 
-    xen->minor_version = atoi(line);
+    //xen->minor_version = atoi(line);
+    xen->minor_version = 16;
     status = VMI_SUCCESS;
 
     dbprint(VMI_DEBUG_XEN, "**The running Xen version is %u.%u\n",
@@ -3099,5 +3100,33 @@ xen_disk_is_bootable(
     } else {
         return VMI_FAILURE;
     }
+}
+#endif
+
+/*
+ * This function is only usable with xenstore. Returns /local/domain/<domID>/hvmloader/bios property.
+ */
+#ifndef HAVE_LIBXENSTORE
+char *
+xen_get_bios(
+    vmi_instance_t UNUSED(vmi))
+{
+    return NULL;
+}
+#else
+char*
+xen_get_bios(
+    vmi_instance_t vmi)
+{
+    xen_instance_t *xen = xen_get_instance(vmi);
+    xs_transaction_t xth = XBT_NULL;
+    char *bios = NULL;
+
+    gchar *tmp = g_strdup_printf("/local/domain/%"PRIu64"/hvmloader/bios", xen->domainid);
+    bios = xen->libxsw.xs_read(xen->xshandle, xth, tmp, NULL);
+
+    g_free(tmp);
+
+    return bios;
 }
 #endif

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -187,6 +187,8 @@ status_t xen_disk_is_bootable(
     vmi_instance_t vmi,
     const char *device_id,
     bool *bootable);
+char *xen_get_bios(
+    vmi_instance_t vmi);
 
 static inline status_t
 driver_xen_setup(vmi_instance_t vmi)
@@ -224,6 +226,7 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.read_disk_ptr = &xen_read_disk;
     driver.get_disks_ptr = &xen_get_disks;
     driver.disk_is_bootable_ptr = &xen_disk_is_bootable;
+    driver.get_bios = &xen_get_bios;
     vmi->driver = driver;
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -501,6 +501,32 @@ status_t xen_set_vmexit_event(vmi_instance_t vmi, bool enabled, bool sync)
     return VMI_SUCCESS;
 }
 
+status_t xen_set_io_event(vmi_instance_t vmi, bool enabled)
+{
+    int rc;
+    xen_instance_t *xen = xen_get_instance(vmi);
+
+    if ( xen->major_version != 4 || xen->minor_version < 16 )
+        return VMI_FAILURE;
+
+    if ( !enabled && !vmi->io_event )
+        return VMI_SUCCESS;
+
+    rc = xen->libxcw.xc_monitor_io(xen_get_xchandle(vmi),
+                                   xen_get_domainid(vmi),
+                                   enabled);
+    if ( rc < 0 ) {
+        errprint("Error %i setting I/O event monitor\n", rc);
+        errprint("xen_set_io_event: Errno: %d\n", errno);
+        return VMI_FAILURE;
+    }
+
+    if ( !enabled )
+        vmi->io_event = NULL;
+
+    return VMI_SUCCESS;
+}
+
 status_t xen_set_privcall_event(vmi_instance_t vmi, bool enabled)
 {
     int rc;
@@ -1101,6 +1127,40 @@ status_t process_vmexit(vmi_instance_t vmi, vm_event_compat_t *vmec)
     process_response ( event->callback(vmi, event),
                        event, vmec );
     vmi->event_callback = 0;
+
+    return VMI_SUCCESS;
+}
+
+static
+status_t process_io_instruction(vmi_instance_t vmi, vm_event_compat_t *vmec)
+{
+    vmi_event_t * event = vmi->io_event;
+
+#ifdef ENABLE_SAFETY_CHECKS
+    if ( !event ) {
+        errprint("%s error: no I/O event handler is registered in LibVMI\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+#endif
+
+    event->io_event.data_size = vmec->io_instruction.data_size;
+    event->io_event.port = vmec->io_instruction.port;
+    event->io_event.input = vmec->io_instruction.input;
+    event->io_event.string_ins = vmec->io_instruction.string_ins;
+
+    event->x86_regs = &vmec->data.regs.x86;
+    event->slat_id = vmec->altp2m_idx;
+    event->vcpu_id = vmec->vcpu_id;
+    event->page_mode = vmec->pm;
+
+    vmi->event_callback = 1;
+    process_response ( event->callback(vmi, event),
+                       event, vmec );
+    vmi->event_callback = 0;
+
+    if ( !vmec->flags || vmec->flags == (1 << VM_EVENT_FLAG_VCPU_PAUSED) )
+        dbprint(VMI_DEBUG_XEN, "%s warning: I/O events require the callback to specify how to handle it\n",
+                __FUNCTION__);
 
     return VMI_SUCCESS;
 }
@@ -3075,6 +3135,10 @@ status_t process_requests_7(vmi_instance_t vmi, uint32_t *requests_processed)
             case VM_EVENT_REASON_VMEXIT:
                 memcpy(&vmec.vmexit, &req->u.vmexit, sizeof(vmec.vmexit));
                 break;
+
+            case VM_EVENT_REASON_IO_INSTRUCTION:
+                memcpy(&vmec.io_instruction, &req->u.io_instruction, sizeof(vmec.io_instruction));
+                break;
         }
 
         vrc = process_request(vmi, &vmec);
@@ -3548,6 +3612,7 @@ status_t xen_init_events(
     xe->process_event[VM_EVENT_REASON_DESCRIPTOR_ACCESS] = &process_desc_access;
     xe->process_event[VM_EVENT_REASON_EMUL_UNIMPLEMENTED] = &process_unimplemented_emul;
     xe->process_event[VM_EVENT_REASON_VMEXIT] = &process_vmexit;
+    xe->process_event[VM_EVENT_REASON_IO_INSTRUCTION] = &process_io_instruction;
 
     vmi->driver.events_listen_ptr = &xen_events_listen;
     vmi->driver.set_reg_access_ptr = &xen_set_reg_access;
@@ -3563,6 +3628,7 @@ status_t xen_init_events(
     vmi->driver.set_desc_access_event_ptr = &xen_set_desc_access_event;
     vmi->driver.set_failed_emulation_event_ptr = &xen_set_failed_emulation_event;
     vmi->driver.set_vmexit_event_ptr = &xen_set_vmexit_event;
+    vmi->driver.set_io_event_ptr = &xen_set_io_event;
 
     xen->libxcw.xc_monitor_get_capabilities(xch, dom, &xe->monitor_capabilities);
 
@@ -3690,6 +3756,8 @@ void xen_events_destroy(vmi_instance_t vmi)
         (void)driver_set_cpuid_event(vmi, 0);
     if ( vmi->debug_event )
         (void)driver_set_debug_event(vmi, 0);
+    if ( vmi->io_event )
+        (void)driver_set_io_event(vmi, 0);
     if ( vmi->guest_requested_event )
         (void)driver_set_guest_requested_event(vmi, 0);
     if ( vmi->failed_emulation_event )

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -1143,10 +1143,10 @@ status_t process_io_instruction(vmi_instance_t vmi, vm_event_compat_t *vmec)
     }
 #endif
 
-    event->io_event.data_size = vmec->io_instruction.data_size;
+    event->io_event.bytes = vmec->io_instruction.bytes;
     event->io_event.port = vmec->io_instruction.port;
-    event->io_event.input = vmec->io_instruction.input;
-    event->io_event.string_ins = vmec->io_instruction.string_ins;
+    event->io_event.in = vmec->io_instruction.in;
+    event->io_event.str = vmec->io_instruction.str;
 
     event->x86_regs = &vmec->data.regs.x86;
     event->slat_id = vmec->altp2m_idx;

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -411,10 +411,10 @@ struct vm_event_mov_to_msr_3 {
 };
 
 struct vm_event_io_instruction {
-    uint32_t data_size;
-    uint32_t port;
-    uint32_t input;
-    uint32_t string_ins;
+    uint32_t bytes; /* size of access */
+    uint16_t port;  /* port number */
+    uint8_t  in;    /* direction (0 = OUT, 1 = IN) */
+    uint8_t  str;   /* string instruction (0 = not string, 1 = string) */
 };
 
 #define VM_EVENT_DESC_IDTR           1

--- a/libvmi/driver/xen/xen_events_abi.h
+++ b/libvmi/driver/xen/xen_events_abi.h
@@ -114,7 +114,8 @@ typedef enum {
 #define VM_EVENT_REASON_DESCRIPTOR_ACCESS       13
 #define VM_EVENT_REASON_EMUL_UNIMPLEMENTED      14
 #define VM_EVENT_REASON_VMEXIT                  15
-#define __VM_EVENT_REASON_MAX                   16
+#define VM_EVENT_REASON_IO_INSTRUCTION          16
+#define __VM_EVENT_REASON_MAX                   17
 
 #define VM_EVENT_X86_CR0    0
 #define VM_EVENT_X86_CR3    1
@@ -407,6 +408,13 @@ struct vm_event_mov_to_msr_3 {
     uint64_t msr;
     uint64_t new_value;
     uint64_t old_value;
+};
+
+struct vm_event_io_instruction {
+    uint32_t data_size;
+    uint32_t port;
+    uint32_t input;
+    uint32_t string_ins;
 };
 
 #define VM_EVENT_DESC_IDTR           1
@@ -706,6 +714,7 @@ typedef struct vm_event_st_7 {
         struct vm_event_debug_6               debug_exception;
         struct vm_event_cpuid                 cpuid;
         struct vm_event_vmexit                vmexit;
+        struct vm_event_io_instruction        io_instruction;
         union {
             struct vm_event_interrupt_x86     x86;
         } interrupt;

--- a/libvmi/driver/xen/xen_events_private.h
+++ b/libvmi/driver/xen/xen_events_private.h
@@ -91,6 +91,7 @@ typedef struct vm_event_compat {
         struct vm_event_cpuid                 cpuid;
         struct vm_event_interrupt_x86         x86_interrupt;
         struct vm_event_vmexit                vmexit;
+        struct vm_event_io_instruction        io_instruction;
     };
 
     union {

--- a/libvmi/events.c
+++ b/libvmi/events.c
@@ -488,6 +488,19 @@ status_t register_watch_domain_event(vmi_instance_t vmi, vmi_event_t *event)
     return rc;
 }
 
+status_t register_io_event(vmi_instance_t vmi, vmi_event_t *event)
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( !vmi->io_event ) {
+        rc = driver_set_io_event(vmi, 1);
+        if ( VMI_SUCCESS == rc )
+            vmi->io_event = event;
+    };
+
+    return rc;
+}
+
 status_t clear_interrupt_event(vmi_instance_t vmi, vmi_event_t *event)
 {
 
@@ -622,6 +635,20 @@ status_t clear_debug_event(vmi_instance_t vmi, vmi_event_t* UNUSED(event))
 
         if ( VMI_SUCCESS == rc )
             vmi->debug_event = NULL;
+    }
+
+    return rc;
+}
+
+status_t clear_io_event(vmi_instance_t vmi, vmi_event_t* UNUSED(event))
+{
+    status_t rc = VMI_FAILURE;
+
+    if ( vmi->io_event ) {
+        rc = driver_set_io_event(vmi, 0);
+
+        if ( VMI_SUCCESS == rc)
+            vmi->io_event = NULL;
     }
 
     return rc;
@@ -847,6 +874,9 @@ vmi_register_event(
             break;
         case VMI_EVENT_VMEXIT:
             rc = register_vmexit_event(vmi, event);
+            break;
+        case VMI_EVENT_IO:
+            rc = register_io_event(vmi, event);
             break;
         default:
             dbprint(VMI_DEBUG_EVENTS, "Unknown event type: %d\n", event->type);

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -70,6 +70,7 @@ typedef uint16_t vmi_event_type_t;
 #define VMI_EVENT_FAILED_EMULATION  10  /**< Emulation failed when requested by VMI_EVENT_RESPONSE_EMULATE */
 #define VMI_EVENT_DOMAIN_WATCH      11  /**< Watch create/destroy events */
 #define VMI_EVENT_VMEXIT            12  /**< VMEXIT */
+#define VMI_EVENT_IO                13  /**< I/O instruction event */
 
 /**
  * Max number of vcpus we can set single step on at one time for a domain
@@ -404,6 +405,13 @@ typedef struct cpuid_event {
     uint32_t _pad;
 } cpuid_event_t;
 
+typedef struct {
+    uint32_t data_size;
+    uint32_t port;
+    uint32_t input;
+    uint32_t string_ins;
+} io_event_t;
+
 #define VMI_DESCRIPTOR_IDTR           1
 #define VMI_DESCRIPTOR_GDTR           2
 #define VMI_DESCRIPTOR_LDTR           3
@@ -546,6 +554,7 @@ struct vmi_event {
         descriptor_event_t descriptor_event;
         watch_domain_event_t watch_event;
         vmexit_event_t vmexit_event;
+        io_event_t io_event;
     };
 
     /*
@@ -652,6 +661,13 @@ struct vmi_event {
         do { \
             (_event)->version = VMI_EVENTS_VERSION; \
             (_event)->type = VMI_EVENT_PRIVILEGED_CALL; \
+            (_event)->callback = _callback; \
+        } while(0)
+
+#define SETUP_IO_EVENT(_event, _callback) \
+        do { \
+            (_event)->version = VMI_EVENTS_VERSION; \
+            (_event)->type = VMI_EVENT_IO; \
             (_event)->callback = _callback; \
         } while(0)
 

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -406,10 +406,10 @@ typedef struct cpuid_event {
 } cpuid_event_t;
 
 typedef struct {
-    uint32_t data_size;
-    uint32_t port;
-    uint32_t input;
-    uint32_t string_ins;
+    uint32_t bytes;
+    uint16_t port;
+    uint8_t in;
+    uint8_t str;
 } io_event_t;
 
 #define VMI_DESCRIPTOR_IDTR           1

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -113,6 +113,15 @@ typedef enum vmi_init_error {
     VMI_INIT_ERROR_NO_CONFIG_ENTRY, /**< Configuration contained no valid entry for VM */
 } vmi_init_error_t;
 
+typedef enum firmware {
+
+    VMI_FIRMWARE_UNKNOWN, /**< Firmware type is undefined */
+
+    VMI_FIRMWARE_LEGACY, /**< Firmware type is BIOS */
+
+    VMI_FIRMWARE_UEFI /**< Firmware type is UEFI (OVMF) */
+} firmware_t;
+
 typedef enum os {
 
     VMI_OS_UNKNOWN,  /**< OS type is unknown */

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -177,6 +177,8 @@ struct vmi_instance {
 
     vmi_event_t *vmexit_event; /**< Handler of VMEXIT events */
 
+    vmi_event_t *io_event; /**< Handler of I/O events */
+
     GHashTable *interrupt_events; /**< interrupt event to function mapping (key: interrupt) */
 
     GHashTable *mem_events_on_gfn; /**< mem event to functions mapping (key: physical address) */


### PR DESCRIPTION
Hello! This PR adds support for I/O event hooking and also new accessor - `vmi_get_firmware_type`, which get firmware type of Xen VM, according to xenstore `/local/domain/<d>/hvmloader/bios` property.