### PR TITLE
Add support of Prototype PTEs in V2P translation on Windows

### DIFF
--- a/libvmi/arch/amd64.c
+++ b/libvmi/arch/amd64.c
@@ -230,6 +230,14 @@ status_t v2p_ia32e (vmi_instance_t vmi,
         goto done;
 
     if (!ENTRY_PRESENT(vmi->x86.transition_pages, info->x86_ia32e.pte_value)) {
+
+        if (vmi->os_type == VMI_OS_WINDOWS && PROTOTYPE(info->x86_ia32e.pte_value))
+        {
+            addr_t vaddr_proto = 0xFFFF000000000000ull | (info->x86_ia32e.pte_value >> 16);
+            dbprint(VMI_DEBUG_PTLOOKUP, "--PTLookup: prototype PTe, lookup addr = 0x%.16"PRIx64"\n", vaddr_proto);
+            return v2p_ia32e(vmi, npt, npm, pt, vaddr_proto, info);
+        }
+
         status = VMI_FAILURE;
         goto done;
     }


### PR DESCRIPTION
[Prototype PTEs](https://codemachine.com/articles/prototype_ptes.html) are not currently supported, and we unable to translate some VAs to PAs on Windows:
```
--PTLookup: lookup addr = 0x00007ff8d1f4b000
--PTLookup: npt = 0x0000000000000000 npm = 0
--PTLookup: pt = 0x000000016e800002
--PTLookup: pml4e_location = 0x000000016e8007f8
--PTLookup: pml4e_value = 0x0a000001688c8867
--PTLookup: pdpte_location = 0x00000001688c8f18
--PTLookup: pdpte_value = 0x0a00000177fdd867
--PTLookup: pde_location = 0x0000000177fdd478
--PTLookup: pde_value= 0x0a0000016d9de867
--PTLookup: pte_location = 0x000000016d9dea58
--PTLookup: pte_value = 0x8e00d8c69a680400
*FAIL*
--PTLookup: paddr = 0x0000000000000000
```

However, at the moment the physical memory of this VA is available (not paged out):
```
0: kd> !vtop 16e800000 0x00007ff8d1f4b000
Amd64VtoP: Virt 00007ff8d1f4b000, pagedir 000000016e800000
Amd64VtoP: PML4E 000000016e8007f8
Amd64VtoP: PDPE 00000001688c8f18
Amd64VtoP: PDE 0000000177fdd478
Amd64VtoP: PTE 000000016d9dea58
Amd64VtoP: Virt ffff8e00d8c69a68, pagedir 000000016e800000
Amd64VtoP: PML4E 000000016e8008e0
Amd64VtoP: PDPE 0000000181586018
Amd64VtoP: PDE 0000000181587630
Amd64VtoP: PTE 000000017e16f348
Amd64VtoP: Mapped phys 000000015e514a68
Amd64VtoP: Mapped phys 0000000162685000
Virtual address 7ff8d1f4b000 translates to physical address 162685000.
0: kd> !pte 0x00007ff8d1f4b000
                                           VA 00007ff8d1f4b000
PXE at FFFFB65B2D96C7F8    PPE at FFFFB65B2D8FFF18    PDE at FFFFB65B1FFE3478    PTE at FFFFB63FFC68FA58
contains 0A000001688C8867  contains 0A00000177FDD867  contains 0A0000016D9DE867  contains 8E00D8C69A680400
pfn 1688c8    ---DA--UWEV  pfn 177fdd    ---DA--UWEV  pfn 16d9de    ---DA--UWEV  not valid
                                                                                  Proto: FFFF8E00D8C69A68

0: kd> dt _HARDWARE_PTE 0xffffb63ffc68fa58
nt!_HARDWARE_PTE
   +0x000 Valid            : 0y0
   +0x000 Write            : 0y0
   +0x000 Owner            : 0y0
   +0x000 WriteThrough     : 0y0
   +0x000 CacheDisable     : 0y0
   +0x000 Accessed         : 0y0
   +0x000 Dirty            : 0y0
   +0x000 LargePage        : 0y0
   +0x000 Global           : 0y0
   +0x000 CopyOnWrite      : 0y0
   +0x000 Prototype        : 0y1
   +0x000 reserved0        : 0y0
   +0x000 PageFrameNumber  : 0y110110001100011010011010011010000000 (0xd8c69a680)
   +0x000 reserved1        : 0y0000
   +0x000 SoftwareWsIndex  : 0y00011100000 (0xe0)
   +0x000 NoExecute        : 0y1
```

The patch allows to get PA as the Windows kernel does, i.e. without having to insert PF for further translation.