### PR TITLE
Adding basic support for reading an ARM64 memory dump

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -727,7 +727,7 @@ GSList* vmi_get_nested_va_pages(vmi_instance_t vmi, addr_t npt, page_mode_t npm,
         return NULL;
 
     if (!valid_pm(pm)) {
-        dbprint(VMI_DEBUG_PTLOOKUP, "Invalid or not supported paging mode during get_va_pages\n");
+        dbprint(VMI_DEBUG_PTLOOKUP, "Invalid or not supported paging mode during get_nested_va_pages\n");
         return NULL;
     }
 #endif

--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -176,7 +176,7 @@ static status_t get_vcpu_page_mode_arm(vmi_instance_t vmi, unsigned long vcpu, p
 
             pm = VMI_PM_AARCH64;
             dbprint(VMI_DEBUG_PTLOOKUP,
-                    "Found ARM64 pagemode. TTBR0 VA width: %u Page size: %u TTBR1 VA width:%u Page size: %u\n",
+                    "Found ARM64 pagemode. TTBR0 VA width: %" PRId64 " Page size: %u TTBR1 VA width:%" PRId64 " Page size: %u\n",
                     64-vmi->arm64.t0sz, vmi->arm64.tg0,
                     64-vmi->arm64.t1sz, vmi->arm64.tg1);
         }

--- a/libvmi/config/grammar.y
+++ b/libvmi/config/grammar.y
@@ -279,6 +279,11 @@ int vmi_parse_config (const char *target_name)
 %token<str>    REKALL_PROFILE
 %token<str>    VOLATILITY_PROFILE
 %token<str>    OSTYPETOK
+%token<str>    PAGEMODETOK
+%token<str>    AARCH64_TTBR0_VA_WIDTH
+%token<str>    AARCH64_TTBR0_GRANULE_SIZE
+%token<str>    AARCH64_TTBR1_VA_WIDTH
+%token<str>    AARCH64_TTBR1_GRANULE_SIZE
 %token<str>    WORD
 %token<str>    FILENAME
 %token         QUOTE
@@ -317,6 +322,16 @@ assignment:
         volatility_ist_assignment
         |
         ostype_assignment
+        |
+        pagemode_assignment
+        |
+        aarch64_ttbr0_va_width_assignment
+        |
+        aarch64_ttbr0_granule_size_assignment
+        |
+        aarch64_ttbr1_va_width_assignment
+        |
+        aarch64_ttbr1_granule_size_assignment
         |
         kpgd_assignment
         |
@@ -659,6 +674,53 @@ ostype_assignment:
             snprintf(tmp_str, CONFIG_STR_LENGTH, "%s", $4);
             char* os_type_str = strndup(tmp_str, CONFIG_STR_LENGTH);
             g_hash_table_insert(tmp_entry, $1, os_type_str);
+            free($4);
+        }
+        ;
+pagemode_assignment:
+        PAGEMODETOK EQUALS QUOTE WORD QUOTE
+        {
+            snprintf(tmp_str, CONFIG_STR_LENGTH, "%s", $4);
+            char* pagemode_str = strndup(tmp_str, CONFIG_STR_LENGTH);
+            g_hash_table_insert(tmp_entry, $1, pagemode_str);
+            free($4);
+        }
+        ;
+aarch64_ttbr0_va_width_assignment:
+        AARCH64_TTBR0_VA_WIDTH EQUALS NUM
+        {
+            uint64_t tmp = strtoull($3, NULL, 0);
+            uint64_t *tmp_ptr = malloc(sizeof(uint64_t));
+            (*tmp_ptr) = tmp;
+            g_hash_table_insert(tmp_entry, $1, tmp_ptr);
+            free($3);
+        }
+        ;
+aarch64_ttbr0_granule_size_assignment:
+        AARCH64_TTBR0_GRANULE_SIZE EQUALS QUOTE WORD QUOTE
+        {
+            snprintf(tmp_str, CONFIG_STR_LENGTH, "%s", $4);
+            char* aarch64_ttbr0_granule_size_str = strndup(tmp_str, CONFIG_STR_LENGTH);
+            g_hash_table_insert(tmp_entry, $1, aarch64_ttbr0_granule_size_str);
+            free($4);
+        }
+        ;
+aarch64_ttbr1_va_width_assignment:
+        AARCH64_TTBR1_VA_WIDTH EQUALS NUM
+        {
+            uint64_t tmp = strtoull($3, NULL, 0);
+            uint64_t *tmp_ptr = malloc(sizeof(uint64_t));
+            (*tmp_ptr) = tmp;
+            g_hash_table_insert(tmp_entry, $1, tmp_ptr);
+            free($3);
+        }
+        ;
+aarch64_ttbr1_granule_size_assignment:
+        AARCH64_TTBR1_GRANULE_SIZE EQUALS QUOTE WORD QUOTE
+        {
+            snprintf(tmp_str, CONFIG_STR_LENGTH, "%s", $4);
+            char* aarch64_ttbr1_granule_size_str = strndup(tmp_str, CONFIG_STR_LENGTH);
+            g_hash_table_insert(tmp_entry, $1, aarch64_ttbr1_granule_size_str);
             free($4);
         }
         ;

