### PR TITLE
Add alternative memory mapping API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -263,7 +263,8 @@ endif
                        examples/breakpoint-emulate-example \
                        examples/read-disk-example \
                        examples/io-event-example \
-                       examples/switch-view-example
+                       examples/switch-view-example \
+                       examples/memory-mapping-example
 
     examples_map_symbol_SOURCES = examples/map-symbol.c
     examples_map_addr_SOURCES = examples/map-addr.c
@@ -278,6 +279,7 @@ endif
     examples_read_disk_example_SOURCES = examples/read-disk-example.c
     examples_io_event_example_SOURCES = examples/io-event-example.c
     examples_switch_view_example_SOURCES = examples/switch-view-example.c
+    examples_memory_mapping_example_SOURCES = examples/memory-mapping-example.c
 
     noinst_PROGRAMS += examples/va-pages
     examples_va_pages_SOURCES = examples/va-pages.c

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -71,6 +71,9 @@ target_link_libraries(vmi-module-list vmi_shared)
 add_executable(switch-view-example switch-view-example.c)
 target_link_libraries(switch-view-example vmi_shared)
 
+add_executable(memory-mapping-example memory-mapping-example.c)
+target_link_libraries(memory-mapping-example vmi_shared)
+
 if (ENABLE_WINDOWS)
     add_executable(vmi-win-guid win-guid.c)
     target_link_libraries(vmi-win-guid vmi_shared)

--- a/examples/memory-mapping-example.c
+++ b/examples/memory-mapping-example.c
@@ -1,0 +1,77 @@
+#include <libvmi/libvmi.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+int main(int argc, char **argv)
+{
+    vmi_instance_t vmi = {0};
+    vmi_init_data_t *init_data = NULL;
+    int retcode = 1;
+    mapped_regions_t mapping = {0};
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <vmname> [<socket>]\n", argv[0]);
+        return retcode;
+    }
+
+    char *name = argv[1];
+
+    if (argc == 3) {
+        char *path = argv[2];
+
+        // fill init_data
+        init_data = malloc(sizeof(vmi_init_data_t) + sizeof(vmi_init_data_entry_t));
+        init_data->count = 1;
+        init_data->entry[0].type = VMI_INIT_DATA_KVMI_SOCKET;
+        init_data->entry[0].data = strdup(path);
+    }
+
+    vmi_init_error_t init_error;
+
+    // initialize the libvmi library
+    if (VMI_FAILURE ==
+            vmi_init_complete(&vmi, name, VMI_INIT_DOMAINNAME, init_data,
+                              VMI_CONFIG_GLOBAL_FILE_ENTRY, NULL, &init_error)) {
+        printf("Failed to init LibVMI library. error: %d\n", init_error);
+        goto cleanup;
+    }
+
+    access_context_t accessContext = {0};
+    accessContext.version = ACCESS_CONTEXT_VERSION;
+    accessContext.translate_mechanism = VMI_TM_PROCESS_PID;
+    accessContext.pid = 0;
+    accessContext.addr = 0;
+
+    // map the whole kernel address space
+    if (vmi_mmap_guest_2(vmi, &accessContext, -1, PROT_READ, &mapping) == VMI_FAILURE) {
+        printf("Unable to map guest memory\n");
+        goto cleanup;
+    }
+    
+    if (mapping.size == 0) {
+        printf("No pages found in given range\n");
+        goto cleanup;
+    }
+
+    printf("Contiguous regions:\n");
+    for (size_t i = 0; i < mapping.size; ++i) {
+        printf("%zu: 0x%"PRIx64", num_pages: %zu\n", i, mapping.regions[i].start_va, mapping.regions[i].num_pages);
+    }
+
+    retcode = 0;
+
+cleanup:
+    vmi_free_mapped_regions(vmi, &mapping);
+
+    // cleanup any memory associated with the libvmi instance
+    vmi_destroy(vmi);
+
+    if (init_data) {
+        free(init_data->entry[0].data);
+        free(init_data);
+    }
+
+    return retcode;
+}

--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -759,6 +759,21 @@ GSList* vmi_get_va_pages(vmi_instance_t vmi, addr_t dtb)
     return vmi->arch_interface.get_pages[vmi->page_mode](vmi, 0, 0, dtb);
 }
 
