### PR TITLE
Fix NtBuildNumber read

### DIFF
--- a/libvmi/os/windows/core.c
+++ b/libvmi/os/windows/core.c
@@ -667,17 +667,13 @@ find_windows_version_from_json_profile(vmi_instance_t vmi)
 {
     status_t ret = VMI_FAILURE;
     windows_instance_t windows = vmi->os_data;
-    addr_t ntbuildnumber_rva;
     uint16_t ntbuildnumber = 0;
 
     // Let's do some sanity checking
     if (!windows->ntoskrnl)
         goto done;
 
-    if (VMI_FAILURE == json_profile_lookup(vmi, "NtBuildNumber", NULL, &ntbuildnumber_rva)) {
-        goto done;
-    }
-    if (VMI_FAILURE == vmi_read_16_pa(vmi, windows->ntoskrnl + ntbuildnumber_rva, &ntbuildnumber)) {
+    if (VMI_FAILURE == vmi_read_16_ksym(vmi, "NtBuildNumber", &ntbuildnumber)) {
         goto done;
     }
 


### PR DESCRIPTION
find_windows_version_from_json_profile() uses kernel PA + symbol RVA to get symbol physical address.

It is valid only if kernel is placed contiguously in a physical memory. In example, the following was observed on WinServer2016 with 4+Gb RAM (from windbg):
| Symbol | VA | PFN | 
|---|---|---|
| nt | fffff802e7a77000  | 102677 | 
| nt!NtBuildNumber | fffff802e7ce9ca0 | 1024e9 |

For the greater VA we have the lesser PA here.