### PR TITLE
Set mem-range access, read wstrings, get last PF

### DIFF
--- a/libvmi/core.c
+++ b/libvmi/core.c
@@ -638,6 +638,9 @@ status_t vmi_init(
     _vmi->init_flags = init_flags;
     _vmi->page_mode = VMI_PM_UNKNOWN;
 
+    _vmi->last_pagetable_lookup_fault.valid = false;
+    _vmi->last_pagetable_lookup_fault.ctx.version = ACCESS_CONTEXT_VERSION;
+
     arch_init_lookup_tables(_vmi);
 
     if ( init_data && init_data->count ) {

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -154,6 +154,12 @@ typedef struct driver_interface {
         addr_t gpfn,
         vmi_mem_access_t,
         uint16_t vmm_pagetable_id);
+    status_t (*set_mem_access_range_ptr)(
+        vmi_instance_t,
+        addr_t gpfn_start,
+        addr_t gpfn_end,
+        vmi_mem_access_t,
+        uint16_t vmm_pagetable_id);
     status_t (*start_single_step_ptr)(
         vmi_instance_t,
         single_step_event_t*);

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -533,6 +533,24 @@ driver_set_mem_access(
 }
 
 static inline status_t
+driver_set_mem_access_range(
+    vmi_instance_t vmi,
+    addr_t gpfn_start,
+    addr_t gpfn_end,
+    vmi_mem_access_t page_access_flag,
+    uint16_t vmm_pagetable_id)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.set_mem_access_range_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_set_mem_access_range function not implemented.\n");
+        return VMI_FAILURE;
+    }
+#endif
+
+    return vmi->driver.set_mem_access_range_ptr(vmi, gpfn_start, gpfn_end, page_access_flag, vmm_pagetable_id);
+}
+
+static inline status_t
 driver_start_single_step(
     vmi_instance_t vmi,
     single_step_event_t *event)

--- a/libvmi/driver/kvm/kvm_events.h
+++ b/libvmi/driver/kvm/kvm_events.h
@@ -71,6 +71,14 @@ kvm_set_mem_access(
     uint16_t vmm_pagetable_id);
 
 status_t
+kvm_set_mem_access_range(
+    vmi_instance_t vmi,
+    addr_t gpfn_start,
+    addr_t gpfn_end,
+    vmi_mem_access_t page_access_flag,
+    uint16_t vmm_pagetable_id);
+
+status_t
 kvm_set_desc_access_event(
     vmi_instance_t,
     bool enabled);

--- a/libvmi/driver/xen/altp2m.c
+++ b/libvmi/driver/xen/altp2m.c
@@ -84,7 +84,7 @@ status_t xen_altp2m_create_p2m ( vmi_instance_t vmi, uint16_t *altp2m_idx )
         errprint ("%s error: invalid domid\n", __FUNCTION__);
         return VMI_FAILURE;
     }