+GSList* vmi_get_va_pages_subset(vmi_instance_t vmi, addr_t dtb, addr_t start, addr_t end)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi)
+        return NULL;
+
+    if (!vmi->arch_interface.get_pages[vmi->page_mode]) {
+        dbprint(VMI_DEBUG_PTLOOKUP, "Invalid or not supported paging mode during get_va_pages\n");
+        return NULL;
+    }
+#endif
+
+    return vmi->arch_interface.get_pages_subset[vmi->page_mode](vmi, 0, 0, dtb, start, end);
+}
+
 GSList* vmi_get_nested_va_pages(vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t pt, page_mode_t pm)
 {
 #ifdef ENABLE_SAFETY_CHECKS
@@ -775,6 +790,24 @@ GSList* vmi_get_nested_va_pages(vmi_instance_t vmi, addr_t npt, page_mode_t npm,
 #endif
 
     return vmi->arch_interface.get_pages[pm](vmi, npt, npm, pt);
+}
+
+GSList* vmi_get_nested_va_pages_subset(vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t pt, page_mode_t pm, addr_t start, addr_t end)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi)
+        return NULL;
+
+    if (valid_npm(npm) && !npt)
+        return NULL;
+
+    if (!valid_pm(pm)) {
+        dbprint(VMI_DEBUG_PTLOOKUP, "Invalid or not supported paging mode during get_va_pages\n");
+        return NULL;
+    }
+#endif
+
+    return vmi->arch_interface.get_pages_subset[pm](vmi, npt, npm, pt, start, end);
 }
 
 status_t

--- a/libvmi/arch/amd64.h
+++ b/libvmi/arch/amd64.h
@@ -28,6 +28,7 @@
 #include "private.h"
 
 status_t v2p_ia32e (vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t pt, addr_t vaddr, page_info_t *info);
-GSList* get_pages_ia32e(vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t dtb);
+GSList *get_pages_ia32e_subset(vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t dtb, addr_t start, addr_t end);
+GSList *get_pages_ia32e(vmi_instance_t vmi, addr_t npt, page_mode_t npm, addr_t dtb);
 
 #endif

--- a/libvmi/arch/arch_interface.c
+++ b/libvmi/arch/arch_interface.c
@@ -227,6 +227,8 @@ void arch_init_lookup_tables(vmi_instance_t vmi)
     vmi->arch_interface.get_pages[VMI_PM_PAE] = get_pages_pae;
     vmi->arch_interface.get_pages[VMI_PM_IA32E] = get_pages_ia32e;
     vmi->arch_interface.get_pages[VMI_PM_EPT_4L] = get_pages_ept_4l;
+
+    vmi->arch_interface.get_pages_subset[VMI_PM_IA32E] = get_pages_ia32e_subset;
 }
 
 status_t arch_init(vmi_instance_t vmi)

--- a/libvmi/arch/arch_interface.h
+++ b/libvmi/arch/arch_interface.h
@@ -35,10 +35,18 @@ typedef GSList* (*arch_get_pages_t)
  addr_t npt,
  page_mode_t npm,
  addr_t dtb);
