### PR TITLE
Update memory size properties in mmap logic

### DIFF
--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -146,9 +146,10 @@ file_init_vmi(
 
 #if USE_MMAP
     /* try memory mapped file I/O */
-    uint64_t size = 0;
+    uint64_t ram_size = 0;
+    addr_t max_addr = 0;
 
-    if (VMI_FAILURE == file_get_memsize(vmi, &size)) {
+    if (VMI_FAILURE == file_get_memsize(vmi, &ram_size, &max_addr)) {
         goto fail;
     }   // if
 
@@ -159,7 +160,7 @@ file_init_vmi(
 #endif // MMAP_HUGETLB
 
     void *map = mmap(NULL,  // addr
-                     size,  // len
+                     ram_size,  // len
                      PROT_READ, // prot
                      mmap_flags,    // flags
                      fd,    // file descriptor
@@ -192,7 +193,7 @@ file_destroy(
 
 #if USE_MMAP
     if (fi->map) {
-        (void) munmap(fi->map, vmi->size);
+        (void) munmap(fi->map, vmi->allocated_ram_size);
         fi->map = 0;
     }
 #endif // USE_MMAP


### PR DESCRIPTION
The `vmi_instance_t` memory size properties were changed in commit daf350644dc, but were not modified within the excluded mmap region.