### PR TITLE
Address to kernel symbol translation for windows

### DIFF
--- a/libvmi/json_profiles/json_profiles.c
+++ b/libvmi/json_profiles/json_profiles.c
@@ -76,7 +76,7 @@ bool json_profile_init(vmi_instance_t vmi, const char* path)
             return false;
     };
 
-    if (vmi->init_flags & VMI_INIT_SYMBOLLOOKUP) {
+    if (vmi->init_flags & VMI_INIT_V2SYM) {
         if (vmi->json.build_reverse_symbol_table == NULL) {
             dbprint(VMI_DEBUG_MISC, "Address to symbol translation not available for this json profile\n");
             return false;

--- a/libvmi/json_profiles/json_profiles.h
+++ b/libvmi/json_profiles/json_profiles.h
@@ -36,6 +36,8 @@ typedef struct json_interface {
 
     json_object *root;
 
+    GHashTable* reverse_symbol_table;
+
     status_t (*handler)(
         json_object *json,
         const char *symbol,
@@ -58,6 +60,11 @@ typedef struct json_interface {
         const char *struct_name,
         const char *struct_member,
         const char **member_type_name);
+
+    status_t
+    (*build_reverse_symbol_table)(
+        json_object *json,
+        GHashTable** table);
 
     const char* (*get_os_type)(
         vmi_instance_t vmi);

--- a/libvmi/json_profiles/volatility_ist.h
+++ b/libvmi/json_profiles/volatility_ist.h
@@ -33,6 +33,11 @@ volatility_ist_symbol_to_rva(
     addr_t *rva,
     size_t *size);
 
+status_t
+volatility_build_reverse_symbol_table(
+    json_object *json,
+    GHashTable** table);
+
 const char* volatility_get_os_type(vmi_instance_t vmi);
 
 status_t
@@ -62,6 +67,14 @@ static inline status_t volatility_ist_symbol_to_rva(
 {
     return VMI_FAILURE;
 }
+
+static inline status_t volatility_build_reverse_symbol_table(
+    json_object *json,
+    GHashTable** table)
+{
+    return VMI_FAILURE;
+}
+
 static inline const char* volatility_get_os_type(vmi_instance_t vmi)
 {
     return NULL;

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -61,6 +61,8 @@ extern "C" {
 
 #define VMI_INIT_DOMAINWATCH (1u << 4) /**< initialize using a domain watcher */
 
+#define VMI_INIT_SYMBOLLOOKUP (1u << 5) /**< initialize address to kernel symbol translation for json profiles */
+
 typedef enum vmi_mode {
 
     VMI_XEN, /**< libvmi is monitoring a Xen VM */

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -61,7 +61,7 @@ extern "C" {
 
 #define VMI_INIT_DOMAINWATCH (1u << 4) /**< initialize using a domain watcher */
 
-#define VMI_INIT_SYMBOLLOOKUP (1u << 5) /**< initialize address to kernel symbol translation for json profiles */
+#define VMI_INIT_V2SYM (1u << 5) /**< initialize address to kernel symbol translation for json profiles */
 
 typedef enum vmi_mode {
 

--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -1047,7 +1047,7 @@ windows_init(vmi_instance_t vmi, GHashTable *config)
     os_interface->os_ksym2v = windows_kernel_symbol_to_address;
     os_interface->os_usym2rva = windows_export_to_rva;
     os_interface->os_v2sym = windows_rva_to_export;
-    os_interface->os_v2ksym = NULL;
+    os_interface->os_v2ksym = windows_address_to_kernel_symbol;
     os_interface->os_read_unicode_struct = windows_read_unicode_struct;
     os_interface->os_read_unicode_struct_pm = windows_read_unicode_struct_pm;
     os_interface->os_teardown = windows_teardown;

--- a/libvmi/os/windows/windows.h
+++ b/libvmi/os/windows/windows.h
@@ -64,6 +64,10 @@ status_t
 windows_kernel_symbol_to_address(vmi_instance_t vmi, const char *symbol,
                                  addr_t *kernel_base_address, addr_t *address);
 
+char*
+windows_address_to_kernel_symbol(vmi_instance_t vmi, addr_t address,
+                                 const access_context_t *ctx);
+
 status_t windows_get_kernel_struct_offset(vmi_instance_t vmi,
         const char*  symbol, const char* member, addr_t *addr);
 


### PR DESCRIPTION
This adds translation of virtual adresses to kernel symbols based on volatility json profiles. A hash table is placed to the side of the json objects to enable lookups in the opposite direction.

The method `windows_address_to_kernel_symbol` (and its linux counterpart) expect an address parameter _and_ an access_context. This is redundant because the access_context already has an address. If it's preferred to only use the addr field from the context, I can adapt for that.