### PR TITLE
add vmi_mmap_guest_pa method

### DIFF
--- a/libvmi/libvmi.h
+++ b/libvmi/libvmi.h
@@ -1411,6 +1411,25 @@ status_t vmi_mmap_guest(
 ) NOEXCEPT;
 
 /**
+ * Maps num_pages of the guest's physical memory into host, starting at the provided paddr.
+ * Each page will have it's own pointer in access_ptrs output array.
+ * Remember to call munmap() on each array item afterwards.
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[in] paddr Physical address to map
+ * @param[in] num_pages Number of guest pages to be mapped (starting from paddr)
+ * @param[in] prot Memory protection flags
+ * @param[out] access_ptrs Output array of size [num_pages] containing pointers to the respective guest's pages
+ */
+status_t vmi_mmap_guest_pa(
+    vmi_instance_t vmi,
+    addr_t paddr,
+    size_t num_pages,
+    int prot,
+    void **access_ptrs
+) NOEXCEPT;
+
+/**
  * Reads count bytes from memory located at the physical address paddr
  * and stores the output in a buf.
  *


### PR DESCRIPTION
Sometimes we may have a physical address of continuous region of memory and want to mmap this region.
So i add `vmi_mmap_guest_pa` method, that does not use address translation.