### PR TITLE
Fix x64 windows address translation

### DIFF
--- a/libvmi/arch/amd64.c
+++ b/libvmi/arch/amd64.c
@@ -283,7 +283,7 @@ GSList* get_pages_ia32e(vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t 
             goto done;
 
         uint64_t pdpte_index;
-        for (pdpte_index = 0; pdpte_index < IA32E_ENTRIES_PER_PAGE; pdpte_index++, pdpte_location++) {
+        for (pdpte_index = 0; pdpte_index < IA32E_ENTRIES_PER_PAGE; pdpte_index++, pdpte_location += entry_size) {
 
             uint64_t pdpte_value = pdpt_page[pdpte_index];
 


### PR DESCRIPTION
On newer versions of Windows (at least Win10 1909), some higher bits of the pfn value are used as flags for transition pages. This results in libvmi returning incorrect physical addresses for transition pages. Tested with `vmi_mmap_guest()` which used to fail a lot prior to this fix.