### PR TITLE
Makefile.am: Add logic to prevent a duplicate call to event.h.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,7 +79,6 @@ if WITH_KVM_LEGACY
     drivers     += libvmi/driver/kvm/kvm_legacy.c
 
 else
-    h_public    += libvmi/events.h
     drivers     += libvmi/driver/kvm/kvm.c \
                    libvmi/driver/kvm/kvm_events.c \
                    libvmi/driver/kvm/kvm_events.h \
@@ -114,6 +113,16 @@ drivers     += libvmi/driver/bareflank/bareflank.h \
                libvmi/driver/bareflank/bareflank.c \
                libvmi/driver/bareflank/hypercall.h \
                libvmi/driver/bareflank/hypercall.S
+endif
+
+if WITH_KVM
+if WITH_KVM_LEGACY
+else
+if WITH_XEN
+else
+    h_public    += libvmi/events.h
+endif
+endif
 endif
 
 os =


### PR DESCRIPTION
Currently, if both KVM and Xen are enabled during build time, `event.h` is called twice, often ending in an error like the following:
```bash
install: will not overwrite just-created <installPath>/event.h with libvmi/event.h
```

This PR removes the duplicate call in KVM's `if` condition, and adds an extra `if` condition at the end of the `drivers =` stanza that calls `event.h` if it has not already been called by Xen, and if Legacy KVM support is not enabled.

This patch was first used in [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/pull/328873) to build `pkgs.libvmi`. If this PR is merged, we can drop our downstream patch.