### PR TITLE
Add vmi_get_domain_status and Xen driver implementation

### DIFF
--- a/libvmi/accessors.c
+++ b/libvmi/accessors.c
@@ -759,6 +759,22 @@ void* vmi_read_page (vmi_instance_t vmi, addr_t frame_num)
     return driver_read_page(vmi, frame_num);
 }
 
+status_t vmi_get_domain_status(vmi_instance_t vmi, domain_status_t *domain_status)
+{
+    #ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi) {
+        errprint("NULL vmi passed to vmi_get_domain_status\n");
+        return VMI_FAILURE;
+    }
+    if (!domain_status) {
+        errprint("NULL domain_status_t passed to vmi_get_domain_status\n");
+        return VMI_FAILURE;
+    }
+    #endif
+
+    return driver_get_domain_status(vmi, domain_status);
+}
+
 GSList* vmi_get_va_pages(vmi_instance_t vmi, addr_t dtb)
 {
 #ifdef ENABLE_SAFETY_CHECKS

--- a/libvmi/driver/driver_interface.h
+++ b/libvmi/driver/driver_interface.h
@@ -121,6 +121,9 @@ typedef struct driver_interface {
     void *(*read_page_ptr) (
         vmi_instance_t,
         addr_t);
+    status_t (*get_domain_status_ptr) (
+        vmi_instance_t vmi,
+        domain_status_t *domain_status);
     void *(*mmap_guest) (
         vmi_instance_t,
         unsigned long *,

--- a/libvmi/driver/driver_wrapper.h
+++ b/libvmi/driver/driver_wrapper.h
@@ -379,6 +379,21 @@ driver_read_page(
     return vmi->driver.read_page_ptr(vmi, page);
 }
 
+static inline status_t
+driver_get_domain_status(
+    vmi_instance_t vmi,
+    domain_status_t *domain_status)
+{
+#ifdef ENABLE_SAFETY_CHECKS
+    if (!vmi->driver.initialized || !vmi->driver.get_domain_status_ptr) {
+        dbprint(VMI_DEBUG_DRIVER, "WARNING: driver_get_domain_status function not implemented.\n");
+        return VMI_FAILURE;
+    }
+#endif
+
+    return vmi->driver.get_domain_status_ptr(vmi, domain_status);
+}
+
 static inline void *
 driver_mmap_guest(
     vmi_instance_t vmi,

--- a/libvmi/driver/xen/xen.c
+++ b/libvmi/driver/xen/xen.c
@@ -2872,6 +2872,45 @@ xen_read_page(
     return memory_cache_insert(vmi, paddr);
 }
 
+status_t xen_get_domain_status(
+    vmi_instance_t vmi,
+    domain_status_t *domain_status)
+{
+
+    status_t ret = VMI_FAILURE;
+    xc_domaininfo_t info = {0};
+    int rc;
+    xen_instance_t *xen = NULL;
+    uint32_t domain_id = xen_get_domainid(vmi);
+
+    xen = xen_get_instance(vmi);
+
+    rc = xen->libxcw.xc_domain_getinfolist(xen->xchandle, domain_id, 1, &info);
+    if (rc==1 && info.domain==domain_id) {
+        ret = VMI_SUCCESS;
+
+        domain_status->missing = 0;
+        domain_status->type = VMI_XEN;
+        // Default set status fields to zero.
+        memset(&domain_status->xen_domain, 0, sizeof(xen_domain_status_t));
+
+        domain_status->xen_domain.dying = (info.flags & XEN_DOMINF_dying);
+        domain_status->xen_domain.shutdown = (info.flags & XEN_DOMINF_shutdown);
+        domain_status->xen_domain.paused = (info.flags & XEN_DOMINF_paused);
+        domain_status->xen_domain.blocked = (info.flags & XEN_DOMINF_blocked);
+        domain_status->xen_domain.running = (info.flags & XEN_DOMINF_running);
+        domain_status->xen_domain.debugged = (info.flags & XEN_DOMINF_debugged);
+        domain_status->xen_domain.xs_domain = (info.flags & XEN_DOMINF_xs_domain);
+        domain_status->xen_domain.hardware_assisted_paging = (info.flags & XEN_DOMINF_hap);
+
+        ret = VMI_SUCCESS;
+    } else {
+        domain_status->missing = 1;
+    }
+
+    return ret;
+}
+
 void *
 xen_mmap_guest(
     vmi_instance_t vmi,

--- a/libvmi/driver/xen/xen.h
+++ b/libvmi/driver/xen/xen.h
@@ -156,6 +156,10 @@ status_t xen_free_gfn(
 void *xen_read_page(
     vmi_instance_t vmi,
     addr_t page);
+status_t
+xen_get_domain_status(
+    vmi_instance_t vmi,
+    domain_status_t *domain_status);
 void *xen_mmap_guest(
     vmi_instance_t vmi,
     unsigned long *pfns,
@@ -240,6 +244,7 @@ driver_xen_setup(vmi_instance_t vmi)
     driver.get_disks_ptr = &xen_get_disks;
     driver.disk_is_bootable_ptr = &xen_disk_is_bootable;
     driver.get_bios = &xen_get_bios;
+    driver.get_domain_status_ptr = &xen_get_domain_status;
     vmi->driver = driver;
     return VMI_SUCCESS;
 }

--- a/libvmi/driver/xen/xen_private.h
+++ b/libvmi/driver/xen/xen_private.h
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <xenctrl.h>
+#include <xen/domctl.h>
 #include <xen/hvm/save.h>
 
 #include "private.h"

--- a/libvmi/libvmi_extra.h
+++ b/libvmi/libvmi_extra.h
@@ -192,6 +192,48 @@ status_t vmi_get_struct_field_type_name_from_json(
     const char **member_type_name) NOEXCEPT;
 #endif
 
+/**
+ * @struct xen_domain_status
+ * @brief Struct contain Xen-specific status flags
+ * Field values are set based on the values in the
+ * xen_domctl_getdomaininfo_t struct's flag field.
+ */
+typedef struct xen_domain_status {
+    bool dying:1;                     /**< set if XEN_DOMINF_dying is set */
+    bool shutdown:1;                  /**< set if XEN_DOMINF_shutdown is set */
+    bool paused:1;                    /**< set if XEN_DOMINF_paused is set */
+    bool blocked:1;                   /**< set if XEN_DOMINF_blocked is set */
+    bool running:1;                   /**< set if XEN_DOMINF_running is set */
+    bool debugged:1;                  /**< set if XEN_DOMINF_debugged is set */
+    bool xs_domain:1;                 /**< set if XEN_DOMINF_xs_domain is set */
+    bool hardware_assisted_paging:1;  /**< set if XEN_DOMINF_hap is set */
+} xen_domain_status_t;
+
+/**
+ * @struct domain_status
+ * @brief Struct containing status flags for a domain.
+ * Also contains hypervisor-specific flags in sub-structs
+ */
+typedef struct domain_status {
+    bool missing:1; /**< Indicates whether the domain was found */
+    vmi_mode_t type; /**< Hypervisor type, used to determine which fields exist in the union below */
+    union {
+        xen_domain_status_t xen_domain;
+    };
+} domain_status_t;
+
+/**
+ * Get the execution status of the domain associated with the provided vmi_instance
+ *
+ * @param[in] vmi LibVMI instance
+ * @param[out] domain_status domain_status_t containing the status flags for the given domain
+ *
+ * @return status_t result of retrieving the domain's status.
+ */
+status_t vmi_get_domain_status(
+        vmi_instance_t vmi,
+        domain_status_t *domain_status);
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds a `vmi_get_domain_status()` function to `libvmi_extra.h` which allows users to retrieve a domain's status via introspection. This is particularly useful when a DomU reboots on Xen (at least on ARM) because the DomU will have a different domain ID when it comes up after reboot. Xen still maintains a record of the domain, so its status can be queried and flags checked to determine that the DomU is no longer running. This can allow introspection programs to destroy and re-initialize a `vmi_instance_t` when the original domain it was associated with reboots or otherwise becomes unavailable.