--- a/libvmi/config/lexicon.l
+++ b/libvmi/config/lexicon.l
@@ -45,34 +45,39 @@ extern void BeginToken (char *t);
 %option nounput
 
 %%
-kpgd                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return KPGD; }
-linux_tasks             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_TASKS; }
-linux_mm                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_MM; }
-linux_name              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_NAME; }
-linux_pid               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PID; }
-linux_pgd               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PGD; }
-linux_addr              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_ADDR; }
-linux_init_task         { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_INIT_TASK; }
-linux_kaslr             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_KASLR; }
-win_ntoskrnl            { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL; }
-win_ntoskrnl_va         { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL_VA; }
-win_tasks               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_TASKS; }
-win_pdbase              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PDBASE; }
-win_pid                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PID; }
-win_pname               { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PNAME; }
-win_kdvb                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KDVB; }
-win_kdbg                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KDBG; }
-win_kpcr                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KPCR; }
-win_sysproc             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_SYSPROC; }
-freebsd_name            { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_NAME; }
-freebsd_pid             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_PID; }
-freebsd_vmspace         { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_VMSPACE; }
-freebsd_pmap            { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_PMAP; }
-freebsd_pgd             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_PGD; }
-sysmap                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return SYSMAPTOK; }
-rekall_profile          { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return REKALL_PROFILE; }
-volatility_ist          { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return VOLATILITY_PROFILE; }
-ostype                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return OSTYPETOK; }
+kpgd                        { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return KPGD; }
+linux_tasks                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_TASKS; }
+linux_mm                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_MM; }
+linux_name                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_NAME; }
+linux_pid                   { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PID; }
+linux_pgd                   { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_PGD; }
+linux_addr                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_ADDR; }
+linux_init_task             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_INIT_TASK; }
+linux_kaslr                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return LINUX_KASLR; }
+win_ntoskrnl                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL; }
+win_ntoskrnl_va             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_NTOSKRNL_VA; }
+win_tasks                   { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_TASKS; }
+win_pdbase                  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PDBASE; }
+win_pid                     { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PID; }
+win_pname                   { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_PNAME; }
+win_kdvb                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KDVB; }
+win_kdbg                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KDBG; }
+win_kpcr                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_KPCR; }
+win_sysproc                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return WIN_SYSPROC; }
+freebsd_name                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_NAME; }
+freebsd_pid                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_PID; }
+freebsd_vmspace             { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_VMSPACE; }
+freebsd_pmap                { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_PMAP; }
+freebsd_pgd                 { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return FREEBSD_PGD; }
+sysmap                      { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return SYSMAPTOK; }
+rekall_profile              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return REKALL_PROFILE; }
+volatility_ist              { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return VOLATILITY_PROFILE; }
+ostype                      { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return OSTYPETOK; }
+pagemode                    { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return PAGEMODETOK; }
+aarch64_ttbr0_va_width      { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return AARCH64_TTBR0_VA_WIDTH; }
+aarch64_ttbr0_granule_size  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return AARCH64_TTBR0_GRANULE_SIZE; }
+aarch64_ttbr1_va_width      { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return AARCH64_TTBR1_VA_WIDTH; }
+aarch64_ttbr1_granule_size  { BeginToken(yytext); yylval.str = strndup(yytext, CONFIG_STR_LENGTH); return AARCH64_TTBR1_GRANULE_SIZE; }
 0x[0-9a-fA-F]+|[0-9]+   {
     BeginToken(yytext);
     yylval.str = strdup(yytext);

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -826,7 +826,9 @@ GHashTable *init_config(vmi_instance_t vmi, vmi_config_t config_mode, void *conf
         vmi->page_mode = get_pagemode_from_config(_config);
     }
 
-    g_hash_table_foreach(_config, (GHFunc)read_config_aarch64_entries, vmi);
+    if (VMI_PM_AARCH64 == vmi->page_mode) {
+        g_hash_table_foreach(_config, (GHFunc)read_config_aarch64_entries, vmi);
+    }
 
     return _config;
 }

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -289,6 +289,94 @@ set_os_type_from_config(
     return ret;
 }
 
