### PR TITLE
Fix signature of a signal handler

### DIFF
--- a/examples/dump-memory.c
+++ b/examples/dump-memory.c
@@ -49,7 +49,7 @@ static int progress_flag;
 static int pause_vm_flag = 1;
 
 volatile int interrupted;
-void sigint_handler()
+void sigint_handler(int signum)
 {
     interrupted = 1;
 }


### PR DESCRIPTION
This fixes a compiler warning:

> examples/dump-memory.c:185:20: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]