### PR TITLE
Move mmap option from source to CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "-s")
 #-----------------------------------------------------------------------------
 option(ENABLE_XEN "Build Xen driver" ON)
 option(ENABLE_FILE "Build file driver" ON)
+option(USE_MMAP "Use mmap instead of standard seek/read in the file driver" OFF)
 
 option(ENABLE_WINDOWS "Build Windows introspection" ON)
 option(ENABLE_LINUX "Build Linux introspection" ON)

--- a/libvmi/driver/file/file.c
+++ b/libvmi/driver/file/file.c
@@ -40,10 +40,6 @@
 #include <unistd.h>
 #include <limits.h>
 
-// Use mmap() if this evaluates to true; otherwise, use a file pointer with
-// seek/read
-#define USE_MMAP 0
-
 // Avoid errors on systems that don't have MAP_POPULATE defined
 #ifndef MAP_POPULATE
 #define MAP_POPULATE 0


### PR DESCRIPTION
Moved the source option to use mmap as the basis of file driver operations instead of seek/read into CMake configuration.