+static page_mode_t
+get_pagemode_from_config(
+    GHashTable *configtbl)
+{
+    const char *cfg_pagemode = NULL;
+    page_mode_t vmi_page_mode = VMI_PM_UNKNOWN;
+
+    cfg_pagemode = g_hash_table_lookup(configtbl, "pagemode");
+    if (!cfg_pagemode) {
+        dbprint(VMI_DEBUG_CORE, "**no pagemode found in config file.\n");
+        return vmi_page_mode;
+    }
+
+    if (!strcmp(cfg_pagemode, "VMI_PM_LEGACY")) {
+        vmi_page_mode = VMI_PM_LEGACY;
+    } else if (!strcmp(cfg_pagemode,"VMI_PM_PAE")) {
+        vmi_page_mode = VMI_PM_PAE;
+    } else if (!strcmp(cfg_pagemode, "VMI_PM_IA32E")) {
+        vmi_page_mode = VMI_PM_IA32E;
+    } else if (!strcmp(cfg_pagemode, "VMI_PM_AARCH32")) {
+        vmi_page_mode = VMI_PM_AARCH32;
+    } else if (!strcmp(cfg_pagemode, "VMI_PM_AARCH64")) {
+        vmi_page_mode = VMI_PM_AARCH64;
+    } else if (!strcmp(cfg_pagemode, "VMI_PM_EPT_4L")) {
+        vmi_page_mode = VMI_PM_EPT_4L;
+    } else if (!strcmp(cfg_pagemode, "VMI_PM_EPT_5L")) {
+        vmi_page_mode = VMI_PM_EPT_5L;
+    } else {
+        errprint("VMI_ERROR: Unknown pagemode type specified in config: %s\n",
+                 cfg_pagemode);
+    }
+    return vmi_page_mode;
+}
+
+page_size_t get_page_size_from_string(char *page_size_string)
+{
+    if (strcmp(page_size_string, "VMI_PS_1KB") == 0) {
+        return VMI_PS_1KB;
+    } else if (strcmp(page_size_string, "VMI_PS_4KB") == 0) {
+        return VMI_PS_4KB;
+    } else if (strcmp(page_size_string, "VMI_PS_16KB") == 0) {
+        return VMI_PS_16KB;
+    } else if (strcmp(page_size_string, "VMI_PS_64KB") == 0) {
+        return VMI_PS_64KB;
+    } else if (strcmp(page_size_string, "VMI_PS_1MB") == 0) {
+        return VMI_PS_1MB;
+    } else if (strcmp(page_size_string, "VMI_PS_2MB") == 0) {
+        return VMI_PS_2MB;
+    } else if (strcmp(page_size_string, "VMI_PS_4MB") == 0) {
+        return VMI_PS_4MB;
+    } else if (strcmp(page_size_string, "VMI_PS_16MB") == 0) {
+        return VMI_PS_16MB;
+    } else if (strcmp(page_size_string, "VMI_PS_32MB") == 0) {
+        return VMI_PS_32MB;
+    } else if (strcmp(page_size_string, "VMI_PS_512MB") == 0) {
+        return VMI_PS_512MB;
+    } else if (strcmp(page_size_string, "VMI_PS_1GB") == 0) {
+        return VMI_PS_1GB;
+    } else {
+        errprint("VMI_ERROR: Unknown page size specified in config: %s\n",
+                 page_size_string);
+        return VMI_PS_UNKNOWN;
+    }
+}
+
+void read_config_aarch64_entries(char* key, gpointer value, vmi_instance_t vmi)
+{
+    if (strncmp(key, "aarch64_ttbr0_va_width", CONFIG_STR_LENGTH) == 0) {
+        vmi->arm64.t0sz = 64 - *(uint64_t *)value;
+        return;
+    }
+
+    if (strncmp(key, "aarch64_ttbr0_granule_size", CONFIG_STR_LENGTH) == 0) {
+        vmi->arm64.tg0 = get_page_size_from_string(value);
+        return;
+    }
+
+    if (strncmp(key, "aarch64_ttbr1_va_width", CONFIG_STR_LENGTH) == 0) {
+        vmi->arm64.t1sz = 64 - *(uint64_t *)value;
+        return;
+    }
+
+    if (strncmp(key, "aarch64_ttbr1_granule_size", CONFIG_STR_LENGTH) == 0) {
+        vmi->arm64.tg1 = get_page_size_from_string(value);
+        return;
+    }
+}
+
 static inline status_t
 init_page_offset(
     vmi_instance_t vmi)
