### PR TITLE
Add extraction for w string

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1293,6 +1293,19 @@ char *vmi_read_str(
     const access_context_t *ctx) NOEXCEPT;
 
 /**
+ * Reads a null terminated UTF-16 string from memory, starting at
+ * the given virtual address. The string will be converted to UTF-8.
+ * The returned value must be freed by the caller.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] ctx Access context
+ * @return String read from memory or NULL on error
+ */
+char *vmi_read_w_str(
+    vmi_instance_t vmi,
+    const access_context_t *ctx) NOEXCEPT;
+
+/**
  * Reads a Unicode string from the given address. If the guest is running
  * Windows, a UNICODE_STRING struct is read. Linux is not yet
  * supported. The returned value must be freed by the caller.


### PR DESCRIPTION
We're trying to extract PWCHARs from Windows (for example the PathToFile  from [LdrLoadDll ](http://undocumented.ntinternals.net/UserMode/Undocumented%20Functions/Executable%20Images/LdrLoadDll.html)). Since those are UTF-16 strings with [16 bit wide chars ](https://learn.microsoft.com/en-us/windows/win32/extensible-storage-engine/wchar) we can't use the vmi_read_str or the os_read_unicode_struct functions.