-    rc = xen->libxcw.xc_altp2m_create_view (xch, domain_id, VMI_MEMACCESS_N, altp2m_idx );
+    rc = xen->libxcw.xc_altp2m_create_view (xch, domain_id, XENMEM_access_rwx, altp2m_idx );
     if ( rc ) {
         errprint ("xc_altp2m_create_view returned rc: %i\n", rc);
         return VMI_FAILURE;

--- a/libvmi/driver/xen/libxc_wrapper.c
+++ b/libvmi/driver/xen/libxc_wrapper.c
@@ -102,7 +102,7 @@ static status_t sanity_check(xen_instance_t *xen)
         case 12:
         /* Fall-through */
         case 11:
-            if ( !w->xc_monitor_emul_unimplemented )
+            if ( !w->xc_monitor_emul_unimplemented || !w->xc_altp2m_set_mem_access_multi )
                 break;
         /* Fall-through */
         case 10:
@@ -234,6 +234,7 @@ status_t create_libxc_wrapper(xen_instance_t *xen)
     wrapper->xc_altp2m_destroy_view = dlsym(wrapper->handle, "xc_altp2m_destroy_view");
     wrapper->xc_altp2m_switch_to_view = dlsym ( wrapper->handle, "xc_altp2m_switch_to_view" );
     wrapper->xc_altp2m_set_mem_access = dlsym ( wrapper->handle, "xc_altp2m_set_mem_access" );
+    wrapper->xc_altp2m_set_mem_access_multi = dlsym ( wrapper->handle, "xc_altp2m_set_mem_access_multi" );
     wrapper->xc_altp2m_change_gfn = dlsym ( wrapper->handle, "xc_altp2m_change_gfn" );
     wrapper->xc_monitor_debug_exceptions = dlsym(wrapper->handle, "xc_monitor_debug_exceptions");
     wrapper->xc_monitor_cpuid = dlsym(wrapper->handle, "xc_monitor_cpuid");

--- a/libvmi/driver/xen/libxc_wrapper.h
+++ b/libvmi/driver/xen/libxc_wrapper.h
@@ -256,6 +256,9 @@ typedef struct {
     int (*xc_monitor_emul_unimplemented)
     (xc_interface *xch, uint32_t domain_id, bool enable);
 
+    int (*xc_altp2m_set_mem_access_multi)
+    (xc_interface *handle, uint32_t domid, uint16_t view_id, uint8_t *access, uint64_t *gfns, uint32_t nr);
+
     /* Xen 4.13+ but may be backported */
     int (*xc_vm_event_get_version)
     (xc_interface *xch);

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -62,10 +62,10 @@ status_t xen_set_mem_access(vmi_instance_t vmi, addr_t gpfn,
         rc = xen->libxcw.xc_altp2m_set_mem_access(xch, dom, altp2m_idx, gpfn, access);
 
     if (rc) {
-        errprint("xc_hvm_set_mem_access failed with code: %d\n", rc);
+        errprint("xc_set_mem_access failed with code: %d\n", rc);
         return VMI_FAILURE;
     }
-    dbprint(VMI_DEBUG_XEN, "--Done Setting memaccess on GPFN: %"PRIu64"\n", gpfn);
+    dbprint(VMI_DEBUG_XEN, "--Done Setting memaccess on GPFN: 0x%"PRIx64"\n", gpfn);
     return VMI_SUCCESS;
 }
 

--- a/libvmi/driver/xen/xen_events.c
+++ b/libvmi/driver/xen/xen_events.c
@@ -69,6 +69,78 @@ status_t xen_set_mem_access(vmi_instance_t vmi, addr_t gpfn,
     return VMI_SUCCESS;
 }
 
+status_t xen_set_mem_access_range(vmi_instance_t vmi, addr_t gpfn_start, addr_t gpfn_end,
+                                  vmi_mem_access_t page_access_flag, uint16_t altp2m_idx)
+{
+    int rc;
+    xenmem_access_t access;
+    xen_instance_t *xen = xen_get_instance(vmi);
+
+    if ( xen->major_version != 4 || xen->minor_version < 11 )
+        return VMI_FAILURE;
+
+    xc_interface *xch = xen_get_xchandle(vmi);
+    domid_t dom = xen_get_domainid(vmi);
+
+#ifdef ENABLE_SAFETY_CHECKS
+    if ( !xch ) {
+        errprint("%s error: invalid xc_interface handle\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+    if ( dom == (domid_t)VMI_INVALID_DOMID ) {
+        errprint("%s error: invalid domid\n", __FUNCTION__);
+        return VMI_FAILURE;
+    }
+#endif
+
+    if ( VMI_FAILURE == convert_vmi_flags_to_xenmem(page_access_flag, &access) )
+        return VMI_FAILURE;
+
+    if ( !altp2m_idx )
+        rc = xen->libxcw.xc_set_mem_access(xch, dom, access, gpfn_start, gpfn_end - gpfn_start);
+    else {
+        uint32_t nr = gpfn_end - gpfn_start;
+        uint64_t* pgfns = NULL;
+        uint8_t* paccess = NULL;
+
+        pgfns = calloc(nr, sizeof(uint64_t));
+        if ( !pgfns ) {
+            errprint("%s error: failed to allocate memory\n", __FUNCTION__);
+            goto done;
+        }
+
+        paccess = calloc(nr, sizeof(uint8_t));
+        if ( !paccess ) {
+            errprint("%s error: failed to allocate memory\n", __FUNCTION__);
+            goto done;
+        }
+
+        for ( uint32_t i = 0; i < nr; i++ ) {
+            pgfns[i] = gpfn_start + i;
+            paccess[i] = access;
+        }
+
+        rc = xen->libxcw.xc_altp2m_set_mem_access_multi(xch, dom, altp2m_idx, paccess, pgfns, nr);
+
+done:
+        if ( pgfns )
+            free(pgfns);
+
+        if ( paccess )
+            free(paccess);
+
+        if ( !pgfns || !paccess )
+            return VMI_FAILURE;
+    }
+
+    if (rc) {
+        errprint("xc_set_mem_access failed with code: %d\n", rc);
+        return VMI_FAILURE;
+    }
+    dbprint(VMI_DEBUG_XEN, "--Done Setting memaccess on GPFNs: 0x%"PRIx64" - 0x%"PRIx64"\n", gpfn_start, gpfn_end);
+    return VMI_SUCCESS;
+}
+
 status_t xen_set_reg_access(vmi_instance_t vmi, reg_event_t *event)
 {
     bool enable;
@@ -3618,6 +3690,7 @@ status_t xen_init_events(
     vmi->driver.set_reg_access_ptr = &xen_set_reg_access;
     vmi->driver.set_intr_access_ptr = &xen_set_intr_access;
     vmi->driver.set_mem_access_ptr = &xen_set_mem_access;
+    vmi->driver.set_mem_access_range_ptr = &xen_set_mem_access_range;
     vmi->driver.start_single_step_ptr = &xen_start_single_step;
     vmi->driver.stop_single_step_ptr = &xen_stop_single_step;
     vmi->driver.shutdown_single_step_ptr = &xen_shutdown_single_step;

--- a/libvmi/events.h
+++ b/libvmi/events.h
@@ -787,6 +787,24 @@ status_t vmi_set_mem_event(
     uint16_t vmm_pagetable_id) NOEXCEPT;
 
 /**
+ * Set mem event on a range of pages. Intended to be used when already registered a generic
+ * violation-type based mem access event handlers.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] gfn_start Guest page-frame number to start setting events
+ * @param[in] gfn_end Guest page-frame number to end setting events
+ * @param[in] access Requested event type on the page
+ * @param[in] vmm_pagetable_id The VMM pagetable ID in which to set the access
+ * @return VMI_SUCCESS or VMI_FAILURE
+ */
+status_t vmi_set_mem_event_range(
+    vmi_instance_t vmi,
+    addr_t gfn_start,
+    addr_t gfn_end,
+    vmi_mem_access_t access,
+    uint16_t vmm_pagetable_id) NOEXCEPT;
+
+/**
  * Setup single-stepping to register the given event
  * after the specified number of steps.
  *

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1306,6 +1306,19 @@ char *vmi_read_str(
     const access_context_t *ctx) NOEXCEPT;
 
 /**
+ * Reads a null terminated wchar_t string from memory,
+ * starting at the given virtual address.  The returned
+ * value must be freed by the caller.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] ctx Access context
+ * @return String read from memory or NULL on error
+ */
+uint16_t *vmi_read_wstr(
+    vmi_instance_t vmi,
+    const access_context_t *ctx) NOEXCEPT;
+
+/**
  * Reads a Unicode string from the given address. If the guest is running
  * Windows, a UNICODE_STRING struct is read. Linux is not yet
  * supported. The returned value must be freed by the caller.
@@ -1587,6 +1600,21 @@ char *vmi_read_str_va(
     vmi_pid_t pid) NOEXCEPT;
 
 /**
+ * Reads a null terminated wchar_t string from memory,
+ * starting at the given virtual address.  The returned
+ * value must be freed by the caller.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] vaddr Virtual address for start of string
+ * @param[in] pid Pid of the virtual address space (0 for kernel)
+ * @return String read from memory or NULL on error
+ */
+uint16_t *vmi_read_wstr_va(
+    vmi_instance_t vmi,
+    addr_t vaddr,
+    vmi_pid_t pid) NOEXCEPT;
+
+/**
  * Reads a Unicode string from the given address. If the guest is running
  * Windows, a UNICODE_STRING struct is read. Linux is not yet
  * supported. The returned value must be freed by the caller.
@@ -1706,6 +1734,18 @@ char *vmi_read_str_pa(
     vmi_instance_t vmi,
     addr_t paddr) NOEXCEPT;
 
+/**
+ * Reads a nul terminated wchar_t string from memory,
+ * starting at the given physical address.  The returned
+ * value must be freed by the caller.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] paddr Physical address for start of string
+ * @return String read from memory or NULL on error
+ */
+uint16_t *vmi_read_wstr_pa(
+    vmi_instance_t vmi,
+    addr_t paddr) NOEXCEPT;
 
 /**
  * Writes count bytes to memory

--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -2340,6 +2340,16 @@ status_t vmi_get_xsave_info(
     xsave_area_t *xsave_info) NOEXCEPT;
 
 /**
+ * Gets the last page table lookup fault that occurred.
+ *
+ * @param[in] vmi LibVMI instance
+ * @return The last page table lookup fault that occurred
+ */
+const access_context_t *
+vmi_get_last_pagetable_lookup_fault(
+    vmi_instance_t vmi) NOEXCEPT;
+
+/**
  * Gets the memory size of the guest or file that LibVMI is currently
  * accessing.  This is the amount of RAM allocated to the guest, but
  * does not necessarily indicate the highest addressable physical address;

--- a/libvmi/os/windows/peparse.c
+++ b/libvmi/os/windows/peparse.c
@@ -68,7 +68,7 @@ dump_exports(
                     continue;
                 }
 
-                _ctx.addr = base3 + ordinal + sizeof(uint32_t);
+                _ctx.addr = base3 + ordinal * sizeof(uint32_t);
                 if (VMI_FAILURE == vmi_read_32(vmi, &_ctx, &loc)) {
                     free(str);
                     continue;

--- a/libvmi/private.h
+++ b/libvmi/private.h
@@ -117,6 +117,12 @@ struct vmi_instance {
 
     page_mode_t page_mode;  /**< paging mode in use */
 
+    struct {
+        bool valid;             /**< true if ctx is valid */
+
+        access_context_t ctx;   /**< access context for the last translation */
+    } last_pagetable_lookup_fault;
+
     arch_interface_t arch_interface; /**< pagetable translation functions */
 
     memory_map_t *memmap;   /**< memory map of available addresses */

--- a/libvmi/read.c
+++ b/libvmi/read.c
@@ -478,6 +478,57 @@ vmi_read_str(
     return ret;
 }
 
+uint16_t *
+vmi_read_wstr(
+    vmi_instance_t vmi,
+    const access_context_t *ctx)
+{
+    access_context_t _ctx = *ctx;
+    addr_t len = 0;
+    uint8_t buf[VMI_PS_4KB];
+    size_t bytes_read;
+    bool read_more = 1;
+    uint16_t *ret = NULL;
+
+    do {
+        size_t offset = _ctx.addr & VMI_BIT_MASK(0,11);
+        size_t read_size = VMI_PS_4KB - offset;
+
+        dbprint(VMI_DEBUG_READ, "--start to read string from 0x%lx, page offset 0x%lx, read: %lu\n",
+                _ctx.addr, offset, read_size);
+
+        if (VMI_FAILURE == vmi_read(vmi, &_ctx, read_size, (void*)&buf, &bytes_read) &&
+                !bytes_read) {
+            return ret;
+        }
+
+        /* Count new non-null characters */
+        size_t read_len = 0;
+        for (read_len = 0; read_len + 1 < bytes_read; read_len += 2) {
+            if (buf[read_len] == 0 && buf[read_len + 1] == 0) {
+                read_more = 0;
+                break;
+            }
+        }
+
+        /*
+         * Realloc, tack on the L'\0' in case of errors and
+         * get ready to read the next page.
+         */
+        uint16_t *_ret = realloc(ret, len + read_len + 2);
+        if ( !_ret )
+            return ret;
+
+        ret = _ret;
+        memcpy(&ret[len / 2], &buf, read_len);
+        len += read_len;
+        ret[len / 2] = 0;
+        _ctx.addr += read_len;
+    } while (read_more);
+
+    return ret;
+}
+
 unicode_string_t*
 vmi_read_unicode_str(
     vmi_instance_t vmi,
@@ -602,6 +653,15 @@ vmi_read_str_pa(
     return vmi_read_str(vmi, &ctx);
 }
 
+uint16_t *
+vmi_read_wstr_pa(
+    vmi_instance_t vmi,
+    addr_t paddr)
+{
+    ACCESS_CONTEXT(ctx, .addr = paddr);
+    return vmi_read_wstr(vmi, &ctx);
+}
+
 ///////////////////////////////////////////////////////////
 // Easy access to virtual memory
 status_t
@@ -697,6 +757,20 @@ vmi_read_str_va(
                    .pid = pid);
 
     return vmi_read_str(vmi, &ctx);
+}
+
+uint16_t *
+vmi_read_wstr_va(
+    vmi_instance_t vmi,
+    addr_t vaddr,
+    vmi_pid_t pid)
+{
+    ACCESS_CONTEXT(ctx,
+                   .translate_mechanism = VMI_TM_PROCESS_PID,
+                   .addr = vaddr,
+                   .pid = pid);
+
+    return vmi_read_wstr(vmi, &ctx);
 }
 
 unicode_string_t *


### PR DESCRIPTION
Hi!

For my needs I've implemented several functions which I thought might be useful for others.

I apologize in advance for making single PR for essentially 3 features. Some of the commits depend on the previous ones, and I didn't want to cause you a headache with potential merge conflicts.

These changes are fairly simple:

- First 3 commits are essentially small fixes/typos, besides fixing the default_access parameter in the xc_altp2m_create_view function call. In practice, at least from my testing, it didn't change any functionality, since the behavior of default_access parameter is either broken in Xen (ignored altogether), or I didn't fully understood its purpose. I am aware of [this commit](https://github.com/xen-project/xen/commit/2aa977eb6baaa4e43a9ef3ad26f9eb117eb178f5), but I still don't understand why I don't receive any mem_events when I switch to a new altp2m that has been created with `default_access = XENMEM_access_n`.
- 4th commit adds `vmi_set_mem_range_event()`, which is complementary function to the `vmi_set_mem_event()`. It is implemented for Xen and KVM.
- 5th commit adds family of `vmi_read_wstr*()` functions, which allows reading Windows' NUL-terminated wide strings.
- 6th commit adds `vmi_get_last_pagetable_lookup_fault()` function, which returns last faulting access_context_t (or NULL, if last access succeeded), as currently there is no way how to determine which VA failed to translate (e.g. during reading large chunks of memory or strings). This information might be useful for a potential future #PF injection.