@@ -733,6 +821,12 @@ GHashTable *init_config(vmi_instance_t vmi, vmi_config_t config_mode, void *conf
         return NULL;
     }
 
+    if (VMI_PM_UNKNOWN == vmi->page_mode) {
+        vmi->page_mode = get_pagemode_from_config(_config);
+    }
+
+    g_hash_table_foreach(_config, (GHFunc)read_config_aarch64_entries, vmi);
+
     return _config;
 }
 
@@ -777,6 +871,7 @@ os_t vmi_init_os(
 
         goto error_exit;
     }
+
 
     /* setup OS specific stuff */
     switch ( vmi->os_type ) {

--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -35,6 +35,7 @@
 #include <pwd.h>
 #include <unistd.h>
 
+#include "config/config_parser.h"
 #include "private.h"
 #include "driver/driver_wrapper.h"
 #include "driver/memory_cache.h"

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -60,7 +60,7 @@ file_get_memory(
 {
     void *memory = 0;
 
-    if (paddr + length >= vmi->max_physical_address) {
+    if (paddr + length > vmi->max_physical_address) {
         dbprint
         (VMI_DEBUG_FILE, "--%s: request for PA range [0x%.16"PRIx64"-0x%.16"PRIx64"] reads past end of file\n",
          __FUNCTION__, paddr, paddr + length);

--- a/libvmi/os/linux/core.c
+++ b/libvmi/os/linux/core.c
@@ -125,8 +125,7 @@ static status_t linux_filemode_32bit_init(vmi_instance_t vmi,
         addr_t pa, addr_t va)
 {
     addr_t test = 0;
-    if (vmi->page_mode != VMI_PM_UNKNOWN)
-    {
+    if (vmi->page_mode != VMI_PM_UNKNOWN) {
         if (VMI_SUCCESS == arch_init(vmi)) {
             if ( VMI_SUCCESS == vmi_pagetable_lookup(vmi, swapper_pg_dir - boundary, va, &test) &&
                     test == pa) {

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -105,9 +105,9 @@ struct vmi_instance {
         } x86;
 
         struct {
-            int t0sz;           /**< TTBR0 VA size (2^(64-t0sz)) */
+            uint64_t t0sz;           /**< TTBR0 VA size (2^(64-t0sz)) */
 
-            int t1sz;           /**< TTBR1 VA size (2^(64-t1sz)) */
+            uint64_t t1sz;           /**< TTBR1 VA size (2^(64-t1sz)) */
 
             page_size_t tg0;    /**< TTBR0 granule size: 4KB/16KB/64KB */
 


### PR DESCRIPTION
This pull request adds/fixes support for LibVMI operating on a memory dump taken from an ARM64 VM. Some of the necessary support was already in LibVMI, so most of my changes are bugfixes for existing code and adding support for specifying the page mode and a couple of values that are involved in address translation. With these changes, I can take a memory dump of a running Xen guest using the included  `dump-memory.c` on-target and then run `process-list.c` with the file on my x86 laptop to get a list of running processes. 

This does feel a little hacky, so I'm open to any feedback/suggestions on changes that could make this better. I added some new fields to the configuration file, but I'm not sure if the names or where they're being parsed in the code make the most sense. 

Example config:
```bash
mem_dump {
    ostype = "Linux";
    sysmap = "/home/user/System.map-5.15.36-xilinx-v2022.2";
    pagemode = "VMI_PM_AARCH64";
    aarch64_ttbr0_va_width = 48;
    aarch64_ttbr0_granule_size = "VMI_PS_4KB";
    aarch64_ttbr1_va_width = 48;
    aarch64_ttbr1_granule_size = "VMI_PS_4KB";
    linux_name = 0x5b0;
    linux_tasks = 0x2e8;
    linux_mm = 0x338;
    linux_pid = 0x3f0;
    linux_pgd = 0x40;
}
```

Process list output:
```bash
./vmi-process-list ~/mem_dump
VMI_WARNING: Looking for kernel PGD and KASLR with slowest available technique
Process listing for file /home/user/mem_dump
[    0] swapper/0 (struct addr:ffff8000093c4e80)
[    1] systemd (struct addr:ffff000001854d80)
[    2] kthreadd (struct addr:ffff000001854040)
[    3] rcu_gp (struct addr:ffff000001894dc0)
[    4] rcu_par_gp (struct addr:ffff000001894080)
[    5] netns (struct addr:ffff000001898e00)
[    6] kworker/0:0 (struct addr:ffff0000018980c0)
[    7] kworker/0:0H (struct addr:ffff00000189ae40)
[    8] kworker/u2:0 (struct addr:ffff00000189a100)
[    9] mm_percpu_wq (struct addr:ffff0000018a0e80)
[   10] ksoftirqd/0 (struct addr:ffff0000018a0140)
[   11] rcu_sched (struct addr:ffff0000018a8ec0)
[   12] migration/0 (struct addr:ffff0000018a8180)
[   13] cpuhp/0 (struct addr:ffff0000018aaf00)
[   14] kdevtmpfs (struct addr:ffff0000018aa1c0)
[   15] inet_frag_wq (struct addr:ffff0000018aef40)
[   16] kworker/0:1 (struct addr:ffff0000018ae200)
[   17] kauditd (struct addr:ffff00000187ef80)
[   18] oom_reaper (struct addr:ffff00000187e240)
[   19] writeback (struct addr:ffff0000019a6fc0)
[   20] kcompactd0 (struct addr:ffff0000019a6280)
[   21] khugepaged (struct addr:ffff0000019ab000)
[   42] cryptd (struct addr:ffff0000019b0300)
[   71] kblockd (struct addr:ffff0000019aa2c0)
[   72] blkcg_punt_bio (struct addr:ffff0000019b1040)
[   73] xen-balloon (struct addr:ffff0000019cc540)
[   74] kworker/u2:1 (struct addr:ffff0000019cd280)
[   75] tpm_dev_wq (struct addr:ffff0000019d2500)
[   76] edac-poller (struct addr:ffff0000019ca000)
[   77] watchdogd (struct addr:ffff0000019b50c0)
[   78] rpciod (struct addr:ffff000001b16d80)
[   79] kworker/0:1H (struct addr:ffff0000019b4380)
[   80] kworker/u3:0 (struct addr:ffff0000019bb140)
[   81] xprtiod (struct addr:ffff0000019b63c0)
[  178] kswapd0 (struct addr:ffff00000209b200)
[  179] ecryptfs-kthrea (struct addr:ffff000001b38dc0)
[  180] nfsiod (struct addr:ffff0000019b7100)
[  182] xenbus (struct addr:ffff000002094440)
[  183] xenwatch (struct addr:ffff00000209d1c0)
[  184] khvcd (struct addr:ffff000001b16040)
[  185] uas (struct addr:ffff00000209c480)
[  186] kpktgend_0 (struct addr:ffff000001b323c0)
[  187] mld (struct addr:ffff000002095180)
[  188] ipv6_addrconf (struct addr:ffff000002089040)
[  189] krfcommd (struct addr:ffff000001b33100)
[  190] jbd2/xvda1-8 (struct addr:ffff00000208e340)
[  191] ext4-rsv-conver (struct addr:ffff00000208c380)
[  210] rpcbind (struct addr:ffff0000019bd180)
[  218] kworker/u2:2 (struct addr:ffff000002088300)
[  228] haveged (struct addr:ffff00000208f080)
[  229] kpktgend_0 (struct addr:ffff00000209a4c0)
[  230] systemd-journal (struct addr:ffff000002090040)
[  231] systemd-udevd (struct addr:ffff0000019bc440)
[  236] systemd-network (struct addr:ffff000002090d80)
[  246] systemd-timesyn (struct addr:ffff0000019d3240)
[  377] klogd (struct addr:ffff000002097140)
[  378] syslogd (struct addr:ffff000002163280)
[  379] dbus-daemon (struct addr:ffff0000019be480)
[  381] systemd-logind (struct addr:ffff000002096400)
[  383] systemd-resolve (struct addr:ffff000002162540)
[  384] rpc.statd (struct addr:ffff0000019cad40)
[  390] inetd (struct addr:ffff00000208d0c0)
[  397] tcf-agent (struct addr:ffff000001b46f00)
[  398] agetty (struct addr:ffff000001b42200)
[  404] systemd-userdbd (struct addr:ffff000001b50240)
[  405] systemd-userwor (struct addr:ffff000001b42f40)
[  406] systemd-userwor (struct addr:ffff000001b4efc0)
[  407] systemd-userwor (struct addr:ffff00000717c0c0)
[  425] agetty (struct addr:ffff0000019bf1c0)
```

This at least partially resolves https://github.com/libvmi/libvmi/issues/1057