+typedef GSList* (*arch_get_pages_subset_t)
+(vmi_instance_t vmi,
+ addr_t npt,
+ page_mode_t npm,
+ addr_t dtb,
+ addr_t start,
+ addr_t end);
 
 typedef struct arch_interface {
     arch_lookup_t lookup[VMI_PM_EPT_5L + 1];
     arch_get_pages_t get_pages[VMI_PM_EPT_5L + 1];
+    arch_get_pages_subset_t get_pages_subset[VMI_PM_EPT_5L + 1];
 } arch_interface_t;
 
 status_t get_vcpu_page_mode(vmi_instance_t vmi, unsigned long vcpu, page_mode_t *out_pm);

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -121,11 +121,12 @@ typedef struct driver_interface {
     void *(*read_page_ptr) (
         vmi_instance_t,
         addr_t);
-    void *(*mmap_guest) (
+    status_t (*mmap_guest) (
         vmi_instance_t,
         unsigned long *,
         unsigned int,
-        int);
+        int,
+        void **);
     status_t (*write_ptr) (
         vmi_instance_t,
         addr_t,

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -379,21 +379,22 @@ driver_read_page(
     return vmi->driver.read_page_ptr(vmi, page);
 }
 
-static inline void *
+static inline status_t
 driver_mmap_guest(
     vmi_instance_t vmi,
     unsigned long *pfns,
     unsigned int size,
-    int prot)
+    int prot,
+    void **access_ptr)
 {
 #ifdef ENABLE_SAFETY_CHECKS
     if (!vmi->driver.initialized || !vmi->driver.mmap_guest) {
         dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_mmap_guest function not implemented.\n");
-        return NULL;
+        return VMI_FAILURE;
     }
 #endif
 
-    return vmi->driver.mmap_guest(vmi, pfns, size, prot);
+    return vmi->driver.mmap_guest(vmi, pfns, size, prot, access_ptr);
 }
 
 static inline status_t

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -2874,15 +2874,23 @@ xen_read_page(
     return memory_cache_insert(vmi, paddr);
 }
 
-void *
+status_t
 xen_mmap_guest(
     vmi_instance_t vmi,
     unsigned long *pfns,
     unsigned int size,
-    int prot)
+    int prot,
+    void **access_ptr)
 {
     xen_instance_t *xen = xen_get_instance(vmi);
-    return xen->libxcw.xc_map_foreign_pages(xen->xchandle, xen->domainid, prot, pfns, size);
+    *access_ptr = xen->libxcw.xc_map_foreign_pages(xen->xchandle, xen->domainid, prot, pfns, size);
+
+    if (MAP_FAILED == *access_ptr || NULL == *access_ptr) {
+        dbprint(VMI_DEBUG_XEN, "--xen_mmap_guest: failed to mmap guest memory");
+        return VMI_FAILURE;
+    }
+
+    return VMI_SUCCESS;
 }
 
 status_t

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -156,11 +156,12 @@ status_t xen_free_gfn(
 void *xen_read_page(
     vmi_instance_t vmi,
     addr_t page);
-void *xen_mmap_guest(
+status_t xen_mmap_guest(
     vmi_instance_t vmi,
     unsigned long *pfns,
     unsigned int size,
-    int prot);
+    int prot,
+    void **access_ptr);
 status_t xen_write(
     vmi_instance_t vmi,
     addr_t paddr,

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -734,6 +734,20 @@ typedef struct page_info {
 } page_info_t;
 
 /**
+ * Struct for holding information about a contiguous region of mapped pages
+ */
+typedef struct mapped_region {
+    addr_t start_va;
+    size_t num_pages;
+    void *access_ptr;
+} mapped_region_t;
+
+typedef struct mapped_regions {
+    size_t size;
+    mapped_region_t *regions;
+} mapped_regions_t;
+
+/**
  * Supported architectures by LibVMI
  */
 typedef enum arch {
@@ -1379,14 +1393,14 @@ status_t vmi_read_va(
 
 /**
  * Maps num_pages of the guest's virtual memory into host, starting at the provided vaddr.
- * Each page will have it's own pointer in access_ptrs output array. Be aware that
+ * Each page will have it's own pointer in access_ptr output array. Be aware that
  * not all virtual pages may be allocated and in such case, the corresponding array item
  * will be set to NULL. Remember to call munmap() on each array item afterwards.
  *
  * @param[in] vmi LibVMI instance
  * @param[in] ctx Access context
  * @param[in] num_pages Number of guest pages to be mapped (starting from ctx.addr)
- * @param[in] prot memory protection flags
+ * @param[in] prot Memory protection flags
  * @param[out] access_ptrs Output array of size [num_pages] containing pointers to the respective guest's pages
  */
 status_t vmi_mmap_guest(
@@ -1396,6 +1410,42 @@ status_t vmi_mmap_guest(
     int prot,
     void **access_ptrs
 ) NOEXCEPT;
+
+/**
+ * Maps num_pages of the guest's virtual memory into the host, starting at the provided virtual address.
+ * Writes the result into an array consisting of mapped_region structs.
+ * A mapped_region describes a chunk of contiguous virtual memory.
+ * Each mapped_region struct holds the base pointer as well as the starting GVA and the size of such a mapped region.
+ * The caller is responsible for freeing the array via vmi_free_mapped_regions() which in turn will also call munmap()
+ * on every single mapped region.
+ *
+ * This function performs a lot better than vmi_mmap_guest() if a large, sparsely mapped memory region is requested.
+ * Results between this function and vmi_mmap_guest() may vary due to different v2p translation mechanisms being used.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] ctx Access context
+ * @param[in] num_pages Number of guest pages to be mapped (starting from ctx.addr)
+ * @param[in] prot Memory protection flags
+ * @param[out] mapped_regions A struct containing the location and length of a dynamically allocated array of
+ * mapped_region structs.
+ * @return VMI_SUCCESS if mapping succeeds, VMI_FAILURE otherwise
+ */
+status_t
+vmi_mmap_guest_2(
+    vmi_instance_t vmi,
+    const access_context_t *ctx,
+    size_t num_pages,
+    int prot,
+    mapped_regions_t *mapped_regions
+) NOEXCEPT;
+
+/**
+ * Frees the content of a mapped_regions struct. Will also unmap each region in the process.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] mapped_regions A mapped_regions struct. The struct itself will not be freed.
+ */
+void vmi_free_mapped_regions(vmi_instance_t vmi, const mapped_regions_t *mapped_regions) NOEXCEPT;
 
 /**
  * Reads count bytes from memory located at the physical address paddr

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -46,7 +46,7 @@ extern "C" {
 /**
  * Retrieve the pages mapped into the address space of a process.
  * @param[in] vmi Instance
- * @param[in] pt The pagetable the process (aka. dtb)
+ * @param[in] pt The pagetable of a process (aka. dtb)
  *
  * @return GSList of page_info_t structures, or NULL on error.
  * The caller is responsible for freeing the list and the structs.
@@ -54,6 +54,22 @@ extern "C" {
 GSList* vmi_get_va_pages(
     vmi_instance_t vmi,
     addr_t pt) NOEXCEPT;
+
+/**
+ * Retrieve a subset of the pages mapped into the address space of a process.
+ * @param[in] vmi Instance
+ * @param[in] pt The pagetable of a process (aka. dtb)
+ * @param[in] start The start of the virtual address range
+ * @param[in] end The end of the virtual address range (including end)
+ *
+ * @return GSList of page_info_t structures, or NULL on error.
+ * The caller is responsible for freeing the list and the structs.
+ */
+GSList* vmi_get_va_pages_subset(
+    vmi_instance_t vmi,
+    addr_t pt,
+    addr_t start,
+    addr_t end) NOEXCEPT;
 
 /**
  * Retrieve the pages mapped into the address space of a process.
@@ -72,6 +88,28 @@ GSList* vmi_get_nested_va_pages(
     page_mode_t npm,
     addr_t pt,
     page_mode_t pm) NOEXCEPT;
+
+/**
+ * Retrieve a subset of the pages mapped into the address space of a process.
+ * @param[in] vmi Instance
+ * @param[in] npt The nested page table to use (if any)
+ * @param[in] npm The paging mode of the nested pagetable (if any)
+ * @param[in] pt The paging mode of the pagetable
+ * @param[in] pm The pagetable of the process
+ * @param[in] start The start of the virtual address range
+ * @param[in] end The end of the virtual address range (including end)
+ *
+ * @return GSList of page_info_t structures, or NULL on error.
+ * The caller is responsible for freeing the list and the structs.
+ */
+GSList* vmi_get_nested_va_pages_subset(
+    vmi_instance_t vmi,
+    addr_t npt,
+    page_mode_t npm,
+    addr_t pt,
+    page_mode_t pm,
+    addr_t start,
+    addr_t end) NOEXCEPT;
 
 #endif
 


### PR DESCRIPTION
When mapping large memory regions that are only sparsely populated `vmi_mmap_guest()` may take a long time (> 30s) because it tries to resolve the virtual address of each page separately. Roughly 2/3 of the execution time is spent doing hashtable lookups because of the v2p cache (assuming it is enabled). Also, the API requires the caller to allocate an array of size `num_pages` and will allocate an array with the same size for storing `pfns` on top of that. This results in a lot of wasted memory for large, sparsely populated memory regions.
This PR introduces an alternative API which directly iterates over any set of page tables and finds chunks of consecutive memory. These regions will be mapped and returned as an array of memory region descriptors. In my case, mapping everything that is accessible via the kernel page tables took about a second (4GB Windows VM).
However, the new API may not produce the exact same results as the old API due to differences in the translation mechanism. For example, on x86 Windows consecutive entries pointing to the same `pfn` will be discarded.