### PR TITLE
Fix compatibility with Xen 4.12-4.16

### DIFF
--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -91,6 +91,16 @@ static status_t sanity_check(xen_instance_t *xen)
             if ( !w->xc_monitor_vmexit )
                 break;
         /* Fall-through */
+        case 16:
+        /* Fall-through */
+        case 15:
+        /* Fall-through */
+        case 14:
+        /* Fall-through */
+        case 13:
+        /* Fall-through */
+        case 12:
+        /* Fall-through */
         case 11:
             if ( !w->xc_monitor_emul_unimplemented )
                 break;


### PR DESCRIPTION
It seems like there is an issue with the existing logic for sanity-checking features available in various versions of Xen. I have been using libvmi with Xen 4.16, but when I pulled in the latest changes from master ran into the following error while trying to run the `vmi-process-list` example program:

```bash
**The running Xen version is 4.16
Failed to find a suitable xenctrl.so!
VMI_ERROR: Could not find a live guest VM or file to use.
VMI_ERROR: Opening a live guest VM requires root access.
Failed to init LibVMI library.
```

The issue appears for me after https://github.com/libvmi/libvmi/pull/1045 was merged, which adds a feature only available in later versions of Xen. It seems like the `default:` case in the `sanity_check` function is catching any non-defined minor version numbers (such as 4.16) and then falling through to the `case 18:` check. I just added explicit case statements for each minor version before 4.17, which resolves the issue for me. 