### PR TITLE
Return success if whole region is unmapped

### DIFF
--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -118,15 +118,15 @@ vmi_mmap_guest(
         buf_offset += vmi->page_size;
     }
 
-    if (pfn_ndx == 0) {
-        goto done;
-    }
+    void *base_ptr = NULL;
+    // do mmap only if there are pages available for mapping
+    if (pfn_ndx != 0) {
+        base_ptr = (char *) driver_mmap_guest(vmi, pfns, pfn_ndx);
 
-    void *base_ptr = (char *)driver_mmap_guest(vmi, pfns, pfn_ndx);
-
-    if (MAP_FAILED == base_ptr || NULL == base_ptr) {
-        dbprint(VMI_DEBUG_READ, "--failed to mmap guest memory");
-        goto done;
+        if (MAP_FAILED == base_ptr || NULL == base_ptr) {
+            dbprint(VMI_DEBUG_READ, "--failed to mmap guest memory");
+            goto done;
+        }
     }
 
     for (i = 0; i < num_pages; i++) {


### PR DESCRIPTION
I would like to propose to return `VMI_SUCCESS` if there are no pages to map. IMHO it shouldn't be viewed as an error, there is simply no work to be done. Otherwise it's going to be hard to distinguish between cases where `driver_mmap_guest()` returns an error or the whole region is simply not mapped.