### PR TITLE
Fix vmi_read_str on page boundary

### DIFF
--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -471,7 +471,7 @@ vmi_read_str(
         memcpy(&ret[len], &buf, read_len);
         len += read_len;
         ret[len] = '\0';
-        _ctx.addr += offset;
+        _ctx.addr += read_len;
     } while (read_more);
 
     return ret;


### PR DESCRIPTION
* This fixes the error with broken lines gethered with `vmi_read_str`.
* Error could be detected with Linux images.
* The error results in trash at the end of gethered string.
* The trash could be a part of string or just a binary trash.
* Sometimes this error results in very long strings with binary trash at the end.
* The error has been introduced in https://github.com/libvmi/libvmi/commit/f686145c3ad19ac52f43ec72cebab9e3bdb2edbc#diff-6fc4f1e471aeac32da0888343b0a89be62a916e7f89e919883833a620d6655d5R474
* It looks like this:
![image](https://user-images.githubusercontent.com/20656851/191059450-79ed7685-ce82-47fa-ba14-e37f2e1b288c.png)
