### PR TITLE
Ensure AArch64 third level descriptor is valid prior to returning address translation

### DIFF
--- a/libvmi/arch/arm_aarch64.c
+++ b/libvmi/arch/arm_aarch64.c
@@ -269,6 +269,14 @@ status_t v2p_aarch64 (vmi_instance_t vmi,
                             "--ARM AArch64 4kb PTLookup: tld_value = 0x%"PRIx64"\n",
                             info->arm_aarch64.tld_value);
 
+                    // Based on the ARM Architecture Reference Manual section D8.3,
+                    // third-level descriptors are only valid if the first two bits are 1
+                    if ((info->arm_aarch64.tld_value & VMI_BIT_MASK(0,1)) != 0b11) {
+                        dbprint(VMI_DEBUG_PTLOOKUP,
+                                "--ARM AArch64 4kb PTLookup: Invalid third-level descriptor");
+                        goto done;
+                    }
+
                     info->size = VMI_PS_4KB;
                     info->paddr = (info->arm_aarch64.tld_value & VMI_BIT_MASK(12,47)) | (vaddr & VMI_BIT_MASK(0,11));
                     status = VMI_SUCCESS;
@@ -294,6 +302,14 @@ status_t v2p_aarch64 (vmi_instance_t vmi,
                     dbprint(VMI_DEBUG_PTLOOKUP,
                             "--ARM AArch64 64kb PTLookup: tld_value = 0x%"PRIx64"\n",
                             info->arm_aarch64.tld_value);
+
+                    // Based on the ARM Architecture Reference Manual section D8.3,
+                    // third-level descriptors are only valid if the first two bits are 1
+                    if ((info->arm_aarch64.tld_value & VMI_BIT_MASK(0,1)) != 0b11) {
+                        dbprint(VMI_DEBUG_PTLOOKUP,
+                                "--ARM AArch64 64kb PTLookup: Invalid third-level descriptor");
+                        goto done;
+                    }
 
                     info->size = VMI_PS_4KB;
                     info->paddr = (info->arm_aarch64.tld_value & VMI_BIT_MASK(16,47)) | (vaddr & VMI_BIT_MASK(0,15));


### PR DESCRIPTION
This merge request fixes an issue in the virtual to physical address translation for the AArch64 architecture. When parsing the translation tables, the descriptors for the zero, first, and second levels are validated, but the third level descriptor is not. However, based on the ARM Documentation (https://developer.arm.com/documentation/ddi0487/ja/?lang=en) section D8.3, the third level descriptor is only valid if the first two bits are 1 (screenshot for reference): 
![image](https://github.com/libvmi/libvmi/assets/16725429/463d2805-16d5-45aa-b001-c895355ef851)
 
I discovered this issue when running LibVMI on a memory dump file from a Xen AArch64 guest, where the third level descriptor was read as all zeros. This was being incorrectly interpreted as indicating a physical address of 0. This issue was masked on-target because the Xen driver's `xc_map_foreign_range` call (at https://github.com/libvmi/libvmi/blob/master/libvmi/driver/xen/xen.c#L52) will fail if it gets an invalid physical address. However, if using LibVMIon a memory dump file, the read will succeed because the `file_get_memory` function is just validating that the address is within bounds of the file. 