### PR TITLE
Change xen_get_vbd_state to check for state==4 instead of state==1

### DIFF
--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -167,7 +167,7 @@ xen_put_memory(
 }
 
 /* Helper function. Read /local/domain/<domID>/device/vbd/state property.
- * If it equals "1" return true.
+ * If it equals "4" return true.
  */
 #ifndef HAVE_LIBXENSTORE
 static bool
@@ -193,7 +193,10 @@ xen_get_vbd_state(
 
     char *state = xen->libxsw.xs_read(xen->xshandle, xth, tmp, &len);
     if (state != NULL) {
-        if (!g_strcmp0(state, "1")) {
+        /* Based on xen/include/public/io/blkif.h and xen/include/public/io/xenbus.h,
+         * a state of "4" indicates that the device is connected.
+        */
+        if (!g_strcmp0(state, "4")) {
             result = true;
         }
         free(state);


### PR DESCRIPTION
I have seen an issue with the `vmi_read_disk` function when using a Xen VM with an attached disk. Currently, attempting to read from the disk results in the following error:
`VMI_ERROR: VMI_ERROR: xen_read_disk: vbd is inactive or error occured`

I believe this is due to the check on the state returned from xenstore on [this line](https://github.com/libvmi/libvmi/blob/9166fd685c45b31322b64acd370d6ce8a9990a10/libvmi/driver/xen/xen.c#L196). On my machine, this value is "4" instead of "1" for the attached disk: 
```bash
xenstore-ls /local/domain/1/device/vbd
51712 = ""
 backend = "/local/domain/0/backend/vbd/1/51712"
 backend-id = "0"
 state = "4"
 virtual-device = "51712"
 device-type = "disk"
 ring-ref = "8"
 event-channel = "3"
 protocol = "arm-abi"
 feature-persistent = "1"
```
Changing the check from `"1"` to `"4"` fixes the issue for me, but I'm not sure if this would cause problems for other deployments or use cases. 

I may not be looking in the right place in the Xen source code, but it appears that `state=="4"` corresponds to the virtual device being connected, based on what I believe are the possible values defined in [xenbus.h](https://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=xen/include/public/io/xenbus.h;h=9cd0cd7c6709694575262795d20fa8cfa4c20d0b;hb=HEAD#l19) and in the comments in [blkif.h](https://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=xen/include/public/io/blkif.h;h=22f1eef0c0ca371a8cfe3eeea99f54bec1e234c9;hb=HEAD#l468) covering the startup procedure. 

I'll mention @blsvntn  as well, since he originally implemented the functionality in https://github.com/libvmi/libvmi/pull/1010 and might have more insight than I do. 

I'm also open to alternative design suggestions, maybe `xen_get_vbd_state` could be refactored to return the state rather than a boolean? 